### PR TITLE
Update decimal schema converter

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnector.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkConnector.java
@@ -25,6 +25,8 @@ package com.wepay.kafka.connect.bigquery;
 
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters;
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConverters;
 import io.aiven.kafka.utils.VersionInfo;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -71,6 +73,8 @@ public class BigQuerySinkConnector extends SinkConnector {
     logger.trace("connector.start()");
     configProperties = properties;
     config = new BigQuerySinkConfig(properties);
+    DebeziumLogicalConverters.initialize(config);
+    KafkaLogicalConverters.initialize(config);
   }
 
   @Override

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -1043,9 +1043,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
   public SchemaConverter<Schema> getSchemaConverter() { /// Update it later
     return new BigQuerySchemaConverter(
         getBoolean(ALL_BQ_FIELDS_NULLABLE_CONFIG),
-        getBoolean(SANITIZE_FIELD_NAME_CONFIG),
-        getDecimalHandlingMode(),
-        getVariableScaleDecimalHandlingMode());
+        getBoolean(SANITIZE_FIELD_NAME_CONFIG));
   }
 
   /**
@@ -1056,11 +1054,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
   public RecordConverter<Map<String, Object>> getRecordConverter() {
     return new BigQueryRecordConverter(
         getBoolean(CONVERT_DOUBLE_SPECIAL_VALUES_CONFIG),
-        getBoolean(CONVERT_DEBEZIUM_TIMESTAMP_TO_INTEGER_CONFIG),
-        getBoolean(USE_STORAGE_WRITE_API_CONFIG),
-        getDecimalHandlingMode(),
-        getVariableScaleDecimalHandlingMode()
-    );
+        getBoolean(USE_STORAGE_WRITE_API_CONFIG));
   }
 
   /**

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -192,8 +192,6 @@ public class BigQuerySinkConfig extends AbstractConfig {
   public static final String DEBEZIUM_VARIABLE_SCALE_DECIMAL_HANDLING_MODE_DOC = "Specifies the conversion strategy for "
           + VariableScaleDecimal.LOGICAL_NAME + "variables.";
 
-  public static final String VARIABLE_SCALE_DECIMAL_HANDLING_MODE_CONFIG =
-      "variableScaleDecimalHandlingMode";
   public static final String TIME_PARTITIONING_TYPE_CONFIG = "timePartitioningType";
   public static final String TIME_PARTITIONING_TYPE_DEFAULT = TimePartitioning.Type.DAY.name().toUpperCase();
   public static final String TIME_PARTITIONING_TYPE_NONE = "NONE";
@@ -1022,10 +1020,11 @@ public class BigQuerySinkConfig extends AbstractConfig {
 
   public DecimalHandlingMode getVariableScaleDecimalHandlingMode() {
     DecimalHandlingMode result = DecimalHandlingMode.valueOf(
-        getString(VARIABLE_SCALE_DECIMAL_HANDLING_MODE_CONFIG).toUpperCase(Locale.ROOT));
+        getString(DEBEZIUM_VARIABLE_SCALE_DECIMAL_HANDLING_MODE_CONFIG).toUpperCase(Locale.ROOT));
     // if default check if deprecated flag is set.
     if (DEBEZIUM_VARIABLE_SCALE_DECIMAL_HANDLING_MODE_DEFAULT.equals(result.name())
             && getBoolean(CONVERT_DEBEZIUM_DECIMAL_CONFIG)) {
+      logger.warn(deprecationMessage(CONVERT_DEBEZIUM_DECIMAL_CONFIG, DEBEZIUM_VARIABLE_SCALE_DECIMAL_HANDLING_MODE_DEFAULT));
       result = DecimalHandlingMode.NUMERIC;
     }
     return result;
@@ -1225,7 +1224,6 @@ public class BigQuerySinkConfig extends AbstractConfig {
   }
 
   private static String deprecatedGcsLoadDoc(String doc) {
-
     return deprecatedDoc(doc, GCS_LOAD_DEPRECATION_NOTICE);
   }
 
@@ -1235,6 +1233,16 @@ public class BigQuerySinkConfig extends AbstractConfig {
 
   private static String deprecatedDoc(String doc, String notice) {
     return DEPRECATED_DOC + " " + doc + " Warning: " + notice;
+  }
+
+  private static String deprecationMessage(String deprecatedOption, String replacementOption) {
+    StringBuilder sb = new StringBuilder(String.format("'%s' has been deprecated.", deprecatedOption));
+    if(replacementOption != null) {
+      sb.append(String.format(" Recommended replacement option is '%s'.", replacementOption));
+    } else {
+      sb.append(" No replacement is planned.");
+    }
+    return sb.toString();
   }
 
   private static class HandlingModeValidator implements ConfigDef.Validator {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -1237,7 +1237,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
 
   private static String deprecationMessage(String deprecatedOption, String replacementOption) {
     StringBuilder sb = new StringBuilder(String.format("'%s' has been deprecated.", deprecatedOption));
-    if(replacementOption != null) {
+    if (replacementOption != null) {
       sb.append(String.format(" Recommended replacement option is '%s'.", replacementOption));
     } else {
       sb.append(" No replacement is planned.");

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -177,7 +177,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
   public static final ConfigDef.Validator DECIMAL_HANDLING_MODE_VALIDATOR = new HandlingModeValidator();
   public static final ConfigDef.Importance DECIMAL_HANDLING_MODE_IMPORTANCE = ConfigDef.Importance.MEDIUM;
   public static final String DECIMAL_HANDLING_MODE_DOC = "Specifies the conversion strategy for "
-          + Decimal.LOGICAL_NAME + "variables.";
+          + Decimal.LOGICAL_NAME + "fields.";
 
   /**
    * @deprecated use {@link #DEBEZIUM_VARIABLE_SCALE_DECIMAL_HANDLING_MODE_CONFIG}=DECIMAL
@@ -190,7 +190,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
   public static final ConfigDef.Validator DEBEZIUM_VARIABLE_SCALE_DECIMAL_HANDLING_MODE_VALIDATOR =  new HandlingModeValidator();
   public static final ConfigDef.Importance DEBEZIUM_VARIABLE_SCALE_DECIMAL_HANDLING_MODE_IMPORTANCE =  ConfigDef.Importance.MEDIUM;
   public static final String DEBEZIUM_VARIABLE_SCALE_DECIMAL_HANDLING_MODE_DOC = "Specifies the conversion strategy for "
-          + VariableScaleDecimal.LOGICAL_NAME + "variables.";
+          + VariableScaleDecimal.LOGICAL_NAME + "fields.";
 
   public static final String TIME_PARTITIONING_TYPE_CONFIG = "timePartitioningType";
   public static final String TIME_PARTITIONING_TYPE_DEFAULT = TimePartitioning.Type.DAY.name().toUpperCase();
@@ -200,11 +200,6 @@ public class BigQuerySinkConfig extends AbstractConfig {
   public static final String ENABLE_RETRIES_CONFIG = "enableRetries";
   public static final Boolean ENABLE_RETRIES_DEFAULT = true;
 
-  public static final ConfigDef.Type VARIABLE_SCALE_DECIMAL_HANDLING_MODE_TYPE = ConfigDef.Type.STRING;
-  public static final ConfigDef.Importance VARIABLE_SCALE_DECIMAL_HANDLING_MODE_IMPORTANCE =
-      ConfigDef.Importance.MEDIUM;
-  public static final String VARIABLE_SCALE_DECIMAL_HANDLING_MODE_DOC =
-      "Handling for io.debezium.data.VariableScaleDecimal fields: none, float, numeric, bignumeric.";  
   private static final ConfigDef.Type TOPICS_TYPE = ConfigDef.Type.LIST;
   private static final ConfigDef.Importance TOPICS_IMPORTANCE = ConfigDef.Importance.HIGH;
   private static final String TOPICS_GROUP = "Common";
@@ -1021,7 +1016,15 @@ public class BigQuerySinkConfig extends AbstractConfig {
   public DecimalHandlingMode getVariableScaleDecimalHandlingMode() {
     DecimalHandlingMode result = DecimalHandlingMode.valueOf(
         getString(DEBEZIUM_VARIABLE_SCALE_DECIMAL_HANDLING_MODE_CONFIG).toUpperCase(Locale.ROOT));
-    // if default check if deprecated flag is set.
+    /*
+    This block of code resolves the tension between DEBEZIUM_VARIABLE_SCALE_DECIMAL_HANDLING_MODE_CONFIG and
+    the deprecated CONVERT_DEBEZIUM_DECIMAL_CONFIG.
+
+    If DEBEZIUM_VARIABLE_SCALE_DECIMAL_HANDLING_MODE_CONFIG is set to anything but the default, it takes precedence so return the value.
+    If DEBEZIUM_VARIABLE_SCALE_DECIMAL_HANDLING_MODE_CONFIG is the default then check CONVERT_DEBEZIUM_DECIMAL_CONFIG.
+    if CONVERT_DEBEZIUM_DECIMAL_CONFIG is set then set the return value to DecimalHandlingMode.NUMERIC.
+    otherwise return the value of the default.
+     */
     if (DEBEZIUM_VARIABLE_SCALE_DECIMAL_HANDLING_MODE_DEFAULT.equals(result.name())
             && getBoolean(CONVERT_DEBEZIUM_DECIMAL_CONFIG)) {
       logger.warn(deprecationMessage(CONVERT_DEBEZIUM_DECIMAL_CONFIG, DEBEZIUM_VARIABLE_SCALE_DECIMAL_HANDLING_MODE_DEFAULT));

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -1030,6 +1030,10 @@ public class BigQuerySinkConfig extends AbstractConfig {
     }
     return result;
   }
