### PR TITLE
feat: Retry row insertion when BigQuery API returns NOT_FOUND dataset

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/BigQueryErrorResponses.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/BigQueryErrorResponses.java
@@ -63,6 +63,15 @@ public class BigQueryErrorResponses {
         && (message.startsWith("Not found: Table ") || message.contains("Table is deleted: "));
   }
 
+  public static boolean isNonExistentDatasetError(BigQueryException exception) {
+    String message = message(exception.getError());
+    // If a dataset does not exist, it will raise a BigQueryException that the input is notFound
+    // Referring to Google Cloud Error Codes Doc: https://cloud.google.com/bigquery/docs/error-messages?hl=en
+    return NOT_FOUND_CODE == exception.getCode()
+        && NOT_FOUND_REASON.equals(exception.getReason())
+        && (message.startsWith("Not found: Dataset ") || message.contains("Dataset is deleted: "));
+  }
+
   public static boolean isTableMissingSchemaError(BigQueryException exception) {
     // If a table is missing a schema, it will raise a BigQueryException that the input is invalid
     // For more information about BigQueryExceptions, see: https://cloud.google.com/bigquery/troubleshooting-errors

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BigQueryErrorResponsesIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BigQueryErrorResponsesIT.java
@@ -148,6 +148,20 @@ public class BigQueryErrorResponsesIT extends BaseConnectorIT {
   }
 
   @Test
+  public void testWriteToNonExistentDataset() {
+    TableId table = TableId.of("nonexistent dataset", suffixedAndSanitizedTable("nonexistent table"));
+
+    BigQueryException e = assertThrows(
+            BigQueryException.class,
+            () -> bigQuery.insertAll(InsertAllRequest.of(table, RowToInsert.of(Collections.singletonMap("f1", "v1")))),
+            "Should have failed to write to nonexistent dataset (and table)"
+    );
+
+    logger.debug("Nonexistent dataset (and table) write error", e);
+    assertTrue(BigQueryErrorResponses.isNonExistentDatasetError(e));
+  }
+
+  @Test
   public void testWriteToTableWithoutSchema() {
     TableId table = TableId.of(dataset(), suffixedAndSanitizedTable("missing schema"));
     createOrAssertSchemaMatches(table, Schema.of());


### PR DESCRIPTION
Every couple of days, BigQuery API might return 404 / NOT_FOUND for Dataset. This happens although the Dataset exists in the same GCP region as where the connector is running. This brings the task to fail and restarting it resumes without any error. This change suggests to retry insertion when this error occurs, instead of failing fast.