### PR TITLE
Enable bigdecimal conversion for Debezium numeric types

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -31,6 +31,7 @@ import com.wepay.kafka.connect.bigquery.convert.BigQueryRecordConverter;
 import com.wepay.kafka.connect.bigquery.convert.BigQuerySchemaConverter;
 import com.wepay.kafka.connect.bigquery.convert.RecordConverter;
 import com.wepay.kafka.connect.bigquery.convert.SchemaConverter;
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters;
 import com.wepay.kafka.connect.bigquery.retrieve.IdentitySchemaRetriever;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -144,6 +145,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
   public static final String BIGQUERY_TIMESTAMP_PARTITION_FIELD_NAME_CONFIG = "timestampPartitionFieldName";
   public static final String BIGQUERY_CLUSTERING_FIELD_NAMES_CONFIG = "clusteringPartitionFieldNames";
   public static final String CONVERT_DEBEZIUM_TIMESTAMP_TO_INTEGER_CONFIG = "convertDebeziumTimestampToInteger";
+  public static final String CONVERT_DEBEZIUM_DECIMAL_CONFIG = "convertDebeziumVariableScaleDecimal";
   public static final String TIME_PARTITIONING_TYPE_CONFIG = "timePartitioningType";
   public static final String TIME_PARTITIONING_TYPE_DEFAULT = TimePartitioning.Type.DAY.name().toUpperCase();
   public static final String TIME_PARTITIONING_TYPE_NONE = "NONE";
