### PR TITLE
use-config-project-when-credentials-disabled

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/MergeBatches.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/MergeBatches.java
@@ -124,10 +124,19 @@ public class MergeBatches {
     String tableName = FieldNameSanitizer.sanitizeName(
         destinationTable.getTable() + intermediateTableSuffix
     );
-    TableId result = TableId.of(
-        destinationTable.getDataset(),
-        tableName
-    );
+    TableId result;
+    if (destinationTable.getProject() == null) {
+      result = TableId.of(
+          destinationTable.getDataset(),
+          tableName
+      );
+    } else {
+      result = TableId.of(
+          destinationTable.getProject(),
+          destinationTable.getDataset(),
+          tableName
+      );
+    }
 
     batchNumbers.put(result, new AtomicInteger());
     batches.put(result, new ConcurrentHashMap<>());


### PR DESCRIPTION
## Overview
This PR addresses incorrect behavior in the project selection logic used by the BigQuery Kafka Connector. When useCredentialsProjectId is set to true, the connector should use the project defined in the connector configuration (via the project parameter), not the one embedded in the service account key file.

The current behavior incorrectly defaults to the credential's project, causing data to be written to unintended destinations even when a specific project is configured.


## What Changed:
- The connector now correctly respects the useCredentialsProjectId flag.
- Batch operations (like MERGE) now also use the right project for intermediate tables.
- Added tests to cover project selection logic and time-partitioning cases.


## Tests
```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.296 s - in com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiWriterTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.036 s - in com.wepay.kafka.connect.bigquery.write.storage.BigQueryBuilderTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in com.wepay.kafka.connect.bigquery.write.storage.BigQueryWriteSettingsBuilderTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.03 s - in com.wepay.kafka.connect.bigquery.write.storage.GcsBuilderTest
Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.104 s - in com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiBatchApplicationStreamTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in com.wepay.kafka.connect.bigquery.write.storage.StorageApiBatchModeHandlerTest
Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.035 s - in com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiDefaultStreamTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.141 s - in com.wepay.kafka.connect.bigquery.write.row.BigQueryWriterTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 s - in com.wepay.kafka.connect.bigquery.write.row.GcsToBqWriterTest
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.164 s - in com.wepay.kafka.connect.bigquery.GcpClientBuilderProjectTest
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.026 s - in com.wepay.kafka.connect.bigquery.config.GcsBucketValidatorTest
Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s - in com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfigTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in com.wepay.kafka.connect.bigquery.config.PartitioningModeValidatorTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in com.wepay.kafka.connect.bigquery.config.MultiPropertyValidatorTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in com.wepay.kafka.connect.bigquery.config.CredentialsValidatorTest
Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s - in com.wepay.kafka.connect.bigquery.config.StorageWriteApiValidatorTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in com.wepay.kafka.connect.bigquery.config.PartitioningTypeValidatorTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in com.wepay.kafka.connect.bigquery.utils.PartitionedTableIdTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in com.wepay.kafka.connect.bigquery.utils.FieldNameSanitizerTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in com.wepay.kafka.connect.bigquery.ErrantRecordHandlerTest
Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.167 s - in com.wepay.kafka.connect.bigquery.BigQuerySinkTaskTest
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.127 s - in com.wepay.kafka.connect.bigquery.BigQueryStorageApiBatchSinkTaskTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in com.wepay.kafka.connect.bigquery.BigQuerySinkConnectorTest
Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.036 s - in com.wepay.kafka.connect.bigquery.MergeQueriesTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.111 s - in com.wepay.kafka.connect.bigquery.BigQueryStorageApiSinkTaskTest
Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in com.wepay.kafka.connect.bigquery.exception.BigQueryStorageWriteApiErrorResponsesTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in com.wepay.kafka.connect.bigquery.exception.BigQueryErrorResponsesTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in com.wepay.kafka.connect.bigquery.exception.BigQueryStorageWriteApiConnectExceptionTest
Tests run: 39, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.045 s - in com.wepay.kafka.connect.bigquery.SchemaManagerTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.025 s - in com.wepay.kafka.connect.bigquery.GcsToBqLoadRunnableTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in com.wepay.kafka.connect.bigquery.convert.KafkaDataConverterTest
Tests run: 25, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.063 s - in com.wepay.kafka.connect.bigquery.convert.BigQuerySchemaConverterTest
Tests run: 26, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s - in com.wepay.kafka.connect.bigquery.convert.BigQueryRecordConverterTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConvertersTest
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConvertersTest
Tests run: 297, Failures: 0, Errors: 0, Skipped: 0

------------------------------------------------------------------------
Reactor Summary for kafka-connect-bigquery-parent 2.7.1-SNAPSHOT:

kafka-connect-bigquery-parent ...................... SUCCESS [  0.000 s]
kafka-connect-bigquery-api ......................... SUCCESS [  1.100 s]
kafka-connect-bigquery ............................. SUCCESS [  3.981 s]
------------------------------------------------------------------------
BUILD SUCCESS
------------------------------------------------------------------------
Total time:  5.304 s
Finished at: 2025-08-07T17:26:18+02:00
------------------------------------------------------------------------
```