### PR TITLE
Enable connection pooling on Storage Write API Default Stream

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBase.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBase.java
@@ -313,7 +313,7 @@ public abstract class StorageWriteApiBase {
     return streamOrTableName -> {
       JsonStreamWriter.Builder builder = JsonStreamWriter.newBuilder(streamOrTableName, writeClient)
               .setRetrySettings(retrySettings);
-      applyJsonWriterConfig(builder);
+      updateJsonStreamWriterBuilder(builder);
       return builder.build();
     };
   }
@@ -321,7 +321,7 @@ public abstract class StorageWriteApiBase {
   /**
    * Override to provide additional configs to JsonStreamWriter
    */
-  protected void applyJsonWriterConfig(JsonStreamWriter.Builder builder) {
+  protected void updateJsonStreamWriterBuilder(JsonStreamWriter.Builder builder) {
     // no-op default
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiDefaultStream.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiDefaultStream.java
@@ -124,7 +124,7 @@ public class StorageWriteApiDefaultStream extends StorageWriteApiBase {
   }
 
   @Override
-  protected void applyJsonWriterConfig(JsonStreamWriter.Builder builder) {
+  protected void updateJsonStreamWriterBuilder(JsonStreamWriter.Builder builder) {
     builder.setEnableConnectionPool(true);
   }
 


### PR DESCRIPTION
### Overview
This PR enables multiplexing for the Storage Write API.  
Note: multiplexing is only available when using the **default stream**.

### What this does
- Allows to reuses existing connections to BigQuery instead of creating new ones. Improves efficiency and scalability when writing many table or running many tasks.
- Reduces connection overhead and helps avoid hitting BigQuery connection quotas.  