### PR TITLE
Retain the original topic, partition and offset in Kafka metadata record

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataBuilder.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataBuilder.java
@@ -68,7 +68,7 @@ public class KafkaDataBuilder {
    */
   public static Map<String, Object> buildKafkaDataRecord(SinkRecord kafkaConnectRecord) {
     HashMap<String, Object> kafkaData = new HashMap<>();
-    kafkaData.put(KAFKA_DATA_TOPIC_FIELD_NAME, kafkaConnectRecord.topic());
+    kafkaData.put(KAFKA_DATA_TOPIC_FIELD_NAME, kafkaConnectRecord.originalTopic());
     kafkaData.put(KAFKA_DATA_PARTITION_FIELD_NAME, kafkaConnectRecord.kafkaPartition());
     kafkaData.put(KAFKA_DATA_OFFSET_FIELD_NAME, kafkaConnectRecord.kafkaOffset());
     kafkaData.put(KAFKA_DATA_INSERT_TIME_FIELD_NAME, System.currentTimeMillis() / 1000.0);

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataConverterTest.java
@@ -45,6 +45,10 @@ public class KafkaDataConverterTest {
   private static final String kafkaDataTopicValue = "testTopic";
   private static final int kafkaDataPartitionValue = 101;
   private static final long kafkaDataOffsetValue = 1337;
+  private static final String kafkaDataMutatedTopicValue = "mutatedTopic";
+  private static final int kafkaDataMutatedPartitionValue = 201;
+  // In 3.6.1, there is no direct way to modify offset via newRecord(), even if SinkRecord itself supports it
+  private static final long kafkaDataMutatedOffsetValue = 456;
   Map<String, Object> expectedKafkaDataFields = new HashMap<>();
 
   @BeforeEach
@@ -62,6 +66,33 @@ public class KafkaDataConverterTest {
     assertTrue(actualKafkaDataFields.containsKey(kafkaDataInsertTimeName));
     assertTrue(actualKafkaDataFields.get(kafkaDataInsertTimeName) instanceof Double);
 
+    actualKafkaDataFields.remove(kafkaDataInsertTimeName);
+
+    assertEquals(expectedKafkaDataFields, actualKafkaDataFields);
+  }
+
+  @Test
+  public void testBuildKafkaDataRecordOnMutatedMetadata() {
+    SinkRecord record = new SinkRecord(
+            kafkaDataTopicValue,
+            kafkaDataPartitionValue,
+            null,
+            null,
+            null,
+            null,
+            kafkaDataOffsetValue
+    );
+    SinkRecord mutatedRecord = record.newRecord(
+            kafkaDataMutatedTopicValue,
+            kafkaDataMutatedPartitionValue,
+            null,
+            null,
+            null,
+            null,
+            null
+    );
+
+    Map<String, Object> actualKafkaDataFields = KafkaDataBuilder.buildKafkaDataRecord(mutatedRecord);
     actualKafkaDataFields.remove(kafkaDataInsertTimeName);
 
     assertEquals(expectedKafkaDataFields, actualKafkaDataFields);


### PR DESCRIPTION
Recent versions of Kafka Connect API (3.6+) [support](https://github.com/apache/kafka/blob/3.6.1/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkRecord.java#L40) keeping original topic name in `SinkRecord`. 
It should be kept in Kafka metadata record, since topic name can be rewritten in upstream SMTs. 