@@ -483,6 +485,10 @@ public class BigQuerySinkConfig extends AbstractConfig {
   private static final Boolean CONVERT_DEBEZIUM_TIMESTAMP_TO_INTEGER_DEFAULT = false;
   private static final ConfigDef.Importance CONVERT_DEBEZIUM_TIMESTAMP_TO_INTEGER_IMPORTANCE =
       ConfigDef.Importance.MEDIUM;
+  private static final ConfigDef.Type CONVERT_DEBEZIUM_DECIMAL_TYPE = ConfigDef.Type.BOOLEAN;
+  private static final Boolean CONVERT_DEBEZIUM_DECIMAL_DEFAULT = false;
+  private static final ConfigDef.Importance CONVERT_DEBEZIUM_DECIMAL_IMPORTANCE =
+      ConfigDef.Importance.LOW;      
   private static final ConfigDef.Type TIME_PARTITIONING_TYPE_TYPE = ConfigDef.Type.STRING;
   private static final ConfigDef.Importance TIME_PARTITIONING_TYPE_IMPORTANCE = ConfigDef.Importance.LOW;
   private static final List<String> TIME_PARTITIONING_TYPES = Stream.concat(
@@ -864,6 +870,11 @@ public class BigQuerySinkConfig extends AbstractConfig {
             CONVERT_DEBEZIUM_TIMESTAMP_TO_INTEGER_TYPE,
             CONVERT_DEBEZIUM_TIMESTAMP_TO_INTEGER_DEFAULT,
             CONVERT_DEBEZIUM_TIMESTAMP_TO_INTEGER_IMPORTANCE
+        ).defineInternal(
+            CONVERT_DEBEZIUM_DECIMAL_CONFIG,
+            CONVERT_DEBEZIUM_DECIMAL_TYPE,
+            CONVERT_DEBEZIUM_DECIMAL_DEFAULT,
+            CONVERT_DEBEZIUM_DECIMAL_IMPORTANCE            
         );
   }
 
@@ -937,6 +948,8 @@ public class BigQuerySinkConfig extends AbstractConfig {
    * @return a {@link SchemaConverter} for BigQuery.
    */
   public SchemaConverter<Schema> getSchemaConverter() {
+    boolean shouldConvertToDebeziumVariableScaleDecimal = getBoolean(CONVERT_DEBEZIUM_DECIMAL_CONFIG);
+    DebeziumLogicalConverters.registerConverters(shouldConvertToDebeziumVariableScaleDecimal);    
     return new BigQuerySchemaConverter(
         getBoolean(ALL_BQ_FIELDS_NULLABLE_CONFIG),
         getBoolean(SANITIZE_FIELD_NAME_CONFIG));
@@ -948,10 +961,13 @@ public class BigQuerySinkConfig extends AbstractConfig {
    * @return a {@link RecordConverter} for BigQuery.
    */
   public RecordConverter<Map<String, Object>> getRecordConverter() {
+    boolean shouldConvertToDebeziumVariableScaleDecimal = getBoolean(CONVERT_DEBEZIUM_DECIMAL_CONFIG);
+    DebeziumLogicalConverters.registerConverters(shouldConvertToDebeziumVariableScaleDecimal);
     return new BigQueryRecordConverter(
         getBoolean(CONVERT_DOUBLE_SPECIAL_VALUES_CONFIG),
         getBoolean(CONVERT_DEBEZIUM_TIMESTAMP_TO_INTEGER_CONFIG),
-        getBoolean(USE_STORAGE_WRITE_API_CONFIG)
+        getBoolean(USE_STORAGE_WRITE_API_CONFIG),
+        shouldConvertToDebeziumVariableScaleDecimal
     );
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
@@ -60,7 +60,7 @@ public class BigQueryRecordConverter implements RecordConverter<Map<String, Obje
 
   static {
     // force registration
-    new DebeziumLogicalConverters();
+    DebeziumLogicalConverters.registerConverters(false);
     new KafkaLogicalConverters();
   }
 
@@ -71,6 +71,14 @@ public class BigQueryRecordConverter implements RecordConverter<Map<String, Obje
   public BigQueryRecordConverter(boolean shouldConvertDoubleSpecial,
                                  boolean shouldConvertDebeziumTimestampToInteger,
                                  boolean useStorageWriteApi) {
+    this(shouldConvertDoubleSpecial, shouldConvertDebeziumTimestampToInteger, useStorageWriteApi, false);
+  }
+
+  public BigQueryRecordConverter(boolean shouldConvertDoubleSpecial,
+                                 boolean shouldConvertDebeziumTimestampToInteger,
+                                 boolean useStorageWriteApi,
+                                 boolean shouldConvertToDebeziumVariableScaleDecimal) {
+    DebeziumLogicalConverters.registerConverters(shouldConvertToDebeziumVariableScaleDecimal);
     this.shouldConvertSpecialDouble = shouldConvertDoubleSpecial;
     this.shouldConvertDebeziumTimestampToInteger = shouldConvertDebeziumTimestampToInteger;
     this.useStorageWriteApi = useStorageWriteApi;
@@ -260,7 +268,7 @@ public class BigQueryRecordConverter implements RecordConverter<Map<String, Obje
     if (shouldConvertDebeziumTimestampToInteger && converter instanceof DebeziumLogicalConverters.TimestampConverter) {
       return (Long) kafkaConnectObject;
     }
-    return converter.convert(kafkaConnectObject);
+    return converter.convert(kafkaConnectSchema, kafkaConnectObject);
   }
 
   /**

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
@@ -60,7 +60,7 @@ public class BigQuerySchemaConverter implements SchemaConverter<com.google.cloud
 
   static {
     // force registration
-    new DebeziumLogicalConverters();
+    DebeziumLogicalConverters.registerConverters(false);
     new KafkaLogicalConverters();
 
     PRIMITIVE_TYPE_MAP = new HashMap<>();

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/LogicalTypeConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/LogicalTypeConverter.java
@@ -101,4 +101,17 @@ public abstract class LogicalTypeConverter {
    */
   public abstract Object convert(Object kafkaConnectObject);
 
+  /**
+   * Convert the given KafkaConnect Record Object using the provided Schema.
+   * Default implementation delegates to {@link #convert(Object)} for backward
+   * compatibility.
+   *
+   * @param kafkaConnectSchema the schema of the value
+   * @param kafkaConnectObject the value to convert
+   * @return the converted Object
+   */
+  public Object convert(Schema kafkaConnectSchema, Object kafkaConnectObject) {
+    return convert(kafkaConnectObject);
+  }
+
 }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverterTest.java
@@ -30,6 +30,7 @@ import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.wepay.kafka.connect.bigquery.exception.ConversionConnectException;
 import com.wepay.kafka.connect.bigquery.utils.FieldNameSanitizer;
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters;
 import io.confluent.connect.avro.AvroData;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
@@ -569,6 +570,38 @@ public class BigQuerySchemaConverterTest {
     Schema kafkaConnectTestSchema = SchemaBuilder
         .struct()
         .field(fieldName, Decimal.schema(0))
+        .build();
+
+    com.google.cloud.bigquery.Schema bigQueryTestSchema =
+        new BigQuerySchemaConverter(false).convertSchema(kafkaConnectTestSchema);
+    assertEquals(bigQueryExpectedSchema, bigQueryTestSchema);
+  }
+
+  @Test
+  public void testDebeziumVariableScaleDecimal() {
+    final String fieldName = "DebeziumDecimal";
+
+    DebeziumLogicalConverters.registerConverters(true);
+
+    com.google.cloud.bigquery.Schema bigQueryExpectedSchema =
+        com.google.cloud.bigquery.Schema.of(
+            com.google.cloud.bigquery.Field.newBuilder(
+                fieldName,
+                LegacySQLTypeName.NUMERIC
+            ).setMode(
+                com.google.cloud.bigquery.Field.Mode.REQUIRED
+            ).build()
+        );
+
+    Schema variableDecimalSchema = SchemaBuilder.struct()
+        .name(io.debezium.data.VariableScaleDecimal.LOGICAL_NAME)
+        .field("scale", Schema.INT32_SCHEMA)
+        .field("value", Schema.BYTES_SCHEMA)
+        .build();
+
+    Schema kafkaConnectTestSchema = SchemaBuilder
+        .struct()
+        .field(fieldName, variableDecimalSchema)
         .build();
 
     com.google.cloud.bigquery.Schema bigQueryTestSchema =

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConvertersTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConvertersTest.java
@@ -33,6 +33,8 @@ import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConve
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters.TimestampConverter;
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters.ZonedTimestampConverter;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
 import org.junit.jupiter.api.Test;
 
 public class DebeziumLogicalConvertersTest {
@@ -129,5 +131,28 @@ public class DebeziumLogicalConvertersTest {
 
     String formattedTimestamp = converter.convert("2017-03-01T14:20:38.808-08:00");
     assertEquals("2017-03-01 14:20:38.808-08:00", formattedTimestamp);
+  }
+
+  @Test
+  public void testVariableScaleDecimalConversion() {
+    DebeziumLogicalConverters.VariableScaleDecimalConverter converter =
+        new DebeziumLogicalConverters.VariableScaleDecimalConverter();
+
+    assertEquals(LegacySQLTypeName.NUMERIC, converter.getBqSchemaType());
+
+    Schema schema = SchemaBuilder.struct()
+        .name(io.debezium.data.VariableScaleDecimal.LOGICAL_NAME)
+        .field("scale", Schema.INT32_SCHEMA)
+        .field("value", Schema.BYTES_SCHEMA)
+        .build();
+
+    converter.checkEncodingType(Schema.Type.STRUCT);
+
+    Struct struct = new Struct(schema)
+        .put("scale", 3)
+        .put("value", new java.math.BigDecimal("123.456").unscaledValue().toByteArray());
+
+    java.math.BigDecimal converted = (java.math.BigDecimal) converter.convert(struct);
+    assertEquals(new java.math.BigDecimal("123.456"), converted);
   }
 }


### PR DESCRIPTION
## Overview
This PR introduces optional support for Debezium's VariableScaleDecimal type, which is used for PostgreSQL NUMERIC columns with variable precision. These values are serialized as structs (with value and scale), which Bigquery doesn’t support directly. Converting them to FLOAT64 can lead to precision loss, so we’ve added a new config flag , convertDebeziumVariableScaleDecimal , that lets users convert these values to BigDecimal before writing to Bigquery.

By default, nothing changes, this behavior is opt-in and won’t affect existing pipelines unless the flag is enabled.

## What’s Changed
* Added a new config flag: convertDebeziumVariableScaleDecimal (default: false) to BigQuerySinkConfig, along with ConfigDef setup and accessors.

* Updated schema and record converter logic to register Debezium-specific converters only if the flag is enabled.

* Refactored BigQueryRecordConverter to accept this flag and initialize the correct set of logical converters accordingly.

* Introduced VariableScaleDecimalConverter, which uses Debezium’s VariableScaleDecimal.toLogical(...) to convert the struct into a proper BigDecimal.

* This setup ensures that the connector will only attempt to handle Debezium-style decimal structs if explicitly configured to do so.

## Tests

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.746 s - in com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiWriterTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.094 s - in com.wepay.kafka.connect.bigquery.write.storage.BigQueryBuilderTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.057 s - in com.wepay.kafka.connect.bigquery.write.storage.BigQueryWriteSettingsBuilderTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.096 s - in com.wepay.kafka.connect.bigquery.write.storage.GcsBuilderTest
[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.275 s - in com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiBatchApplicationStreamTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s - in com.wepay.kafka.connect.bigquery.write.storage.StorageApiBatchModeHandlerTest
[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.116 s - in com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiDefaultStreamTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.377 s - in com.wepay.kafka.connect.bigquery.write.row.BigQueryWriterTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.035 s - in com.wepay.kafka.connect.bigquery.write.row.GcsToBqWriterTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.152 s - in com.wepay.kafka.connect.bigquery.config.GcsBucketValidatorTest
[INFO] Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.038 s - in com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfigTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in com.wepay.kafka.connect.bigquery.config.PartitioningModeValidatorTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.024 s - in com.wepay.kafka.connect.bigquery.config.MultiPropertyValidatorTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.019 s - in com.wepay.kafka.connect.bigquery.config.CredentialsValidatorTest
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.025 s - in com.wepay.kafka.connect.bigquery.config.StorageWriteApiValidatorTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s - in com.wepay.kafka.connect.bigquery.config.PartitioningTypeValidatorTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in com.wepay.kafka.connect.bigquery.utils.PartitionedTableIdTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.028 s - in com.wepay.kafka.connect.bigquery.utils.FieldNameSanitizerTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.052 s - in com.wepay.kafka.connect.bigquery.ErrantRecordHandlerTest
[INFO] Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.246 s - in com.wepay.kafka.connect.bigquery.BigQuerySinkTaskTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.11 s - in com.wepay.kafka.connect.bigquery.BigQueryStorageApiBatchSinkTaskTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.013 s - in com.wepay.kafka.connect.bigquery.BigQuerySinkConnectorTest
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.182 s - in com.wepay.kafka.connect.bigquery.MergeQueriesTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.05 s - in com.wepay.kafka.connect.bigquery.BigQueryStorageApiSinkTaskTest
[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s - in com.wepay.kafka.connect.bigquery.exception.BigQueryStorageWriteApiErrorResponsesTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in com.wepay.kafka.connect.bigquery.exception.BigQueryErrorResponsesTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in com.wepay.kafka.connect.bigquery.exception.BigQueryStorageWriteApiConnectExceptionTest
[INFO] Tests run: 39, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.13 s - in com.wepay.kafka.connect.bigquery.SchemaManagerTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.104 s - in com.wepay.kafka.connect.bigquery.GcsToBqLoadRunnableTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in com.wepay.kafka.connect.bigquery.convert.KafkaDataConverterTest
[INFO] Tests run: 25, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.212 s - in com.wepay.kafka.connect.bigquery.convert.BigQuerySchemaConverterTest
[INFO] Tests run: 26, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.033 s - in com.wepay.kafka.connect.bigquery.convert.BigQueryRecordConverterTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 s - in com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConvertersTest
[INFO] tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.017 s - in com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConvertersTest
[INFO] Results:
[INFO] 
[INFO] Tests run: 287, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  12.716 s
[INFO] Finished at: 2025-06-19T17:06:17+02:00
[INFO] ------------------------------------------------------------------------
```
