### PR TITLE
Add ability to ignore unknown fields in kafka messages

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -135,6 +135,7 @@ public class BigQuerySinkTask extends SinkTask {
   private StorageWriteApiBase storageApiWriter;
   private StorageApiBatchModeHandler batchHandler;
   private boolean autoCreateTables;
+  private boolean ignoreUnknownFields;
   private int retry;
   private long retryWait;
   private Map<String, PartitionedTableId> topicToPartitionTableId;
@@ -492,6 +493,7 @@ public class BigQuerySinkTask extends SinkTask {
           retry,
           retryWait,
           autoCreateTables,
+          ignoreUnknownFields,
           mergeBatches.intermediateToDestinationTables(),
           errantRecordHandler,
           time);
@@ -501,10 +503,11 @@ public class BigQuerySinkTask extends SinkTask {
           retry,
           retryWait,
           autoCreateTables,
+          ignoreUnknownFields,
           errantRecordHandler,
           time);
     } else {
-      return new SimpleBigQueryWriter(bigQuery, retry, retryWait, errantRecordHandler, time);
+      return new SimpleBigQueryWriter(bigQuery, retry, retryWait, ignoreUnknownFields, errantRecordHandler, time);
     }
   }
 
@@ -554,6 +557,7 @@ public class BigQuerySinkTask extends SinkTask {
     stopped = false;
     config = new BigQuerySinkTaskConfig(properties);
     autoCreateTables = config.getBoolean(BigQuerySinkConfig.TABLE_CREATE_CONFIG);
+    ignoreUnknownFields = config.getBoolean(BigQuerySinkConfig.IGNORE_UNKNOWN_FIELDS_CONFIG);
     upsertDelete = config.getBoolean(BigQuerySinkConfig.UPSERT_ENABLED_CONFIG)
         || config.getBoolean(BigQuerySinkConfig.DELETE_ENABLED_CONFIG);
 
@@ -639,7 +643,8 @@ public class BigQuerySinkTask extends SinkTask {
             autoCreateTables,
             errantRecordHandler,
             getSchemaManager(),
-            attemptSchemaUpdate
+            attemptSchemaUpdate,
+            ignoreUnknownFields
         );
         storageApiWriter = writer;
 
@@ -659,7 +664,8 @@ public class BigQuerySinkTask extends SinkTask {
             autoCreateTables,
             errantRecordHandler,
             getSchemaManager(),
-            attemptSchemaUpdate
+            attemptSchemaUpdate,
+            ignoreUnknownFields
         );
       }
     }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -199,7 +199,8 @@ public class BigQuerySinkConfig extends AbstractConfig {
   public static final String MAX_RETRIES_CONFIG = "max.retries";
   public static final String ENABLE_RETRIES_CONFIG = "enableRetries";
   public static final Boolean ENABLE_RETRIES_DEFAULT = true;
-
+  public static final String IGNORE_UNKNOWN_FIELDS_CONFIG = "ignoreUnknownFields";
+  public static final Boolean IGNORE_UNKNOWN_FIELDS_DEFAULT = false;
   private static final ConfigDef.Type TOPICS_TYPE = ConfigDef.Type.LIST;
   private static final ConfigDef.Importance TOPICS_IMPORTANCE = ConfigDef.Importance.HIGH;
   private static final String TOPICS_GROUP = "Common";
@@ -535,7 +536,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
   private static final ConfigDef.Type CONVERT_DEBEZIUM_TIMESTAMP_TO_INTEGER_TYPE = ConfigDef.Type.BOOLEAN;
   private static final Boolean CONVERT_DEBEZIUM_TIMESTAMP_TO_INTEGER_DEFAULT = false;
   private static final ConfigDef.Importance CONVERT_DEBEZIUM_TIMESTAMP_TO_INTEGER_IMPORTANCE =
-      ConfigDef.Importance.MEDIUM;   
+      ConfigDef.Importance.MEDIUM;
   private static final ConfigDef.Type TIME_PARTITIONING_TYPE_TYPE = ConfigDef.Type.STRING;
   private static final ConfigDef.Importance TIME_PARTITIONING_TYPE_IMPORTANCE = ConfigDef.Importance.LOW;
   private static final List<String> TIME_PARTITIONING_TYPES = Stream.concat(
@@ -566,6 +567,11 @@ public class BigQuerySinkConfig extends AbstractConfig {
   private static final String MAX_RETRIES_DOC = "The maximum number of times to retry on retriable errors before failing the task.";
   private static final ConfigDef.Type ENABLE_RETRIES_TYPE = ConfigDef.Type.BOOLEAN;
   private static final ConfigDef.Importance ENABLE_RETRIES_IMPORTANCE = ConfigDef.Importance.MEDIUM;
+  private static final ConfigDef.Type IGNORE_UNKNOWN_FIELDS_TYPE = ConfigDef.Type.BOOLEAN;
+  private static final ConfigDef.Importance IGNORE_UNKNOWN_FIELDS_IMPORTANCE = ConfigDef.Importance.LOW;
+  private static final String IGNORE_UNKNOWN_FIELDS_DOC = "Whether fields in a record that are not present in the " +
+          "BigQuery table schema should be ignored during ingestion. When enabled, unknown fields will be silently " +
+          "dropped instead of causing the record to be rejected.\n";
   private static final List<MultiPropertyValidator<BigQuerySinkConfig>> MULTI_PROPERTY_VALIDATIONS = new ArrayList<>();
 
   static {
@@ -932,6 +938,12 @@ public class BigQuerySinkConfig extends AbstractConfig {
             MAX_RETRIES_VALIDATOR,
             MAX_RETRIES_IMPORTANCE,
             MAX_RETRIES_DOC
+        ).define(
+            IGNORE_UNKNOWN_FIELDS_CONFIG,
+            IGNORE_UNKNOWN_FIELDS_TYPE,
+            IGNORE_UNKNOWN_FIELDS_DEFAULT,
+            IGNORE_UNKNOWN_FIELDS_IMPORTANCE,
+            IGNORE_UNKNOWN_FIELDS_DOC
         ).defineInternal(
             ENABLE_RETRIES_CONFIG,
             ENABLE_RETRIES_TYPE,
@@ -1036,7 +1048,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
   public boolean getShouldConvertDebeziumTimestampToInteger() {
     return getBoolean(CONVERT_DEBEZIUM_TIMESTAMP_TO_INTEGER_CONFIG);
   }
-  
+
   /**
    * Return a new instance of the configured Schema Converter.
    *

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/AdaptiveBigQueryWriter.java
@@ -66,6 +66,7 @@ public class AdaptiveBigQueryWriter extends BigQueryWriter {
    * @param retry               How many retries to make in the event of a 500/503 error.
    * @param retryWait           How long to wait in between retries.
    * @param autoCreateTables    Whether tables should be automatically created
+   * @param ignoreUnknownFields Whether to ignore fields in records that are not defined in target BQ table schema
    * @param errantRecordHandler Used to handle errant records
    * @param time                used to wait during backoff periods
    */
@@ -74,9 +75,10 @@ public class AdaptiveBigQueryWriter extends BigQueryWriter {
                                 int retry,
                                 long retryWait,
                                 boolean autoCreateTables,
+                                boolean ignoreUnknownFields,
                                 ErrantRecordHandler errantRecordHandler,
                                 Time time) {
-    super(retry, retryWait, errantRecordHandler, time);
+    super(retry, retryWait, ignoreUnknownFields, errantRecordHandler, time);
     this.bigQuery = bigQuery;
     this.schemaManager = schemaManager;
     this.autoCreateTables = autoCreateTables;

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriter.java
@@ -54,6 +54,7 @@ public abstract class BigQueryWriter {
   protected final Time time;
   private final int retries;
   private final long retryWaitMs;
+  private final boolean ignoreUnknownFields;
   private final Random random;
   private final ErrantRecordHandler errantRecordHandler;
 
@@ -62,12 +63,15 @@ public abstract class BigQueryWriter {
    *                            or a service unavailable error.
    * @param retryWaitMs         the amount of time to wait in between reattempting a request if BQ returns
    *                            an internal service error or a service unavailable error.
+   * @param ignoreUnknownFields whether to ignore fields in records that are not defined in target BQ table schema
    * @param errantRecordHandler used to handle errant records
    * @param time                used to wait during backoff periods
    */
-  public BigQueryWriter(int retries, long retryWaitMs, ErrantRecordHandler errantRecordHandler, Time time) {
+  public BigQueryWriter(int retries, long retryWaitMs, boolean ignoreUnknownFields,
+                        ErrantRecordHandler errantRecordHandler, Time time) {
     this.retries = retries;
     this.retryWaitMs = retryWaitMs;
+    this.ignoreUnknownFields = ignoreUnknownFields;
 
     this.random = new Random();
     this.errantRecordHandler = errantRecordHandler;
@@ -97,7 +101,7 @@ public abstract class BigQueryWriter {
   protected InsertAllRequest createInsertAllRequest(PartitionedTableId tableId,
                                                     Collection<InsertAllRequest.RowToInsert> rows) {
     return InsertAllRequest.newBuilder(tableId.getFullTableId(), rows)
-        .setIgnoreUnknownValues(false)
+        .setIgnoreUnknownValues(ignoreUnknownFields)
         .setSkipInvalidRows(false)
         .build();
   }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/SimpleBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/SimpleBigQueryWriter.java
@@ -52,11 +52,13 @@ public class SimpleBigQueryWriter extends BigQueryWriter {
    * @param bigQuery            The object used to send write requests to BigQuery.
    * @param retry               How many retries to make in the event of a 500/503 error.
    * @param retryWait           How long to wait in between retries.
+   * @param ignoreUnknownFields whether to ignore fields in records that are not defined in target BQ table schema
    * @param errantRecordHandler Used to handle errant records
    * @param time                used to wait during backoff periods
    */
-  public SimpleBigQueryWriter(BigQuery bigQuery, int retry, long retryWait, ErrantRecordHandler errantRecordHandler, Time time) {
-    super(retry, retryWait, errantRecordHandler, time);
+  public SimpleBigQueryWriter(BigQuery bigQuery, int retry, long retryWait, boolean ignoreUnknownFields,
+                              ErrantRecordHandler errantRecordHandler, Time time) {
+    super(retry, retryWait, ignoreUnknownFields, errantRecordHandler, time);
     this.bigQuery = bigQuery;
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/UpsertDeleteBigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/UpsertDeleteBigQueryWriter.java
@@ -47,6 +47,7 @@ public class UpsertDeleteBigQueryWriter extends AdaptiveBigQueryWriter {
    * @param retry                           How many retries to make in the event of a 500/503 error.
    * @param retryWait                       How long to wait in between retries.
    * @param autoCreateTables                Whether destination tables should be automatically created
+   * @param ignoreUnknownFields             Whether to ignore fields in records that are not defined in target BQ table
    * @param intermediateToDestinationTables A mapping used to determine the destination table for
    *                                        given intermediate tables; used for create/update
    *                                        operations in order to propagate them to the destination
@@ -59,6 +60,7 @@ public class UpsertDeleteBigQueryWriter extends AdaptiveBigQueryWriter {
                                     int retry,
                                     long retryWait,
                                     boolean autoCreateTables,
+                                    boolean ignoreUnknownFields,
                                     Map<TableId, TableId> intermediateToDestinationTables,
                                     ErrantRecordHandler errantRecordHandler,
                                     Time time) {
@@ -66,7 +68,8 @@ public class UpsertDeleteBigQueryWriter extends AdaptiveBigQueryWriter {
     // automatically created
     // The super class will handle all of the logic for writing to, creating, and updating
     // intermediate tables; this class will handle logic for creating/updating the destination table
-    super(bigQuery, schemaManager.forIntermediateTables(), retry, retryWait, true, errantRecordHandler, time);
+    super(bigQuery, schemaManager.forIntermediateTables(), retry, retryWait, true, ignoreUnknownFields,
+            errantRecordHandler, time);
     this.schemaManager = schemaManager;
     this.autoCreateTables = autoCreateTables;
     this.intermediateToDestinationTables = intermediateToDestinationTables;

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBase.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBase.java
@@ -65,6 +65,7 @@ public abstract class StorageWriteApiBase {
   protected final int retry;
   protected final long retryWait;
   private final boolean autoCreateTables;
+  private final boolean ignoreUnknownFields;
   private final BigQueryWriteSettings writeSettings;
   private final boolean attemptSchemaUpdate;
   protected SchemaManager schemaManager;
@@ -79,6 +80,7 @@ public abstract class StorageWriteApiBase {
    * @param writeSettings       Write Settings for stream which carry authentication and other header information
    * @param autoCreateTables    boolean flag set if table should be created automatically
    * @param errantRecordHandler Used to handle errant records
+   * @param ignoreUnknownFields whether to ignore fields in records that are not defined in target BQ table schema
    */
   protected StorageWriteApiBase(int retry,
                                 long retryWait,
@@ -86,7 +88,8 @@ public abstract class StorageWriteApiBase {
                                 boolean autoCreateTables,
                                 ErrantRecordHandler errantRecordHandler,
                                 SchemaManager schemaManager,
-                                boolean attemptSchemaUpdate) {
+                                boolean attemptSchemaUpdate,
+                                boolean ignoreUnknownFields) {
     this.retry = retry;
     this.retryWait = retryWait;
     this.autoCreateTables = autoCreateTables;
@@ -94,6 +97,7 @@ public abstract class StorageWriteApiBase {
     this.errantRecordHandler = errantRecordHandler;
     this.schemaManager = schemaManager;
     this.attemptSchemaUpdate = attemptSchemaUpdate;
+    this.ignoreUnknownFields = ignoreUnknownFields;
     try {
       this.writeClient = getWriteClient();
     } catch (IOException e) {
@@ -312,6 +316,7 @@ public abstract class StorageWriteApiBase {
             .build();
     return streamOrTableName -> JsonStreamWriter.newBuilder(streamOrTableName, writeClient)
             .setRetrySettings(retrySettings)
+            .setIgnoreUnknownFields(ignoreUnknownFields)
             .build();
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBatchApplicationStream.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBatchApplicationStream.java
@@ -86,7 +86,8 @@ public class StorageWriteApiBatchApplicationStream extends StorageWriteApiBase {
       boolean autoCreateTables,
       ErrantRecordHandler errantRecordHandler,
       SchemaManager schemaManager,
-      boolean attemptSchemaUpdate) {
+      boolean attemptSchemaUpdate,
+      boolean ignoreUnknownFields) {
     super(
         retry,
         retryWait,
@@ -94,7 +95,8 @@ public class StorageWriteApiBatchApplicationStream extends StorageWriteApiBase {
         autoCreateTables,
         errantRecordHandler,
         schemaManager,
-        attemptSchemaUpdate
+        attemptSchemaUpdate,
+        ignoreUnknownFields
     );
     streams = new ConcurrentHashMap<>();
     currentStreams = new ConcurrentHashMap<>();

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiDefaultStream.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiDefaultStream.java
@@ -54,7 +54,8 @@ public class StorageWriteApiDefaultStream extends StorageWriteApiBase {
                                       boolean autoCreateTables,
                                       ErrantRecordHandler errantRecordHandler,
                                       SchemaManager schemaManager,
-                                      boolean attemptSchemaUpdate) {
+                                      boolean attemptSchemaUpdate,
+                                      boolean ignoreUnknownFields) {
     super(
         retry,
         retryWait,
@@ -62,7 +63,8 @@ public class StorageWriteApiDefaultStream extends StorageWriteApiBase {
         autoCreateTables,
         errantRecordHandler,
         schemaManager,
-        attemptSchemaUpdate
+        attemptSchemaUpdate,
+        ignoreUnknownFields
     );
   }
 

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/StorageWriteApiBigQuerySinkConnectorIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/StorageWriteApiBigQuerySinkConnectorIT.java
@@ -307,6 +307,97 @@ public class StorageWriteApiBigQuerySinkConnectorIT extends BaseConnectorIT {
     assertEquals(expectedRows(), testRows.stream().map(row -> row.get(0)).collect(Collectors.toSet()));
   }
 
+  @Test public void testRecordWithUnknownFieldFails() throws InterruptedException {
+    // create topic in Kafka
+    final String topic = suffixedTableOrTopic("storage-api-json-extra-field-fails");
+    final String table = sanitizedTable(topic);
+
+    // create topic
+    connect.kafka().createTopic(topic, TASKS_MAX);
+
+    // clean table
+    TableClearer.clearTables(bigQuery, dataset(), table);
+
+    // create the table with an incomplete schema
+    createTable(table, true);
+
+    // setup props for the sink connector
+    Map<String, String> props = configs(topic);
+
+    // use the JSON converter with schemas enabled
+    props.put(KEY_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
+    props.put(KEY_CONVERTER_CLASS_CONFIG + "." + JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, "false");
+    props.put(VALUE_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
+    props.put(VALUE_CONVERTER_CLASS_CONFIG + "." + JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, "false");
+    props.remove(BigQuerySinkConfig.KAFKA_KEY_FIELD_NAME_CONFIG);
+
+    // start a sink connector
+    connect.configureConnector(CONNECTOR_NAME, props);
+
+    // wait for tasks to spin up
+    waitForConnectorToStart(CONNECTOR_NAME, TASKS_MAX);
+
+    // Instantiate the converters we'll use to send records to the connector
+    initialiseJsonConverters();
+
+    //produce records
+    produceJsonRecords(topic);
+    connect.assertions().assertConnectorIsRunningAndTasksHaveFailed(
+            CONNECTOR_NAME,
+            TASKS_MAX,
+            "Tasks should have failed when writing record with fields not present"
+                    + "in target table." );
+  } @Test public void testRecordWithUnknownFieldWhenIgnoreEnabled() throws InterruptedException {
+    // create topic in Kafka
+    final String topic = suffixedTableOrTopic("storage-api-json-extra-field");
+    final String table = sanitizedTable(topic);
+
+    // create topic
+    connect.kafka().createTopic(topic, TASKS_MAX);
+
+    // clean table
+    TableClearer.clearTables(bigQuery, dataset(), table);
+
+    // create the table with the incomplete schema
+    createTable(table, true);
+
+    // setup props for the sink connector
+    Map<String, String> props = configs(topic);
+
+    // use the JSON converter with schemas enabled
+    props.put(KEY_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
+    props.put(KEY_CONVERTER_CLASS_CONFIG + "." + JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, "false");
+    props.put(VALUE_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
+    props.put(VALUE_CONVERTER_CLASS_CONFIG + "." + JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, "false");
+    props.remove(BigQuerySinkConfig.KAFKA_KEY_FIELD_NAME_CONFIG);
+
+    props.put(BigQuerySinkConfig.IGNORE_UNKNOWN_FIELDS_CONFIG, "true");
+
+    // start a sink connector
+    connect.configureConnector(CONNECTOR_NAME, props);
+
+    // wait for tasks to spin up
+    waitForConnectorToStart(CONNECTOR_NAME, TASKS_MAX);
+
+    // Instantiate the converters we'll use to send records to the connector
+    initialiseJsonConverters();
+
+    //produce records
+    produceJsonRecords(topic);
+
+    // wait for tasks to write to BigQuery and commit offsets for their records
+    waitForCommittedRecords(CONNECTOR_NAME, topic, NUM_RECORDS_PRODUCED, TASKS_MAX);
+
+    List<List<Object>> testRows;
+    try {
+      testRows = readAllRows(bigQuery, table, "f1");
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+
+    assertEquals(expectedRows(), testRows.stream().map(row -> row.get(0)).collect(Collectors.toSet()));
+  }
+
   @Test
   public void testTopicsRegex() throws InterruptedException {
     // create topic in Kafka


### PR DESCRIPTION
### Summary
This change introduces a new connector configuration option to control how unknown fields in Kafka records are handled when writing to BigQuery.

### Details
- Added a config flag ignoreUnknownFields (default: false).
- When enabled, fields not present in the BigQuery table schema are silently ignored instead of causing the record to be rejected.
- Applied to both ingestion modes: insertAll and StorageWriteApi