### PR TITLE
Reset snapshot version to 2.6.0

### DIFF
--- a/kcbq-api/pom.xml
+++ b/kcbq-api/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.wepay.kcbq</groupId>
         <artifactId>kcbq-parent</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/kcbq-connector/pom.xml
+++ b/kcbq-connector/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.wepay.kcbq</groupId>
         <artifactId>kcbq-parent</artifactId>
-        <version>2.7.0-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>com.wepay.kcbq</groupId>
     <artifactId>kcbq-parent</artifactId>
-    <version>2.7.0-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
There's been no 2.6.0 release of the connector; the snapshot version was set because of the previous maintainer's branching/versioning/releasing strategy. In preparation for a 2.6.0 release, we can reset the version to 2.6.0-SNAPSHOT.