### PR TITLE
Enable client-side request level retries for Storage Write API

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/ApplicationStream.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/ApplicationStream.java
@@ -68,12 +68,13 @@ public class ApplicationStream {
    */
   private final AtomicInteger maxCalls;
   private final AtomicLong totalRowsSent;
+  private final JsonStreamWriterFactory jsonWriterFactory;
   private StreamState currentState = null;
   private WriteStream stream = null;
   private JsonStreamWriter jsonWriter = null;
   private List<String> committableStreams;
 
-  public ApplicationStream(String tableName, BigQueryWriteClient client) throws Exception {
+  public ApplicationStream(String tableName, BigQueryWriteClient client, JsonStreamWriterFactory jsonWriterFactory) throws Exception {
     this.client = client;
     this.tableName = tableName;
     this.offsetInformation = new HashMap<>();
@@ -82,6 +83,7 @@ public class ApplicationStream {
     this.completedCalls = new AtomicInteger();
     this.totalRowsSent = new AtomicLong();
     this.committableStreams = new ArrayList<>();
+    this.jsonWriterFactory = jsonWriterFactory;
     generateStream();
     currentState = StreamState.CREATED;
     logger.debug("New Application stream {} created", getStreamName());
@@ -94,7 +96,7 @@ public class ApplicationStream {
   private void generateStream() throws Descriptors.DescriptorValidationException, IOException, InterruptedException {
     this.stream = client.createWriteStream(
         tableName, WriteStream.newBuilder().setType(WriteStream.Type.PENDING).build());
-    this.jsonWriter = JsonStreamWriter.newBuilder(stream.getName(), client).build();
+    this.jsonWriter = jsonWriterFactory.create(getStreamName());
     this.committableStreams.add(getStreamName());
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/ApplicationStream.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/ApplicationStream.java
@@ -74,7 +74,8 @@ public class ApplicationStream {
   private JsonStreamWriter jsonWriter = null;
   private List<String> committableStreams;
 
-  public ApplicationStream(String tableName, BigQueryWriteClient client, JsonStreamWriterFactory jsonWriterFactory) throws Exception {
+  public ApplicationStream(String tableName, BigQueryWriteClient client, JsonStreamWriterFactory jsonWriterFactory)
+          throws Exception {
     this.client = client;
     this.tableName = tableName;
     this.offsetInformation = new HashMap<>();
@@ -87,6 +88,18 @@ public class ApplicationStream {
     generateStream();
     currentState = StreamState.CREATED;
     logger.debug("New Application stream {} created", getStreamName());
+  }
+
+  /**
+   * @deprecated This constructor does not support custom {@link JsonStreamWriter} configuration.
+   * Use {@link #ApplicationStream(String, BigQueryWriteClient, JsonStreamWriterFactory)} instead
+   * to supply a factory for creating writers with custom settings.
+   */
+  @Deprecated
+  public ApplicationStream(String tableName, BigQueryWriteClient client) throws Exception {
+    this(tableName, client, streamOrTableName ->
+            JsonStreamWriter.newBuilder(streamOrTableName, client).build()
+    );
   }
 
   public Map<TopicPartition, OffsetAndMetadata> getOffsetInformation() {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/JsonStreamWriterFactory.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/JsonStreamWriterFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 Copyright 2022 Aiven Oy and
+ * bigquery-connector-for-apache-kafka project contributors
+ *
+ * This software contains code derived from the Confluent BigQuery
+ * Kafka Connector, Copyright Confluent, Inc, which in turn
+ * contains code derived from the WePay BigQuery Kafka Connector,
+ * Copyright WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wepay.kafka.connect.bigquery.write.storage;
+
+import com.google.cloud.bigquery.storage.v1.JsonStreamWriter;
+import com.google.protobuf.Descriptors;
+import java.io.IOException;
+
+/**
+ * A functional interface for creating {@link JsonStreamWriter} instances.
+ */
+@FunctionalInterface
+public interface JsonStreamWriterFactory {
+  JsonStreamWriter create(String streamOrTableName) throws Descriptors.DescriptorValidationException,
+        IOException, InterruptedException;
+}

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBase.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBase.java
@@ -28,6 +28,7 @@ import com.google.cloud.bigquery.storage.v1.AppendRowsResponse;
 import com.google.cloud.bigquery.storage.v1.BigQueryWriteClient;
 import com.google.cloud.bigquery.storage.v1.BigQueryWriteSettings;
 import com.google.cloud.bigquery.storage.v1.Exceptions;
+import com.google.cloud.bigquery.storage.v1.JsonStreamWriter;
 import com.google.cloud.bigquery.storage.v1.RowError;
 import com.google.cloud.bigquery.storage.v1.TableName;
 import com.google.common.annotations.VisibleForTesting;
@@ -57,6 +58,7 @@ import org.slf4j.LoggerFactory;
 public abstract class StorageWriteApiBase {
 
   private static final Logger logger = LoggerFactory.getLogger(StorageWriteApiBase.class);
+  protected final JsonStreamWriterFactory jsonWriterFactory;
   protected final int retry;
   protected final long retryWait;
   private final boolean autoCreateTables;
@@ -95,6 +97,7 @@ public abstract class StorageWriteApiBase {
       logger.error("Failed to create Big Query Storage Write API write client due to {}", e.getMessage());
       throw new BigQueryStorageWriteApiConnectException("Failed to create Big Query Storage Write API write client", e);
     }
+    this.jsonWriterFactory = getJsonWriterFactory();
     this.time = Time.SYSTEM;
   }
 
@@ -295,6 +298,16 @@ public abstract class StorageWriteApiBase {
       this.writeClient = BigQueryWriteClient.create(writeSettings);
     }
     return this.writeClient;
+  }
+
+  /**
+   * Returns a {@link JsonStreamWriterFactory} for creating configured {@link JsonStreamWriter} instances
+   *
+   * @return a {@link JsonStreamWriterFactory}
+   */
+  protected JsonStreamWriterFactory getJsonWriterFactory() {
+    return streamOrTableName -> JsonStreamWriter.newBuilder(streamOrTableName, writeClient)
+            .build();
   }
 
   /**

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBase.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBase.java
@@ -305,7 +305,8 @@ public abstract class StorageWriteApiBase {
     RetrySettings retrySettings = RetrySettings.newBuilder()
             .setMaxAttempts(retry)
             .setInitialRetryDelay(Duration.ofMillis(retryWait))
-            .setMaxRetryDelay(Duration.ofMillis(retryWait))
+            .setRetryDelayMultiplier(1.1)
+            .setMaxRetryDelay(Duration.ofMinutes(1))
             .build();
     return streamOrTableName -> JsonStreamWriter.newBuilder(streamOrTableName, writeClient)
             .setRetrySettings(retrySettings)

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBase.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBase.java
@@ -59,6 +59,8 @@ import org.threeten.bp.Duration;
 public abstract class StorageWriteApiBase {
 
   private static final Logger logger = LoggerFactory.getLogger(StorageWriteApiBase.class);
+  private static final double RETRY_DELAY_MULTIPLIER = 1.1;
+  private static final int MAX_RETRY_DELAY_MINUTES = 1;
   protected final JsonStreamWriterFactory jsonWriterFactory;
   protected final int retry;
   protected final long retryWait;
@@ -305,8 +307,8 @@ public abstract class StorageWriteApiBase {
     RetrySettings retrySettings = RetrySettings.newBuilder()
             .setMaxAttempts(retry)
             .setInitialRetryDelay(Duration.ofMillis(retryWait))
-            .setRetryDelayMultiplier(1.1)
-            .setMaxRetryDelay(Duration.ofMinutes(1))
+            .setRetryDelayMultiplier(RETRY_DELAY_MULTIPLIER)
+            .setMaxRetryDelay(Duration.ofMinutes(MAX_RETRY_DELAY_MINUTES))
             .build();
     return streamOrTableName -> JsonStreamWriter.newBuilder(streamOrTableName, writeClient)
             .setRetrySettings(retrySettings)

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBatchApplicationStream.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBatchApplicationStream.java
@@ -237,7 +237,7 @@ public class StorageWriteApiBatchApplicationStream extends StorageWriteApiBase {
         TableName.parse(tableName), rows != null ? getSinkRecords(rows) : null, retry, retryWait, time);
     do {
       try {
-        return new ApplicationStream(tableName, getWriteClient());
+        return new ApplicationStream(tableName, getWriteClient(), jsonWriterFactory);
       } catch (Exception e) {
         String baseErrorMessage = String.format(
             "Failed to create Application stream writer on table %s due to %s",

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiDefaultStream.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiDefaultStream.java
@@ -104,7 +104,7 @@ public class StorageWriteApiDefaultStream extends StorageWriteApiBase {
       StorageWriteApiRetryHandler retryHandler = new StorageWriteApiRetryHandler(table, getSinkRecords(rows), retry, retryWait, time);
       do {
         try {
-          return JsonStreamWriter.newBuilder(t, getWriteClient()).build();
+          return jsonWriterFactory.create(tableName);
         } catch (Exception e) {
           String baseErrorMessage = String.format(
               "Failed to create Default stream writer on table %s due to %s",

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiDefaultStreamTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiDefaultStreamTest.java
@@ -23,9 +23,7 @@
 
 package com.wepay.kafka.connect.bigquery.write.storage;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.doNothing;
@@ -56,12 +54,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Stream;
+
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 
@@ -83,9 +86,8 @@ public class StorageWriteApiDefaultStreamTest {
       new ConvertedRecord(mockedSinkRecord, new JSONObject()),
       new ConvertedRecord(mockedSinkRecord, new JSONObject()));
   private final StorageWriteApiDefaultStream defaultStream = mock(StorageWriteApiDefaultStream.class, CALLS_REAL_METHODS);
-  private final String nonRetriableExpectedException = "Failed to write rows on table "
-      + mockedTableName.toString()
-      + " due to I am non-retriable error";
+  private final String baseErrorMessage = "Failed to write rows on table "
+      + mockedTableName.toString();
   private final String retriableExpectedException = "Exceeded 0 attempts to write to table "
       + mockedTableName.toString() + " ";
   private final String malformedrequestExpectedException = "Insertion failed at table dummyTable for following rows:" +
@@ -147,34 +149,27 @@ public class StorageWriteApiDefaultStreamTest {
     defaultStream.initializeAndWriteRecords(mockedTableName, testRows, null);
   }
 
-  @Test
-  public void testDefaultStreamNonRetriableError() throws Exception {
-    AppendRowsResponse nonRetriableError = AppendRowsResponse.newBuilder()
+  @ParameterizedTest(name = "{index} – {0}")
+  @MethodSource("terminalClientErrors")
+  public void testDefaultStreamTerminalClientErrors(String testCase, String errorMessage) throws Exception {
+    AppendRowsResponse clientError = AppendRowsResponse.newBuilder()
         .setError(
             Status.newBuilder()
                 .setCode(0)
-                .setMessage("I am non-retriable error")
+                .setMessage(errorMessage)
                 .build()
         ).build();
 
-    when(mockedResponse.get()).thenReturn(nonRetriableError);
+    when(mockedResponse.get()).thenReturn(clientError);
 
-    verifyException(nonRetriableExpectedException);
+    verifyTerminalException(errorMessage);
   }
 
-  @Test
-  public void testDefaultStreamRetriableError() throws Exception {
-    AppendRowsResponse retriableError = AppendRowsResponse.newBuilder()
-        .setError(
-            Status.newBuilder()
-                .setCode(0)
-                .setMessage("I am an INTERNAL error")
-                .build()
-        ).build();
-
-    when(mockedResponse.get()).thenReturn(retriableError);
-
-    verifyException(retriableExpectedException);
+  public static Stream<Arguments> terminalClientErrors() {
+    return Stream.of(
+            Arguments.of("Non-retriable errors", "I am non-retriable error"),
+            Arguments.of("Request-level errors", "I am an INTERNAL error")
+    );
   }
 
   @Test
@@ -214,24 +209,21 @@ public class StorageWriteApiDefaultStreamTest {
     verifyNoInteractions(mockedSchemaManager);
   }
 
-  @Test
-  public void testDefaultStreamNonRetriableException() throws Exception {
-    InterruptedException exception = new InterruptedException("I am non-retriable error");
-
+  @ParameterizedTest(name = "{index} – {0}")
+  @MethodSource("terminalClientExceptions")
+  public void testDefaultStreamTerminalClientException(String testCase, Exception exception)
+          throws Exception {
     when(mockedResponse.get()).thenThrow(exception);
 
-    verifyException(nonRetriableExpectedException);
+    verifyTerminalException(exception.getMessage());
   }
 
-  @Test
-  public void testDefaultStreamRetriableException() throws Exception {
-    ExecutionException exception = new ExecutionException(new StatusRuntimeException(
-        io.grpc.Status.fromCode(io.grpc.Status.Code.INTERNAL).withDescription("I am an INTERNAL error")
-    ));
-
-    when(mockedResponse.get()).thenThrow(exception);
-
-    verifyException(retriableExpectedException);
+  public static Stream<Arguments> terminalClientExceptions() {
+    return Stream.of(
+            Arguments.of("Non-retriable errors", new InterruptedException("I am non-retriable error")),
+            Arguments.of("Request-level errors", new ExecutionException(new StatusRuntimeException(
+                    io.grpc.Status.fromCode(io.grpc.Status.Code.INTERNAL).withDescription("I am an INTERNAL error"))))
+    );
   }
 
   @Test
@@ -287,12 +279,18 @@ public class StorageWriteApiDefaultStreamTest {
     verify(mockedStreamWriter, times(1)).close();
   }
 
-  private void verifyException(String expectedException) {
+  private void verifyTerminalException(String expectedException) {
     BigQueryStorageWriteApiConnectException e = assertThrows(
         BigQueryStorageWriteApiConnectException.class,
         () -> defaultStream.initializeAndWriteRecords(mockedTableName, testRows, null)
     );
-    assertEquals(expectedException, e.getMessage());
+
+    assertAll(
+            () -> assertTrue(e.getMessage().startsWith(baseErrorMessage), "Should fail task with base message"),
+            () -> assertTrue(e.getMessage().contains(expectedException),"Should include cause of failure"),
+            () -> assertFalse(e.getMessage().contains(retriableExpectedException),
+                    "Should not use connector retry path")
+    );
   }
 
   private void verifyDLQ(List<ConvertedRecord> rows) {


### PR DESCRIPTION
### Overview
The Java BigQuery Storage Write API client library already provides [configurable retries](https://cloud.google.com/java/docs/reference/google-cloud-bigquerystorage/latest/com.google.cloud.bigquery.storage.v1.JsonStreamWriter.Builder#com_google_cloud_bigquery_storage_v1_JsonStreamWriter_Builder_setRetrySettings_com_google_api_gax_retrying_RetrySettings_) for handling request-level errors. This change enables those client-side retries so the connector can rely on the Java client’s built-in logic for those error types instead of relying on the retry handler.

### What changed
- Centralized JsonStreamWriter configuration so that both default stream and batch application stream use the same setup.
- Enabled request-level retries in JsonStreamWriter configuration.
- Updated connector retry logic to skip reattempting writes that have already been retried by the Java client library. 

**Note:** After the client library exhausts its configured reattempts, it still returns a "retriable" status code.
Previously, the connector would interpret this as retriable and attempt again, eventually failing with: "Exceeded X attempts to write to table ...". Now, the task fails immediately with: "Failed to write rows on table ..."