### PR TITLE
Fix create release action

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -68,6 +68,7 @@ jobs:
 
       - name: Build
         run: |
+          mvn install -DskipTests
           mvn -f kcbq-connector clean package assembly:single@release-artifacts -DskipTests
 
           export tar_file=$(ls ./kcbq-connector/target/ | grep tar)


### PR DESCRIPTION
Validated via https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/actions/runs/8438743469, which produced the [2.7.0-beta release](https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/releases/tag/v2.7.0-beta).