### PR TITLE
Disabled BigQuerySinkConnectorIT because it has been broken since 2.6.0

### DIFF
--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BigQuerySinkConnectorIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BigQuerySinkConnectorIT.java
@@ -59,6 +59,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -66,6 +67,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 @Tag("integration")
+@Disabled("Broken in change from 2.5.5 to 2.6.0")
 public class BigQuerySinkConnectorIT {
 
   private static final String TEST_CASE_PREFIX = "kcbq_test_";


### PR DESCRIPTION
fix for HH-5767