### PR TITLE
Revert deprecation notice for partition decorator syntax

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -36,14 +36,11 @@ import com.wepay.kafka.connect.bigquery.retrieve.IdentitySchemaRetriever;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -68,8 +65,6 @@ public class BigQuerySinkConfig extends AbstractConfig {
   public static final String DEPRECATED_DOC = "(DEPRECATED)";
   public static final String GCS_LOAD_DEPRECATION_NOTICE =
       "GCS batch loading has been deprecated and will be removed in a future major release.";
-  public static final String DECORATOR_SYNTAX_DEPRECATION_NOTICE =
-      "Use of partition decorator syntax has been deprecated and will be removed in a future release.";
 
   // Values taken from https://github.com/apache/kafka/blob/1.1.1/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SinkConnectorConfig.java#L33
   public static final String TOPICS_CONFIG = SinkConnector.TOPICS_CONFIG;
@@ -576,14 +571,6 @@ public class BigQuerySinkConfig extends AbstractConfig {
           ENABLE_BATCH_CONFIG
       );
     }
-
-    if (getBoolean(BIGQUERY_PARTITION_DECORATOR_CONFIG)) {
-      logger.warn(
-          DECORATOR_SYNTAX_DEPRECATION_NOTICE
-            + " To disable this feature, set the {} property to false in the connector configuration",
-          BIGQUERY_PARTITION_DECORATOR_CONFIG
-      );
-    }
   }
 
   /**
@@ -815,13 +802,13 @@ public class BigQuerySinkConfig extends AbstractConfig {
             BIGQUERY_MESSAGE_TIME_PARTITIONING_CONFIG_TYPE,
             BIGQUERY_MESSAGE_TIME_PARTITIONING_DEFAULT,
             BIGQUERY_MESSAGE_TIME_PARTITIONING_IMPORTANCE,
-            deprecatedPartitionSyntaxDoc(BIGQUERY_MESSAGE_TIME_PARTITIONING_DOC)
+            BIGQUERY_MESSAGE_TIME_PARTITIONING_DOC
         ).define(
             BIGQUERY_PARTITION_DECORATOR_CONFIG,
             BIGQUERY_PARTITION_DECORATOR_CONFIG_TYPE,
             BIGQUERY_PARTITION_DECORATOR_DEFAULT,
             BIGQUERY_PARTITION_DECORATOR_IMPORTANCE,
-            deprecatedPartitionSyntaxDoc(BIGQUERY_PARTITION_DECORATOR_DOC)
+            BIGQUERY_PARTITION_DECORATOR_DOC
         ).define(
             BIGQUERY_TIMESTAMP_PARTITION_FIELD_NAME_CONFIG,
             BIGQUERY_TIMESTAMP_PARTITION_FIELD_NAME_TYPE,
@@ -1171,10 +1158,6 @@ public class BigQuerySinkConfig extends AbstractConfig {
   private static String deprecatedGcsLoadDoc(String doc) {
 
     return deprecatedDoc(doc, GCS_LOAD_DEPRECATION_NOTICE);
-  }
-
-  public static String deprecatedPartitionSyntaxDoc(String doc) {
-    return deprecatedDoc(doc, DECORATOR_SYNTAX_DEPRECATION_NOTICE);
   }
 
   private static String deprecatedDoc(String doc, String notice) {


### PR DESCRIPTION
This reverts the deprecation warning introduced in #21 regarding the use of partition decorator syntax.

BigQuery Storage Write API recently [introduced support for partition decorator syntax](https://cloud.google.com/bigquery/docs/write-api#ingestion-time_partitioning), so it no longer needs to be deprecated.

A follow-up PR enables support for this syntax when using the Storage Write API: #69 