### PR TITLE
update decimal schema converter

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -31,19 +31,16 @@ import com.wepay.kafka.connect.bigquery.convert.BigQueryRecordConverter;
 import com.wepay.kafka.connect.bigquery.convert.BigQuerySchemaConverter;
 import com.wepay.kafka.connect.bigquery.convert.RecordConverter;
 import com.wepay.kafka.connect.bigquery.convert.SchemaConverter;
-import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters;
 import com.wepay.kafka.connect.bigquery.retrieve.IdentitySchemaRetriever;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -171,25 +168,26 @@ public class BigQuerySinkConfig extends AbstractConfig {
   public static final String MAX_RETRIES_CONFIG = "max.retries";
   public static final String ENABLE_RETRIES_CONFIG = "enableRetries";
   public static final Boolean ENABLE_RETRIES_DEFAULT = true;
+
   public enum DecimalHandlingMode {
-    NONE,
+    RECORD,
     FLOAT,
     NUMERIC,
     BIGNUMERIC
   }
 
-  public static final DecimalHandlingMode DECIMAL_HANDLING_MODE_DEFAULT = DecimalHandlingMode.NUMERIC;
+  public static final DecimalHandlingMode DECIMAL_HANDLING_MODE_DEFAULT = DecimalHandlingMode.FLOAT;
   public static final DecimalHandlingMode VARIABLE_SCALE_DECIMAL_HANDLING_MODE_DEFAULT =
       DecimalHandlingMode.NUMERIC;
   public static final ConfigDef.Type DECIMAL_HANDLING_MODE_TYPE = ConfigDef.Type.STRING;
   public static final ConfigDef.Importance DECIMAL_HANDLING_MODE_IMPORTANCE = ConfigDef.Importance.MEDIUM;
   public static final String DECIMAL_HANDLING_MODE_DOC =
-      "Handling for org.apache.kafka.connect.data.Decimal fields: none, float, numeric, bignumeric.";
+      "Handling for org.apache.kafka.connect.data.Decimal fields: record, float, numeric, bignumeric.";
   public static final ConfigDef.Type VARIABLE_SCALE_DECIMAL_HANDLING_MODE_TYPE = ConfigDef.Type.STRING;
   public static final ConfigDef.Importance VARIABLE_SCALE_DECIMAL_HANDLING_MODE_IMPORTANCE =
       ConfigDef.Importance.MEDIUM;
   public static final String VARIABLE_SCALE_DECIMAL_HANDLING_MODE_DOC =
-      "Handling for io.debezium.data.VariableScaleDecimal fields: none, float, numeric, bignumeric.";  
+      "Handling for io.debezium.data.VariableScaleDecimal fields: record, float, numeric, bignumeric.";
   private static final ConfigDef.Type TOPICS_TYPE = ConfigDef.Type.LIST;
   private static final ConfigDef.Importance TOPICS_IMPORTANCE = ConfigDef.Importance.HIGH;
   private static final String TOPICS_GROUP = "Common";
@@ -940,7 +938,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
               if (value == null) {
                 return;
               }
-              DecimalHandlingMode.valueOf(((String) value).toUpperCase());
+              DecimalHandlingMode.valueOf(((String) value).toUpperCase(Locale.ROOT));
             },
             DECIMAL_HANDLING_MODE_IMPORTANCE,
             DECIMAL_HANDLING_MODE_DOC
@@ -952,7 +950,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
               if (value == null) {
                 return;
               }
-              DecimalHandlingMode.valueOf(((String) value).toUpperCase());
+              DecimalHandlingMode.valueOf(((String) value).toUpperCase(Locale.ROOT));
             },
             VARIABLE_SCALE_DECIMAL_HANDLING_MODE_IMPORTANCE,
             VARIABLE_SCALE_DECIMAL_HANDLING_MODE_DOC
@@ -1013,7 +1011,6 @@ public class BigQuerySinkConfig extends AbstractConfig {
     return DecimalHandlingMode.valueOf(
         getString(VARIABLE_SCALE_DECIMAL_HANDLING_MODE_CONFIG).toUpperCase());
   }
-  
   /**
    * Return a new instance of the configured Schema Converter.
    *

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -1016,7 +1016,8 @@ public class BigQuerySinkConfig extends AbstractConfig {
    *
    * @return a {@link SchemaConverter} for BigQuery.
    */
