### PR TITLE
Add optional configuration flag to use project ID from keyfile

### DIFF
--- a/docs/sink-connector-config-options.rst
+++ b/docs/sink-connector-config-options.rst
@@ -160,6 +160,13 @@ BigQuery Sink Connector Configuration Options
   * Default: false
   * Importance: medium
 
+``useProjectIdFromCredentials``
+  Use the ``project_id`` from the service account credentials if it exists. Falls back to ``project`` when not available.
+
+  * Type: boolean
+  * Default: false
+  * Importance: medium
+
 ``allBQFieldsNullable``
   If true, no fields in any produced BigQuery schema will be REQUIRED. All non-nullable avro fields will be translated as NULLABLE (or REPEATED, if arrays).
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -114,6 +114,8 @@ public class BigQuerySinkConfig extends AbstractConfig {
   public static final boolean UPSERT_ENABLED_DEFAULT = false;
   public static final String USE_STORAGE_WRITE_API_CONFIG = "useStorageWriteApi";
   public static final boolean USE_STORAGE_WRITE_API_DEFAULT = false;
+  public static final String USE_PROJECT_FROM_CREDENTIALS_CONFIG = "useProjectIdFromCredentials";
+  public static final boolean USE_PROJECT_FROM_CREDENTIALS_DEFAULT = false;  
   public static final String ENABLE_BATCH_MODE_CONFIG = "enableBatchMode";
   public static final boolean ENABLE_BATCH_MODE_DEFAULT = false;
   public static final String COMMIT_INTERVAL_SEC_CONFIG = "commitInterval";
@@ -341,6 +343,10 @@ public class BigQuerySinkConfig extends AbstractConfig {
   private static final ConfigDef.Importance USE_STORAGE_WRITE_API_IMPORTANCE = ConfigDef.Importance.MEDIUM;
   private static final String USE_STORAGE_WRITE_API_DOC =
       "(Beta feature: use with caution) Use Google's New Storage Write API for data streaming. Not available for upsert/delete mode";
+  private static final ConfigDef.Type USE_PROJECT_FROM_CREDENTIALS_TYPE = ConfigDef.Type.BOOLEAN;
+  private static final ConfigDef.Importance USE_PROJECT_FROM_CREDENTIALS_IMPORTANCE = ConfigDef.Importance.MEDIUM;
+  private static final String USE_PROJECT_FROM_CREDENTIALS_DOC =
+      "Use the project_id from the service account credentials if present. Falls back to 'project' if absent.";
   private static final ConfigDef.Type ENABLE_BATCH_MODE_TYPE = ConfigDef.Type.BOOLEAN;
   private static final ConfigDef.Importance ENABLE_BATCH_MODE_IMPORTANCE = ConfigDef.Importance.LOW;
   private static final String ENABLE_BATCH_MODE_DOC = "Use Google's New Storage Write API with batch mode";
@@ -834,6 +840,12 @@ public class BigQuerySinkConfig extends AbstractConfig {
             USE_STORAGE_WRITE_API_DEFAULT,
             USE_STORAGE_WRITE_API_IMPORTANCE,
             USE_STORAGE_WRITE_API_DOC
+        ).define(
+            USE_PROJECT_FROM_CREDENTIALS_CONFIG,
+            USE_PROJECT_FROM_CREDENTIALS_TYPE,
+            USE_PROJECT_FROM_CREDENTIALS_DEFAULT,
+            USE_PROJECT_FROM_CREDENTIALS_IMPORTANCE,
+            USE_PROJECT_FROM_CREDENTIALS_DOC            
         ).define(
             ENABLE_BATCH_MODE_CONFIG,
             ENABLE_BATCH_MODE_TYPE,

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/GcpClientBuilderProjectTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/GcpClientBuilderProjectTest.java
@@ -1,0 +1,46 @@
+import com.wepay.kafka.connect.bigquery.GcpClientBuilder;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class GcpClientBuilderProjectTest {
+
+  private String getProject(GcpClientBuilder<?> builder) throws Exception {
+    Field f = GcpClientBuilder.class.getDeclaredField("project");
+    f.setAccessible(true);
+    return (String) f.get(builder);
+  }
+
+  @Test
+  public void testProjectFromCredentials() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    properties.put(BigQuerySinkConfig.PROJECT_CONFIG, "config_project");
+    properties.put(BigQuerySinkConfig.KEY_SOURCE_CONFIG, GcpClientBuilder.KeySource.JSON.name());
+    properties.put(BigQuerySinkConfig.KEYFILE_CONFIG, "{\"project_id\":\"cred_project\"}");
+    properties.put(BigQuerySinkConfig.DEFAULT_DATASET_CONFIG, "dataset");
+    properties.put(BigQuerySinkConfig.USE_PROJECT_FROM_CREDENTIALS_CONFIG, "true");
+    BigQuerySinkConfig config = new BigQuerySinkConfig(properties);
+
+    GcpClientBuilder.BigQueryBuilder builder = new GcpClientBuilder.BigQueryBuilder();
+    builder.withConfig(config);
+    assertEquals("cred_project", getProject(builder));
+  }
+
+  @Test
+  public void testFallbackToConfigProject() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    properties.put(BigQuerySinkConfig.PROJECT_CONFIG, "config_project");
+    properties.put(BigQuerySinkConfig.KEY_SOURCE_CONFIG, GcpClientBuilder.KeySource.JSON.name());
+    properties.put(BigQuerySinkConfig.KEYFILE_CONFIG, "{}");
+    properties.put(BigQuerySinkConfig.DEFAULT_DATASET_CONFIG, "dataset");
+    properties.put(BigQuerySinkConfig.USE_PROJECT_FROM_CREDENTIALS_CONFIG, "true");
+    BigQuerySinkConfig config = new BigQuerySinkConfig(properties);
+
+    GcpClientBuilder.BigQueryBuilder builder = new GcpClientBuilder.BigQueryBuilder();
+    builder.withConfig(config);
+    assertEquals("config_project", getProject(builder));
+  }
+}


### PR DESCRIPTION
## Overview

This PR adds a configuration flag so the connector can automatically read the project ID from service account credentials.
GcpClientBuilder checks the flag and, when enabled, attempts to extract project_id from the credentials before falling back to the configured project value. 
A unit test GcpClientBuilderProjectTest verifies that the builder uses the credentials’ project when present and otherwise falls back to project.

## Tests

You can find the summary of test results below:

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.138 s - in GcpClientBuilderProjectTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.584 s - in com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiWriterTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.066 s - in com.wepay.kafka.connect.bigquery.write.storage.BigQueryBuilderTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.019 s - in com.wepay.kafka.connect.bigquery.write.storage.BigQueryWriteSettingsBuilderTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.074 s - in com.wepay.kafka.connect.bigquery.write.storage.GcsBuilderTest
[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.286 s - in com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiBatchApplicationStreamTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 s - in com.wepay.kafka.connect.bigquery.write.storage.StorageApiBatchModeHandlerTest
[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.078 s - in com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiDefaultStreamTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.266 s - in com.wepay.kafka.connect.bigquery.write.row.BigQueryWriterTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.045 s - in com.wepay.kafka.connect.bigquery.write.row.GcsToBqWriterTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.113 s - in com.wepay.kafka.connect.bigquery.config.GcsBucketValidatorTest
[INFO] Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.067 s - in com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfigTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in com.wepay.kafka.connect.bigquery.config.PartitioningModeValidatorTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in com.wepay.kafka.connect.bigquery.config.MultiPropertyValidatorTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.033 s - in com.wepay.kafka.connect.bigquery.config.CredentialsValidatorTest
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.025 s - in com.wepay.kafka.connect.bigquery.config.StorageWriteApiValidatorTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in com.wepay.kafka.connect.bigquery.config.PartitioningTypeValidatorTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in com.wepay.kafka.connect.bigquery.utils.PartitionedTableIdTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in com.wepay.kafka.connect.bigquery.utils.FieldNameSanitizerTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in com.wepay.kafka.connect.bigquery.ErrantRecordHandlerTest
[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.259 s - in com.wepay.kafka.connect.bigquery.BigQuerySinkTaskTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.149 s - in com.wepay.kafka.connect.bigquery.BigQueryStorageApiBatchSinkTaskTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in com.wepay.kafka.connect.bigquery.BigQuerySinkConnectorTest
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.09 s - in com.wepay.kafka.connect.bigquery.MergeQueriesTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.115 s - in com.wepay.kafka.connect.bigquery.BigQueryStorageApiSinkTaskTest
[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s - in com.wepay.kafka.connect.bigquery.exception.BigQueryStorageWriteApiErrorResponsesTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in com.wepay.kafka.connect.bigquery.exception.BigQueryErrorResponsesTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in com.wepay.kafka.connect.bigquery.exception.BigQueryStorageWriteApiConnectExceptionTest
[INFO] Tests run: 39, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.114 s - in com.wepay.kafka.connect.bigquery.SchemaManagerTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.088 s - in com.wepay.kafka.connect.bigquery.GcsToBqLoadRunnableTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in com.wepay.kafka.connect.bigquery.convert.KafkaDataConverterTest
[INFO] Tests run: 24, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.23 s - in com.wepay.kafka.connect.bigquery.convert.BigQuerySchemaConverterTest
[INFO] Tests run: 25, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.026 s - in com.wepay.kafka.connect.bigquery.convert.BigQueryRecordConverterTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConvertersTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s - in com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConvertersTest
[INFO] Results:
[INFO] 
[INFO] Tests run: 286, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for kafka-connect-bigquery-parent 2.6.1-SNAPSHOT:
[INFO] 
[INFO] kafka-connect-bigquery-parent ...................... SUCCESS [  0.002 s]
[INFO] kafka-connect-bigquery-api ......................... SUCCESS [  3.715 s]
[INFO] kafka-connect-bigquery ............................. SUCCESS [ 17.336 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  21.971 s
[INFO] Finished at: 2025-06-04T16:22:50+02:00
[INFO] ------------------------------------------------------------------------

```