+
+  public boolean getShouldConvertDebeziumTimestampToInteger() {
+    return getBoolean(CONVERT_DEBEZIUM_TIMESTAMP_TO_INTEGER_CONFIG);
+  }
   
   /**
    * Return a new instance of the configured Schema Converter.

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
@@ -27,12 +27,9 @@ import com.google.cloud.bigquery.InsertAllRequest.RowToInsert;
 import com.google.protobuf.ByteString;
 import com.wepay.kafka.connect.bigquery.api.KafkaSchemaRecordType;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.DecimalHandlingMode;
-import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters;
-import com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConverters;
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.LogicalConverterRegistry;
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.LogicalTypeConverter;
 import com.wepay.kafka.connect.bigquery.exception.ConversionConnectException;
-import io.debezium.data.VariableScaleDecimal;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,7 +40,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
@@ -61,18 +57,18 @@ public class BigQueryRecordConverter implements RecordConverter<Map<String, Obje
           Integer.class, Long.class, Float.class, Double.class, String.class)
   );
 
-  static {
-    // force registration
-    DebeziumLogicalConverters.initialize();
-    KafkaLogicalConverters.initialize();
+  private final boolean shouldConvertSpecialDouble;
+  private final boolean useStorageWriteApi;
+
+  public BigQueryRecordConverter(boolean shouldConvertDoubleSpecial, boolean useStorageWriteApi) {
+    this.shouldConvertSpecialDouble = shouldConvertDoubleSpecial;
+    this.useStorageWriteApi = useStorageWriteApi;
   }
 
-  private final boolean shouldConvertSpecialDouble;
-  private final boolean shouldConvertDebeziumTimestampToInteger;
-  private final boolean useStorageWriteApi;
-  private final DecimalHandlingMode decimalHandlingMode;
-  private final DecimalHandlingMode variableScaleDecimalHandlingMode;  
-
+  /**
+   * @deprecated use {@link #BigQueryRecordConverter(boolean, boolean)} as all other values are processed during config.
+   */
+  @Deprecated
   public BigQueryRecordConverter(boolean shouldConvertDoubleSpecial,
                                  boolean shouldConvertDebeziumTimestampToInteger,
                                  boolean useStorageWriteApi) {
@@ -80,6 +76,10 @@ public class BigQueryRecordConverter implements RecordConverter<Map<String, Obje
         DecimalHandlingMode.NUMERIC, DecimalHandlingMode.NUMERIC);
   }
 