-  public SchemaConverter<Schema> getSchemaConverter() { /// Update it later
+
+  public SchemaConverter<Schema> getSchemaConverter() {
     return new BigQuerySchemaConverter(
         getBoolean(ALL_BQ_FIELDS_NULLABLE_CONFIG),
         getBoolean(SANITIZE_FIELD_NAME_CONFIG),

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
@@ -26,11 +26,13 @@ package com.wepay.kafka.connect.bigquery.convert;
 import com.google.cloud.bigquery.InsertAllRequest.RowToInsert;
 import com.google.protobuf.ByteString;
 import com.wepay.kafka.connect.bigquery.api.KafkaSchemaRecordType;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.DecimalHandlingMode;
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters;
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConverters;
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.LogicalConverterRegistry;
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.LogicalTypeConverter;
 import com.wepay.kafka.connect.bigquery.exception.ConversionConnectException;
+import io.debezium.data.VariableScaleDecimal;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -41,19 +43,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.sink.SinkRecord;
-import io.debezium.data.VariableScaleDecimal;
-import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.DecimalHandlingMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 /**
  * Class for converting from {@link SinkRecord SinkRecords} and BigQuery rows, which are represented
  * as {@link Map Maps} from {@link String Strings} to {@link Object Objects}.
  */
+
 public class BigQueryRecordConverter implements RecordConverter<Map<String, Object>> {
 
   private static final Set<Class<?>> BASIC_TYPES = new HashSet<>(

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
@@ -40,14 +40,15 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 /**
- * Class for converting from {@link Schema Kafka Connect Schemas} to
- * {@link com.google.cloud.bigquery.Schema BigQuery Schemas}.
- */
+* Class for converting from {@link Schema Kafka Connect Schemas} to
+* {@link com.google.cloud.bigquery.Schema BigQuery Schemas}.
+*/
+
 public class BigQuerySchemaConverter implements SchemaConverter<com.google.cloud.bigquery.Schema> {
 
   /**
@@ -187,8 +188,8 @@ public class BigQuerySchemaConverter implements SchemaConverter<com.google.cloud
     if (Decimal.LOGICAL_NAME.equals(logicalName)) {
       if (kafkaConnectSchema.type() != Schema.Type.BYTES) {
         throw new ConversionConnectException(
-            "Decimal logical type must have BYTES schema but found: " +
-                kafkaConnectSchema.type());
+            "Decimal logical type must have BYTES schema but found: " 
+            + kafkaConnectSchema.type());
       }
       result = convertDecimalField(kafkaConnectSchema, fieldName);
     } else if (VariableScaleDecimal.LOGICAL_NAME.equals(logicalName)) {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
@@ -185,6 +185,11 @@ public class BigQuerySchemaConverter implements SchemaConverter<com.google.cloud
 
     String logicalName = kafkaConnectSchema.name();
     if (Decimal.LOGICAL_NAME.equals(logicalName)) {
+      if (kafkaConnectSchema.type() != Schema.Type.BYTES) {
+        throw new ConversionConnectException(
+            "Decimal logical type must have BYTES schema but found: " +
+                kafkaConnectSchema.type());
+      }
       result = convertDecimalField(kafkaConnectSchema, fieldName);
     } else if (VariableScaleDecimal.LOGICAL_NAME.equals(logicalName)) {
       result = convertVariableScaleDecimalField(kafkaConnectSchema, fieldName);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/KafkaLogicalConverters.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/KafkaLogicalConverters.java
@@ -96,29 +96,17 @@ public class KafkaLogicalConverters {
         Schema schema, String fieldName) {
       checkEncodingType(schema.type());
       Map<String, String> params = schema.parameters();
-      Long precision = null;
-      Long scale = null;
+      com.google.cloud.bigquery.Field.Builder builder =
+          com.google.cloud.bigquery.Field.newBuilder(fieldName, LegacySQLTypeName.NUMERIC);
       if (params != null) {
         String precisionStr = params.get("connect.decimal.precision");
         if (precisionStr != null) {
-          precision = Long.valueOf(precisionStr);
+          builder.setPrecision(Long.valueOf(precisionStr));
         }
         String scaleStr = params.get("scale");
         if (scaleStr != null) {
-          scale = Long.valueOf(scaleStr);
+          builder.setScale(Long.valueOf(scaleStr));
         }
-      }
-      com.google.cloud.bigquery.LegacySQLTypeName type = LegacySQLTypeName.NUMERIC;
-      if ((precision != null && precision > 38) || (scale != null && scale > 9)) {
-        type = LegacySQLTypeName.BIGNUMERIC;
-      }
-      com.google.cloud.bigquery.Field.Builder builder =
-          com.google.cloud.bigquery.Field.newBuilder(fieldName, type);
-      if (precision != null) {
-        builder.setPrecision(precision);
-      }
-      if (scale != null) {
-        builder.setScale(scale);
       }
       return builder;
     }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/KafkaLogicalConverters.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/KafkaLogicalConverters.java
@@ -81,7 +81,7 @@ public class KafkaLogicalConverters {
     public DecimalConverter() {
       super(Decimal.LOGICAL_NAME,
           Schema.Type.BYTES,
-          LegacySQLTypeName.NUMERIC);
+          LegacySQLTypeName.FLOAT);
 
     }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/LogicalTypeConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/LogicalTypeConverter.java
@@ -23,6 +23,7 @@
 
 package com.wepay.kafka.connect.bigquery.convert.logicaltype;
 
+import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.wepay.kafka.connect.bigquery.exception.ConversionConnectException;
 import java.text.SimpleDateFormat;
@@ -91,6 +92,19 @@ public abstract class LogicalTypeConverter {
 
   public LegacySQLTypeName getBqSchemaType() {
     return bqSchemaType;
+  }
+
+  /**
+   * Build a BigQuery field for the given Kafka Connect schema.
+   * Subclasses may override to customize precision, scale, or type.
+   *
+   * @param schema the Kafka Connect schema of the logical field
+   * @param fieldName the name of the field
+   * @return a {@link Field.Builder} initialized for this logical type
+   */
+  public Field.Builder getFieldBuilder(Schema schema, String fieldName) {
+    checkEncodingType(schema.type());
+    return Field.newBuilder(fieldName, bqSchemaType);
   }
 
   /**

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/KafkaLogicalConvertersTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/KafkaLogicalConvertersTest.java
@@ -26,6 +26,7 @@ package com.wepay.kafka.connect.bigquery.convert.logicaltype;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConverters.DateConverter;
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConverters.DecimalConverter;
@@ -34,6 +35,7 @@ import com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConverte
 import java.math.BigDecimal;
 import java.util.Date;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Decimal;
 import org.junit.jupiter.api.Test;
 
 public class KafkaLogicalConvertersTest {
@@ -68,6 +70,14 @@ public class KafkaLogicalConvertersTest {
 
     // expecting no-op
     assertEquals(bigDecimal, convertedDecimal);
+
+    Schema schema = Decimal.builder(2).parameter("connect.decimal.precision", "10").build();
+    Field field = converter.getFieldBuilder(schema, "foo").build();
+    assertEquals(LegacySQLTypeName.NUMERIC, field.getType());
+    assertEquals(Long.valueOf(2L), field.getScale());
+    assertEquals(Long.valueOf(10L), field.getPrecision());
+
+ 
   }
 
   @Test


### PR DESCRIPTION
## Overview
This change introduces sink-side controls for how DECIMAL types are represented in BigQuery at both schema-generation and value-conversion time:

New handling modes for fixed-scale Kafka Connect Decimal and Debezium VariableScaleDecimal:
- RECORD (previously discussed as “NONE” in review): write as a STRUCT { scale, value } (Debezium-style payload)
- FLOAT (default; backward compatible): write as BigQuery FLOAT64
- NUMERIC: write as BigQuery NUMERIC with scale/precision awareness
- BIGNUMERIC: write as BigQuery BIGNUMERIC with scale/precision awareness
- Default remains FLOAT to avoid a breaking change

## What Changed

* Configurable decimal handling:
We’ve added a DecimalHandlingMode enum (RECORD, FLOAT, NUMERIC, BIGNUMERIC) to BigQuerySinkConfig so you can choose exactly how decimals land in BigQuery. The setting is case-insensitive, so you don’t have to worry about capitalization when configuring it.

* Record conversion logic:
BigQueryRecordConverter now keeps separate modes for Kafka Decimal and Debezium VariableScaleDecimal and applies them in convertLogical. For Kafka Decimal, RECORD produces a {scale,value} struct, NUMERIC/BIGNUMERIC preserves the original BigDecimal, and FLOAT (the default) converts to a double. Debezium’s VariableScaleDecimal follows the same mapping, yielding a struct, double, or BigDecimal as configured.

* Schema conversion logic:
BigQuerySchemaConverter checks that Kafka Decimal uses a BYTES base type and then builds the BigQuery field according to the selected mode. RECORD emits a nested {scale,value} RECORD; NUMERIC/BIGNUMERIC delegates to the logical converter and logs a warning if precision/scale exceed BigQuery limits; and FLOAT (default) uses a FLOAT64 field. VariableScaleDecimal is handled with the same approach to keep schema and value conversion in sync.

* Logical converter internals:
KafkaLogicalConverters.DecimalConverter still targets LegacySQLTypeName.NUMERIC for its builder and now exposes getFieldBuilder, which lets us propagate precision and scale from schema parameters into BigQuery field definitions when NUMERIC/BIGNUMERIC is chosen. It also enforces BYTES encoding for Kafka Decimal, ensuring we decode consistently before producing either a BigDecimal or the struct form.

* Tests:
New unit tests cover all modes end-to-end. 
testKafkaDecimalNumericMode verifies that NUMERIC produces a BigDecimal in the output map.
testKafkaDecimalRecordMode checks the {scale,value} struct for RECORD. 
testKafkaDecimalDefaultFloat confirms FLOAT (and the default) yields a Double. 
Schema tests mirror these scenarios, including default FLOAT mapping and explicit NUMERIC/BIGNUMERIC with precision/scale propagation.


## Tests

```
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.311 s - in com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiWriterTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.04 s - in com.wepay.kafka.connect.bigquery.write.storage.BigQueryBuilderTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s - in com.wepay.kafka.connect.bigquery.write.storage.BigQueryWriteSettingsBuilderTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.032 s - in com.wepay.kafka.connect.bigquery.write.storage.GcsBuilderTest
Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.106 s - in com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiBatchApplicationStreamTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in com.wepay.kafka.connect.bigquery.write.storage.StorageApiBatchModeHandlerTest
Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.037 s - in com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiDefaultStreamTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.133 s - in com.wepay.kafka.connect.bigquery.write.row.BigQueryWriterTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 s - in com.wepay.kafka.connect.bigquery.write.row.GcsToBqWriterTest
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.229 s - in com.wepay.kafka.connect.bigquery.GcpClientBuilderProjectTest
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.027 s - in com.wepay.kafka.connect.bigquery.config.GcsBucketValidatorTest
Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.015 s - in com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfigTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in com.wepay.kafka.connect.bigquery.config.PartitioningModeValidatorTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in com.wepay.kafka.connect.bigquery.config.MultiPropertyValidatorTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s - in com.wepay.kafka.connect.bigquery.config.CredentialsValidatorTest
Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in com.wepay.kafka.connect.bigquery.config.StorageWriteApiValidatorTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in com.wepay.kafka.connect.bigquery.config.PartitioningTypeValidatorTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in com.wepay.kafka.connect.bigquery.utils.PartitionedTableIdTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in com.wepay.kafka.connect.bigquery.utils.FieldNameSanitizerTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in com.wepay.kafka.connect.bigquery.ErrantRecordHandlerTest
Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.167 s - in com.wepay.kafka.connect.bigquery.BigQuerySinkTaskTest
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.125 s - in com.wepay.kafka.connect.bigquery.BigQueryStorageApiBatchSinkTaskTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s - in com.wepay.kafka.connect.bigquery.BigQuerySinkConnectorTest
Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.033 s - in com.wepay.kafka.connect.bigquery.MergeQueriesTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.112 s - in com.wepay.kafka.connect.bigquery.BigQueryStorageApiSinkTaskTest
Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in com.wepay.kafka.connect.bigquery.exception.BigQueryStorageWriteApiErrorResponsesTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in com.wepay.kafka.connect.bigquery.exception.BigQueryErrorResponsesTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in com.wepay.kafka.connect.bigquery.exception.BigQueryStorageWriteApiConnectExceptionTest
Tests run: 39, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.048 s - in com.wepay.kafka.connect.bigquery.SchemaManagerTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.027 s - in com.wepay.kafka.connect.bigquery.GcsToBqLoadRunnableTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in com.wepay.kafka.connect.bigquery.convert.KafkaDataConverterTest
Tests run: 27, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.063 s - in com.wepay.kafka.connect.bigquery.convert.BigQuerySchemaConverterTest
Tests run: 29, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s - in com.wepay.kafka.connect.bigquery.convert.BigQueryRecordConverterTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConvertersTest
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConvertersTest

Tests run: 302, Failures: 0, Errors: 0, Skipped: 0
------------------------------------------------------------------------
BUILD SUCCESS
------------------------------------------------------------------------
Total time:  6.997 s
Finished at: 2025-08-12T13:49:14+02:00
------------------------------------------------------------------------
```