+  /**
+   * @deprecated use {@link #BigQueryRecordConverter(boolean, boolean)} as all other values are processed during config.
+   */
+  @Deprecated
   public BigQueryRecordConverter(boolean shouldConvertDoubleSpecial,
                                  boolean shouldConvertDebeziumTimestampToInteger,
                                  boolean useStorageWriteApi,
@@ -89,19 +89,16 @@ public class BigQueryRecordConverter implements RecordConverter<Map<String, Obje
         shouldConvertToDebeziumVariableScaleDecimal ? DecimalHandlingMode.NUMERIC : DecimalHandlingMode.RECORD);
   }
 
+  /**
+   * @deprecated use {@link #BigQueryRecordConverter(boolean, boolean)} as all other values are processed during config.
+   */
+  @Deprecated
   public BigQueryRecordConverter(boolean shouldConvertDoubleSpecial,
                                  boolean shouldConvertDebeziumTimestampToInteger,
                                  boolean useStorageWriteApi,
                                  DecimalHandlingMode decimalHandlingMode,
                                  DecimalHandlingMode variableScaleDecimalHandlingMode) {
-    if (variableScaleDecimalHandlingMode != DecimalHandlingMode.RECORD) {
-      DebeziumLogicalConverters.registerVariableScaleDecimalConverter();
-    }
-    this.shouldConvertSpecialDouble = shouldConvertDoubleSpecial;
-    this.shouldConvertDebeziumTimestampToInteger = shouldConvertDebeziumTimestampToInteger;
-    this.useStorageWriteApi = useStorageWriteApi;
-    this.decimalHandlingMode = decimalHandlingMode;
-    this.variableScaleDecimalHandlingMode = variableScaleDecimalHandlingMode;    
+    this(shouldConvertDoubleSpecial, useStorageWriteApi);
   }
 
   /**
@@ -183,8 +180,10 @@ public class BigQueryRecordConverter implements RecordConverter<Map<String, Obje
             kafkaConnectSchema.name() + " is not optional, but converting object had null value");
       }
     }
-    if (LogicalConverterRegistry.isRegisteredLogicalType(kafkaConnectSchema.name())) {
-      return convertLogical(kafkaConnectObject, kafkaConnectSchema);
+
+    LogicalTypeConverter converter = LogicalConverterRegistry.getConverter(kafkaConnectSchema.name());
+    if (converter != null) {
+      return converter.convert(kafkaConnectObject);
     }
     Schema.Type kafkaConnectSchemaType = kafkaConnectSchema.type();
     switch (kafkaConnectSchemaType) {
@@ -278,48 +277,6 @@ public class BigQueryRecordConverter implements RecordConverter<Map<String, Obje
       bigQueryEntryList.add(bigQueryEntry);
     }
     return bigQueryEntryList;
-  }
-
-  private Object convertLogical(Object kafkaConnectObject,
-                                Schema kafkaConnectSchema) {
-    String logicalName = kafkaConnectSchema.name();
-    if (Decimal.LOGICAL_NAME.equals(logicalName)) {
-      java.math.BigDecimal decimal = (java.math.BigDecimal) kafkaConnectObject;
-      switch (decimalHandlingMode) {
-        case RECORD:
-          Map<String, Object> struct = new HashMap<>();
-          struct.put("scale", decimal.scale());
-          struct.put("value", decimal.unscaledValue().toByteArray());
-          return struct;
-        case FLOAT:
-          return decimal.doubleValue();
-        case NUMERIC:
-        case BIGNUMERIC:
-        default:
-          return decimal;
-      }
-    }
-    if (VariableScaleDecimal.LOGICAL_NAME.equals(logicalName)) {
-      LogicalTypeConverter converter =
-          LogicalConverterRegistry.getConverter(logicalName);
-      java.math.BigDecimal decimal = (java.math.BigDecimal) converter.convert(kafkaConnectObject);
-      switch (variableScaleDecimalHandlingMode) {
-        case FLOAT:
-          return decimal.doubleValue();
-        case NUMERIC:
-        case BIGNUMERIC:
-        default:
-          return decimal;
-      }
-    }
-
-    LogicalTypeConverter converter =
-        LogicalConverterRegistry.getConverter(logicalName);
-    if (shouldConvertDebeziumTimestampToInteger
-        && converter instanceof DebeziumLogicalConverters.TimestampConverter) {
-      return (Long) kafkaConnectObject;
-    }
-    return converter.convert(kafkaConnectObject);
   }
 
   /**

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQueryRecordConverter.java
@@ -60,6 +60,12 @@ public class BigQueryRecordConverter implements RecordConverter<Map<String, Obje
   private final boolean shouldConvertSpecialDouble;
   private final boolean useStorageWriteApi;
 
+  /**
+   * Creates a record converter.
+   *
+   * @param shouldConvertDoubleSpecial if {@code true} converts doubles of Infinity to MAX_VALUE and negative Infinity to MIN_VALUE.
+   * @param useStorageWriteApi if {@code true} use the storage write API.
+   */
   public BigQueryRecordConverter(boolean shouldConvertDoubleSpecial, boolean useStorageWriteApi) {
     this.shouldConvertSpecialDouble = shouldConvertDoubleSpecial;
     this.useStorageWriteApi = useStorageWriteApi;

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
@@ -62,10 +62,6 @@ public class BigQuerySchemaConverter implements SchemaConverter<com.google.cloud
   private static final Map<Schema.Type, LegacySQLTypeName> PRIMITIVE_TYPE_MAP;
 
   static {
-    // force registration
-    DebeziumLogicalConverters.initialize();
-    KafkaLogicalConverters.initialize();
-
     PRIMITIVE_TYPE_MAP = new HashMap<>();
     PRIMITIVE_TYPE_MAP.put(Schema.Type.BOOLEAN,
         LegacySQLTypeName.BOOLEAN);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
@@ -40,8 +40,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Schema;
 
 /**
  * Class for converting from {@link Schema Kafka Connect Schemas} to
@@ -218,7 +218,7 @@ public class BigQuerySchemaConverter implements SchemaConverter<com.google.cloud
   private Optional<com.google.cloud.bigquery.Field.Builder> convertDecimalField(
       Schema schema, String fieldName) {
     switch (decimalHandlingMode) {
-      case NONE:
+      case RECORD:
         com.google.cloud.bigquery.Field scaleField =
             com.google.cloud.bigquery.Field.of("scale", LegacySQLTypeName.INTEGER);
         com.google.cloud.bigquery.Field valueField =
@@ -249,7 +249,7 @@ public class BigQuerySchemaConverter implements SchemaConverter<com.google.cloud
   private Optional<com.google.cloud.bigquery.Field.Builder> convertVariableScaleDecimalField(
       Schema schema, String fieldName) {
     switch (variableScaleDecimalHandlingMode) {
-      case NONE:
+      case RECORD:
         return convertStruct(schema, fieldName);
       case FLOAT:
         return Optional.of(

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConverters.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConverters.java
@@ -224,7 +224,7 @@ public class DebeziumLogicalConverters {
   }
 
   /**
-   * Class for converting Debezium variable scale decimals to BigQuery NUMERIC.
+   * Class for converting Debezium variable scale decimals.
    */
   public static class VariableScaleDecimalConverter extends LogicalTypeConverter {
     /**

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConverters.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConverters.java
@@ -179,7 +179,7 @@ public class DebeziumLogicalConverters {
     public TimestampConverter(boolean asInteger) {
       super(Timestamp.SCHEMA_NAME,
           Schema.Type.INT64,
-          LegacySQLTypeName.TIMESTAMP);
+          asInteger ? LegacySQLTypeName.INTEGER : LegacySQLTypeName.TIMESTAMP);
       this.asInteger = asInteger;
     }
 
@@ -231,7 +231,7 @@ public class DebeziumLogicalConverters {
     public VariableScaleDecimalConverter(final BigQuerySinkConfig.DecimalHandlingMode decimalHandlingMode) {
       super(VariableScaleDecimal.LOGICAL_NAME,
           Schema.Type.STRUCT,
-          LegacySQLTypeName.NUMERIC);
+          decimalHandlingMode.sqlTypeName);
       this.decimalHandlingMode = decimalHandlingMode;
     }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConverters.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConverters.java
@@ -56,7 +56,7 @@ public class DebeziumLogicalConverters {
     LogicalConverterRegistry.register(Time.SCHEMA_NAME, new TimeConverter());
     LogicalConverterRegistry.register(ZonedTimestamp.SCHEMA_NAME, new ZonedTimestampConverter());
     LogicalConverterRegistry.register(Timestamp.SCHEMA_NAME, new TimestampConverter(config.getShouldConvertDebeziumTimestampToInteger()));
-    LogicalConverterRegistry.registerIfAbsent(VariableScaleDecimal.LOGICAL_NAME, new VariableScaleDecimalConverter(config.getVariableScaleDecimalHandlingMode()));
+    LogicalConverterRegistry.register(VariableScaleDecimal.LOGICAL_NAME, new VariableScaleDecimalConverter(config.getVariableScaleDecimalHandlingMode()));
   }
 
   private DebeziumLogicalConverters() {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/KafkaLogicalConverters.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/KafkaLogicalConverters.java
@@ -46,10 +46,11 @@ public class KafkaLogicalConverters {
 
   /**
    * These values are extracted from BigQuery documentation.
+   *
    * @see <a href="https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#numeric-type">BigQuery data types</a>
    */
-  private final static int MAX_NUMERIC_PRECISION = 38;
-  private final static int MAX_NUMERIC_SCALE = 9;
+  private static final int MAX_NUMERIC_PRECISION = 38;
+  private static final int MAX_NUMERIC_SCALE = 9;
 
   public static void initialize(final BigQuerySinkConfig config) {
     LogicalConverterRegistry.register(Date.LOGICAL_NAME, new DateConverter());

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/KafkaLogicalConverters.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/KafkaLogicalConverters.java
@@ -81,8 +81,7 @@ public class KafkaLogicalConverters {
     public DecimalConverter() {
       super(Decimal.LOGICAL_NAME,
           Schema.Type.BYTES,
-          LegacySQLTypeName.NUMERIC);
-
+          LegacySQLTypeName.FLOAT);
     }
 
     @Override

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/KafkaLogicalConverters.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/KafkaLogicalConverters.java
@@ -44,6 +44,13 @@ import org.apache.kafka.connect.data.Timestamp;
  */
 public class KafkaLogicalConverters {
 
+  /**
+   * These values are extracted from BigQuery documentation.
+   * @see <a href="https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#numeric-type">BigQuery data types</a>
+   */
+  private final static int MAX_NUMERIC_PRECISION = 38;
+  private final static int MAX_NUMERIC_SCALE = 9;
+
   public static void initialize(final BigQuerySinkConfig config) {
     LogicalConverterRegistry.register(Date.LOGICAL_NAME, new DateConverter());
     LogicalConverterRegistry.register(Decimal.LOGICAL_NAME, new DecimalConverter(config.getDecimalHandlingMode()));
@@ -143,11 +150,11 @@ public class KafkaLogicalConverters {
               scale = Long.valueOf(scaleStr);
             }
           }
-          if (decimalHandlingMode.sqlTypeName != LegacySQLTypeName.BIGNUMERIC) {
-            if (precision != null && precision > 38) {
+          if (decimalHandlingMode.sqlTypeName == LegacySQLTypeName.NUMERIC) {
+            if (precision != null && precision > MAX_NUMERIC_PRECISION) {
               throw new ConversionConnectException(String.format("Requested precision (%s) is too high for %s type", precision, decimalHandlingMode.sqlTypeName));
             }
-            if (scale != null && scale > 9) {
+            if (scale != null && scale > MAX_NUMERIC_SCALE) {
               throw new ConversionConnectException(String.format("Requested scale (%s) is too large for %s type", precision, decimalHandlingMode.sqlTypeName));
             }
           }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/KafkaLogicalConverters.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/KafkaLogicalConverters.java
@@ -81,7 +81,7 @@ public class KafkaLogicalConverters {
     public DecimalConverter(final BigQuerySinkConfig.DecimalHandlingMode decimalHandlingMode) {
       super(Decimal.LOGICAL_NAME,
           Schema.Type.BYTES,
-          LegacySQLTypeName.FLOAT);
+          decimalHandlingMode.sqlTypeName);
       this.decimalHandlingMode = decimalHandlingMode;
     }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/LogicalConverterRegistry.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/LogicalConverterRegistry.java
@@ -68,11 +68,11 @@ public class LogicalConverterRegistry {
   /**
    * Gets the converter registered with the logical type name.
    *
-   * @param logicalTypeName the logical type name.
-   * @return the LogicalTypeConverter or {@code null} if none is registered.
+   * @param logicalTypeName the logical type name. May be {@code null}.
+   * @return the LogicalTypeConverter or {@code null} if none is registered or {@code null} passed for {@code logicalTypeName}.
    */
   public static LogicalTypeConverter getConverter(String logicalTypeName) {
-    return converterMap.get(logicalTypeName);
+    return logicalTypeName == null ? null : converterMap.get(logicalTypeName);
   }
 
   /**

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/LogicalTypeConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/LogicalTypeConverter.java
@@ -23,6 +23,7 @@
 
 package com.wepay.kafka.connect.bigquery.convert.logicaltype;
 
+import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.wepay.kafka.connect.bigquery.exception.ConversionConnectException;
 import java.text.SimpleDateFormat;
@@ -91,6 +92,19 @@ public abstract class LogicalTypeConverter {
 
   public LegacySQLTypeName getBqSchemaType() {
     return bqSchemaType;
+  }
+
+  /**
+   * Build a BigQuery field for the given Kafka Connect schema.
+   * Subclasses may override to customize precision, scale, or type.
+   *
+   * @param schema the Kafka Connect schema of the logical field
+   * @param fieldName the name of the field
+   * @return a {@link Field.Builder} initialized for this logical type
+   */
+  public Field.Builder getFieldBuilder(Schema schema, String fieldName) {
+    checkEncodingType(schema.type());
+    return Field.newBuilder(fieldName, bqSchemaType);
   }
 
   /**

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/LogicalTypeConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/LogicalTypeConverter.java
@@ -27,7 +27,9 @@ import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.wepay.kafka.connect.bigquery.exception.ConversionConnectException;
 import java.text.SimpleDateFormat;
+import java.util.Optional;
 import java.util.TimeZone;
+import java.util.function.BiFunction;
 import org.apache.kafka.connect.data.Schema;
 
 /**
@@ -101,11 +103,27 @@ public abstract class LogicalTypeConverter {
    * @param schema the Kafka Connect schema of the logical field
    * @param fieldName the name of the field
    * @return a {@link Field.Builder} initialized for this logical type
+   * @deprecated use {@link #getFieldBuilder(Schema, String, BiFunction)}
    */
+  @Deprecated
   public Field.Builder getFieldBuilder(Schema schema, String fieldName) {
+    return getFieldBuilder(schema, fieldName, (a, b) -> Optional.empty());
+  }
+
+  /**
+   * Build a BigQuery field for the given Kafka Connect schema.
+   * Subclasses may override to customize precision, scale, or type.
+   *
+   * @param schema the Kafka Connect schema of the logical field
+   * @param fieldName the name of the field
+   * @param convertStruct a function that converts the schema and field name into a Field.Builder.
+   * @return a {@link Field.Builder} initialized for this logical type
+   */
+  public Field.Builder getFieldBuilder(Schema schema, String fieldName, BiFunction<Schema, String, Optional<Field.Builder>> convertStruct) {
     checkEncodingType(schema.type());
     return Field.newBuilder(fieldName, bqSchemaType);
   }
+
 
   /**
    * Convert the given KafkaConnect Record Object to a BigQuery Record Object.
@@ -114,5 +132,4 @@ public abstract class LogicalTypeConverter {
    * @return the converted Object
    */
   public abstract Object convert(Object kafkaConnectObject);
-
 }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
@@ -53,6 +53,8 @@ import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters;
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConverters;
 import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 import com.wepay.kafka.connect.bigquery.utils.MockTime;
 import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
@@ -156,10 +158,21 @@ public class BigQuerySinkTaskTest {
     return spoofSinkRecord(topic, null, null, field, value, timestampType, timestamp);
   }
 
+  /**
+   * Initialize the converters.  This is normally done by BigQuerySinkConnector before task is created.
+   * @param properties the configuration properties.
+   */
+  private void initialize(Map<String, String> properties) {
+    BigQuerySinkConfig config = new BigQuerySinkConfig(properties);
+    DebeziumLogicalConverters.initialize(config);
+    KafkaLogicalConverters.initialize(config);
+  }
+
   @Test
   public void testGetRecordTableUsesConfiguredProject() throws Exception {
     Map<String, String> properties = propertiesFactory.getProperties();
     properties.put(BigQuerySinkConfig.USE_CREDENTIALS_PROJECT_ID_CONFIG, "false");
+    initialize(properties);
 
     BigQuerySinkTask task = new BigQuerySinkTask(
         mock(BigQuery.class),
@@ -188,6 +201,7 @@ public class BigQuerySinkTaskTest {
   public void testGetRecordTableUsesCredentialsProject() throws Exception {
     Map<String, String> properties = propertiesFactory.getProperties();
     properties.put(BigQuerySinkConfig.USE_CREDENTIALS_PROJECT_ID_CONFIG, "true");
+    initialize(properties);
 
     BigQuerySinkTask task = new BigQuerySinkTask(
         mock(BigQuery.class),
@@ -280,6 +294,7 @@ public class BigQuerySinkTaskTest {
     Map<String, String> properties = propertiesFactory.getProperties();
     properties.put(BigQuerySinkConfig.TOPICS_CONFIG, topic);
     properties.put(BigQuerySinkConfig.DEFAULT_DATASET_CONFIG, "scratch");
+    initialize(properties);
 
     BigQuery bigQuery = mock(BigQuery.class);
     Table mockTable = mock(Table.class);
@@ -324,6 +339,7 @@ public class BigQuerySinkTaskTest {
     properties.put(BigQuerySinkConfig.TOPICS_CONFIG, topic);
     properties.put(BigQuerySinkConfig.DEFAULT_DATASET_CONFIG, "scratch");
     properties.put(BigQuerySinkConfig.ENABLE_BATCH_CONFIG, "test-topic");
+    initialize(properties);
 
     BigQuery bigQuery = mock(BigQuery.class);
     Table mockTable = mock(Table.class);
@@ -371,6 +387,7 @@ public class BigQuerySinkTaskTest {
     Map<String, String> properties = propertiesFactory.getProperties();
     properties.put(BigQuerySinkConfig.TOPICS_CONFIG, topic);
     properties.put(BigQuerySinkConfig.DEFAULT_DATASET_CONFIG, "scratch");
+    initialize(properties);
 
     BigQuery bigQuery = mock(BigQuery.class);
     Table mockTable = mock(Table.class);
@@ -410,6 +427,7 @@ public class BigQuerySinkTaskTest {
   @Test
   public void testEmptyPut() {
     Map<String, String> properties = propertiesFactory.getProperties();
+    initialize(properties);
     BigQuery bigQuery = mock(BigQuery.class);
     Storage storage = mock(Storage.class);
 
@@ -442,6 +460,7 @@ public class BigQuerySinkTaskTest {
         .build();
 
     Map<String, String> properties = propertiesFactory.getProperties();
+    initialize(properties);
     BigQuery bigQuery = mock(BigQuery.class);
     Storage storage = mock(Storage.class);
 
@@ -475,6 +494,7 @@ public class BigQuerySinkTaskTest {
     properties.put(BigQuerySinkConfig.TOPICS_CONFIG, topic);
     properties.put(BigQuerySinkConfig.DEFAULT_DATASET_CONFIG, "scratch");
     properties.put(BigQuerySinkConfig.BIGQUERY_MESSAGE_TIME_PARTITIONING_CONFIG, "true");
+    initialize(properties);
 
     BigQuery bigQuery = mock(BigQuery.class);
     Table mockTable = mock(Table.class);
@@ -522,6 +542,7 @@ public class BigQuerySinkTaskTest {
     properties.put(BigQuerySinkConfig.DEFAULT_DATASET_CONFIG, "scratch");
     properties.put(BigQuerySinkConfig.BIGQUERY_PARTITION_DECORATOR_CONFIG, "true");
     properties.put(BigQuerySinkConfig.BIGQUERY_MESSAGE_TIME_PARTITIONING_CONFIG, "true");
+    initialize(properties);
 
     BigQuery bigQuery = mock(BigQuery.class);
     Table mockTable = mock(Table.class);
@@ -568,6 +589,7 @@ public class BigQuerySinkTaskTest {
     properties.put(BigQuerySinkConfig.TOPICS_CONFIG, topic);
     properties.put(BigQuerySinkConfig.DEFAULT_DATASET_CONFIG, "scratch");
     properties.put(BigQuerySinkConfig.BIGQUERY_PARTITION_DECORATOR_CONFIG, "false");
+    initialize(properties);
 
     BigQuery bigQuery = mock(BigQuery.class);
     Table mockTable = mock(Table.class);
@@ -614,6 +636,7 @@ public class BigQuerySinkTaskTest {
     properties.put(BigQuerySinkConfig.TOPICS_CONFIG, topic);
     properties.put(BigQuerySinkConfig.DEFAULT_DATASET_CONFIG, "scratch");
     properties.put(BigQuerySinkConfig.BIGQUERY_MESSAGE_TIME_PARTITIONING_CONFIG, "true");
+    initialize(properties);
 
     BigQuery bigQuery = mock(BigQuery.class);
     Table mockTable = mock(Table.class);
@@ -663,6 +686,7 @@ public class BigQuerySinkTaskTest {
     properties.put(BigQuerySinkConfig.MERGE_INTERVAL_MS_CONFIG, "-1");
     properties.put(BigQuerySinkConfig.MERGE_RECORDS_THRESHOLD_CONFIG, "2");
     properties.put(BigQuerySinkConfig.KAFKA_KEY_FIELD_NAME_CONFIG, key);
+    initialize(properties);
 
     BigQuery bigQuery = mock(BigQuery.class);
     Storage storage = mock(Storage.class);
@@ -744,6 +768,7 @@ public class BigQuerySinkTaskTest {
     Map<String, String> properties = propertiesFactory.getProperties();
     properties.put(BigQuerySinkConfig.TOPICS_CONFIG, topic);
     properties.put(BigQuerySinkConfig.DEFAULT_DATASET_CONFIG, "scratch");
+    initialize(properties);
 
     BigQuery bigQuery = mock(BigQuery.class);
     Table mockTable = mock(Table.class);
@@ -789,6 +814,7 @@ public class BigQuerySinkTaskTest {
   @Test
   public void testEmptyFlush() {
     Map<String, String> properties = propertiesFactory.getProperties();
+    initialize(properties);
     BigQuery bigQuery = mock(BigQuery.class);
     Storage storage = mock(Storage.class);
 
@@ -816,6 +842,7 @@ public class BigQuerySinkTaskTest {
   @Test
   public void testFlushAfterStop() {
     Map<String, String> properties = propertiesFactory.getProperties();
+    initialize(properties);
     Storage storage = mock(Storage.class);
 
     BigQuery bigQuery = mock(BigQuery.class);
@@ -870,6 +897,7 @@ public class BigQuerySinkTaskTest {
     properties.put(BigQuerySinkConfig.BIGQUERY_RETRY_WAIT_CONFIG, "2000");
     properties.put(BigQuerySinkConfig.TOPICS_CONFIG, topic);
     properties.put(BigQuerySinkConfig.DEFAULT_DATASET_CONFIG, dataset);
+    initialize(properties);
 
     BigQuery bigQuery = mock(BigQuery.class);
     when(bigQuery.getTable(any())).thenThrow(new BigQueryException(new SocketTimeoutException("mock timeout")));
@@ -909,6 +937,7 @@ public class BigQuerySinkTaskTest {
     properties.put(BigQuerySinkConfig.BIGQUERY_RETRY_WAIT_CONFIG, "2000");
     properties.put(BigQuerySinkConfig.TOPICS_CONFIG, topic);
     properties.put(BigQuerySinkConfig.DEFAULT_DATASET_CONFIG, dataset);
+    initialize(properties);
 
     BigQuery bigQuery = mock(BigQuery.class);
     Table mockTable = mock(Table.class);
@@ -958,6 +987,7 @@ public class BigQuerySinkTaskTest {
     properties.put(BigQuerySinkConfig.BIGQUERY_RETRY_WAIT_CONFIG, "2000");
     properties.put(BigQuerySinkConfig.TOPICS_CONFIG, topic);
     properties.put(BigQuerySinkConfig.DEFAULT_DATASET_CONFIG, dataset);
+    initialize(properties);
 
     BigQuery bigQuery = mock(BigQuery.class);
     Table mockTable = mock(Table.class);
@@ -1008,6 +1038,7 @@ public class BigQuerySinkTaskTest {
     properties.put(BigQuerySinkConfig.BIGQUERY_RETRY_WAIT_CONFIG, "2000");
     properties.put(BigQuerySinkConfig.TOPICS_CONFIG, topic);
     properties.put(BigQuerySinkConfig.DEFAULT_DATASET_CONFIG, dataset);
+    initialize(properties);
 
     BigQuery bigQuery = mock(BigQuery.class);
     Table mockTable = mock(Table.class);
@@ -1055,6 +1086,7 @@ public class BigQuerySinkTaskTest {
     Map<String, String> properties = propertiesFactory.getProperties();
     properties.put(BigQuerySinkConfig.TOPICS_CONFIG, topic);
     properties.put(BigQuerySinkConfig.DEFAULT_DATASET_CONFIG, dataset);
+    initialize(properties);
 
     BigQuery bigQuery = mock(BigQuery.class);
     Table mockTable = mock(Table.class);
@@ -1105,6 +1137,7 @@ public class BigQuerySinkTaskTest {
     properties.put(BigQuerySinkConfig.BIGQUERY_MESSAGE_TIME_PARTITIONING_CONFIG, "true");
     properties.put(BigQuerySinkConfig.TOPICS_CONFIG, topic);
     properties.put(BigQuerySinkConfig.DEFAULT_DATASET_CONFIG, dataset);
+    initialize(properties);
 
     StandardTableDefinition mockTableDefinition = mock(StandardTableDefinition.class);
     when(mockTableDefinition.getTimePartitioning()).thenReturn(TimePartitioning.of(TimePartitioning.Type.HOUR));
@@ -1154,6 +1187,7 @@ public class BigQuerySinkTaskTest {
     Map<String, String> properties = propertiesFactory.getProperties();
     properties.put(BigQuerySinkConfig.TOPICS_CONFIG, topic);
     properties.put(BigQuerySinkConfig.DEFAULT_DATASET_CONFIG, dataset);
+    initialize(properties);
 
     BigQuery bigQuery = mock(BigQuery.class);
     Table mockTable = mock(Table.class);

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverterTest.java
@@ -25,9 +25,12 @@ package com.wepay.kafka.connect.bigquery.convert;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.LegacySQLTypeName;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import com.wepay.kafka.connect.bigquery.exception.ConversionConnectException;
 import com.wepay.kafka.connect.bigquery.utils.FieldNameSanitizer;
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters;
@@ -581,7 +584,11 @@ public class BigQuerySchemaConverterTest {
   public void testDebeziumVariableScaleDecimal() {
     final String fieldName = "DebeziumDecimal";
 
-    DebeziumLogicalConverters.registerVariableScaleDecimalConverter();
+    final BigQuerySinkConfig config = mock(BigQuerySinkConfig.class);
+    when(config.getVariableScaleDecimalHandlingMode()).thenReturn(BigQuerySinkConfig.DecimalHandlingMode.NUMERIC);
+
+    DebeziumLogicalConverters.initialize(config);
+    //DebeziumLogicalConverters.registerVariableScaleDecimalConverter();
 
     com.google.cloud.bigquery.Schema bigQueryExpectedSchema =
         com.google.cloud.bigquery.Schema.of(

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConvertersTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/DebeziumLogicalConvertersTest.java
@@ -24,9 +24,12 @@
 package com.wepay.kafka.connect.bigquery.convert.logicaltype;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.cloud.bigquery.LegacySQLTypeName;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters.DateConverter;
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters.MicroTimeConverter;
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters.MicroTimestampConverter;
@@ -112,13 +115,14 @@ public class DebeziumLogicalConvertersTest {
 
   @Test
   public void testTimestampConversion() {
-    TimestampConverter converter = new TimestampConverter();
+    TimestampConverter converter = new TimestampConverter(false);
 
     assertEquals(LegacySQLTypeName.TIMESTAMP, converter.getBqSchemaType());
 
     converter.checkEncodingType(Schema.Type.INT64);
 
-    String formattedTimestamp = converter.convert(MILLI_TIMESTAMP);
+    Object formattedTimestamp = converter.convert(MILLI_TIMESTAMP);
+    assertInstanceOf(String.class, formattedTimestamp);
     assertEquals("2017-03-01 22:20:38.808", formattedTimestamp);
   }
 
@@ -137,7 +141,7 @@ public class DebeziumLogicalConvertersTest {
   @Test
   public void testVariableScaleDecimalConversion() {
     DebeziumLogicalConverters.VariableScaleDecimalConverter converter =
-        new DebeziumLogicalConverters.VariableScaleDecimalConverter();
+        new DebeziumLogicalConverters.VariableScaleDecimalConverter(BigQuerySinkConfig.DecimalHandlingMode.NUMERIC);
 
     assertEquals(LegacySQLTypeName.NUMERIC, converter.getBqSchemaType());
 
@@ -160,7 +164,7 @@ public class DebeziumLogicalConvertersTest {
   @Test
   public void testVariableScaleDecimalConversionNullValue() {
     DebeziumLogicalConverters.VariableScaleDecimalConverter converter =
-        new DebeziumLogicalConverters.VariableScaleDecimalConverter();
+        new DebeziumLogicalConverters.VariableScaleDecimalConverter(BigQuerySinkConfig.DecimalHandlingMode.NUMERIC);
 
     Schema schema = SchemaBuilder.struct()
         .name(io.debezium.data.VariableScaleDecimal.LOGICAL_NAME)

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/KafkaLogicalConvertersTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/KafkaLogicalConvertersTest.java
@@ -27,7 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
@@ -37,14 +36,12 @@ import com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConverte
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConverters.TimestampConverter;
 import java.math.BigDecimal;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.kafka.connect.data.Schema;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 public class KafkaLogicalConvertersTest {
 

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiWriterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiWriterTest.java
@@ -69,7 +69,6 @@ public class StorageWriteApiWriterTest {
     when(mockedConfig.getBoolean(BigQuerySinkConfig.USE_STORAGE_WRITE_API_CONFIG)).thenReturn(true);
     RecordConverter<Map<String, Object>> recordConverter = new BigQueryRecordConverter(
         false,
-        false,
         true
     );
     when(mockedConfig.getRecordConverter()).thenReturn(recordConverter);
@@ -119,7 +118,7 @@ public class StorageWriteApiWriterTest {
     BigQuerySinkTaskConfig mockedConfig = Mockito.mock(BigQuerySinkTaskConfig.class);
     when(mockedConfig.getBoolean(BigQuerySinkConfig.USE_STORAGE_WRITE_API_CONFIG)).thenReturn(true);
     RecordConverter<Map<String, Object>> recordConverter = new BigQueryRecordConverter(
-        false, false, false);
+        false, false);
     when (mockedConfig.getRecordConverter()).thenReturn(recordConverter);
     StorageApiBatchModeHandler batchModeHandler = mock(StorageApiBatchModeHandler.class);
     SinkRecordConverter sinkRecordConverter = new SinkRecordConverter(mockedConfig, null, null);
@@ -140,8 +139,6 @@ public class StorageWriteApiWriterTest {
         .initializeAndWriteRecords(any(), any(), streamName.capture());
 
     assertEquals(expectedStreamName, streamName.getValue());
-
-
   }
 
   private SinkRecord createRecord(String topic, long offset) {


### PR DESCRIPTION
## Overview
This PR is based on the PR here:  https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/pull/82
You can find the details and discussions there.
On top of the PR above convertsKafkaConnectDecimalLogicalType added to KafkaLogicalConvertersTest.java in this PR

The NUMERIC fields are represented as io.debezium.data.VariableScaleDecimal and can be safely converted to NUMERIC in BigQuery.
However, the Kafka connector currently parses NUMERIC(x,y) types in PostgreSQL as org.apache.kafka.connect.data.Decimal, which isn’t handled by the existing conversion function.
As a result, these NUMERIC(x,y) fields are skipped during type conversion and stored as floats instead of NUMERIC.
The main goal here is ensuring the conversion of org.apache.kafka.connect.data.Decimal to NUMERIC types.

## Tests
```
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConvertersTest

```


