### PR TITLE
Set BigQuery Write API Trace ID for connector identification

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -87,6 +87,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
   public static final String TOPICS_REGEX_DEFAULT = "";
   public static final String ENABLE_BATCH_CONFIG = "enableBatchLoad";
   public static final String BATCH_LOAD_INTERVAL_SEC_CONFIG = "batchLoadIntervalSec";
+  public static final String CONNECTOR_NAME_CONFIG = "name";
   public static final String GCS_BUCKET_NAME_CONFIG = "gcsBucketName";
   public static final String GCS_FOLDER_NAME_CONFIG = "gcsFolderName";
   public static final String GCS_FOLDER_NAME_DEFAULT = "";
@@ -946,6 +947,11 @@ public class BigQuerySinkConfig extends AbstractConfig {
             CONVERT_DEBEZIUM_DECIMAL_CONFIG,
             ConfigDef.Type.BOOLEAN,
             false,
+            ConfigDef.Importance.LOW
+        ).defineInternal(
+            CONNECTOR_NAME_CONFIG,
+            ConfigDef.Type.STRING,
+            null,
             ConfigDef.Importance.LOW
         ).define(
             DECIMAL_HANDLING_MODE_CONFIG,

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -1144,6 +1144,10 @@ public class BigQuerySinkConfig extends AbstractConfig {
     return Optional.ofNullable(getString(KAFKA_DATA_FIELD_NAME_CONFIG));
   }
 
+  public Optional<String> getConnectorName() {
+    return Optional.ofNullable(getString(CONNECTOR_NAME_CONFIG));
+  }
+
   public boolean isUpsertDeleteEnabled() {
     return getBoolean(UPSERT_ENABLED_CONFIG) || getBoolean(DELETE_ENABLED_CONFIG);
   }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBase.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBase.java
@@ -46,7 +46,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.json.JSONArray;
@@ -62,7 +61,6 @@ public abstract class StorageWriteApiBase {
   private static final Logger logger = LoggerFactory.getLogger(StorageWriteApiBase.class);
   private static final double RETRY_DELAY_MULTIPLIER = 1.1;
   private static final int MAX_RETRY_DELAY_MINUTES = 1;
-  private static final String TRACE_ID_FORMAT = "AivenKafkaConnector:%s";
   private final String traceId;
   protected final JsonStreamWriterFactory jsonWriterFactory;
   protected final int retry;
@@ -89,7 +87,8 @@ public abstract class StorageWriteApiBase {
                                 boolean autoCreateTables,
                                 ErrantRecordHandler errantRecordHandler,
                                 SchemaManager schemaManager,
-                                boolean attemptSchemaUpdate) {
+                                boolean attemptSchemaUpdate,
+                                String traceId) {
     this.retry = retry;
     this.retryWait = retryWait;
     this.autoCreateTables = autoCreateTables;
@@ -104,7 +103,7 @@ public abstract class StorageWriteApiBase {
       throw new BigQueryStorageWriteApiConnectException("Failed to create Big Query Storage Write API write client", e);
     }
     this.jsonWriterFactory = getJsonWriterFactory();
-    this.traceId = String.format(TRACE_ID_FORMAT, UUID.randomUUID());
+    this.traceId = traceId;
     this.time = Time.SYSTEM;
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBase.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBase.java
@@ -46,6 +46,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.json.JSONArray;
@@ -61,6 +62,8 @@ public abstract class StorageWriteApiBase {
   private static final Logger logger = LoggerFactory.getLogger(StorageWriteApiBase.class);
   private static final double RETRY_DELAY_MULTIPLIER = 1.1;
   private static final int MAX_RETRY_DELAY_MINUTES = 1;
+  private static final String TRACE_ID_FORMAT = "AivenKafkaConnector:%s";
+  private final String traceId;
   protected final JsonStreamWriterFactory jsonWriterFactory;
   protected final int retry;
   protected final long retryWait;
@@ -101,6 +104,7 @@ public abstract class StorageWriteApiBase {
       throw new BigQueryStorageWriteApiConnectException("Failed to create Big Query Storage Write API write client", e);
     }
     this.jsonWriterFactory = getJsonWriterFactory();
+    this.traceId = String.format(TRACE_ID_FORMAT, UUID.randomUUID());
     this.time = Time.SYSTEM;
   }
 
@@ -312,6 +316,7 @@ public abstract class StorageWriteApiBase {
             .build();
     return streamOrTableName -> JsonStreamWriter.newBuilder(streamOrTableName, writeClient)
             .setRetrySettings(retrySettings)
+            .setTraceId(traceId)
             .build();
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBase.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBase.java
@@ -107,21 +107,22 @@ public abstract class StorageWriteApiBase {
       throw new BigQueryStorageWriteApiConnectException("Failed to create Big Query Storage Write API write client", e);
     }
     this.jsonWriterFactory = getJsonWriterFactory();
-    this.traceId = generateTraceId(config.getString(BigQuerySinkConfig.CONNECTOR_NAME_CONFIG));
+    this.traceId = generateTraceId(config.getConnectorName().orElse(null));
     this.time = Time.SYSTEM;
   }
 
   /**
-   * @deprecated This constructor does not support does not support configuration of additional write settings.
-   * Use {@link #StorageWriteApiBase(int retry, long retryWait, BigQueryWriteSettings writeSettings,
-   * boolean autoCreateTables, ErrantRecordHandler errantRecordHandler, SchemaManager schemaManager,
-   * boolean attemptSchemaUpdate, BigQuerySinkConfig config)} instead.
-   *
    * @param retry               How many retries to make in the event of a retriable error.
    * @param retryWait           How long to wait in between retries.
    * @param writeSettings       Write Settings for stream which carry authentication and other header information
    * @param autoCreateTables    boolean flag set if table should be created automatically
    * @param errantRecordHandler Used to handle errant records
+   *
+   * @deprecated This constructor does not support does not support configuration of additional write settings.
+   * Use {@link #StorageWriteApiBase(int retry, long retryWait, BigQueryWriteSettings writeSettings,
+   * boolean autoCreateTables, ErrantRecordHandler errantRecordHandler, SchemaManager schemaManager,
+   * boolean attemptSchemaUpdate, BigQuerySinkConfig config)} instead.
+   *
    */
   @Deprecated
   protected StorageWriteApiBase(int retry,

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBatchApplicationStream.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBatchApplicationStream.java
@@ -31,6 +31,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.Descriptors;
 import com.wepay.kafka.connect.bigquery.ErrantRecordHandler;
 import com.wepay.kafka.connect.bigquery.SchemaManager;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import com.wepay.kafka.connect.bigquery.exception.BigQueryStorageWriteApiConnectException;
 import java.io.IOException;
 import java.util.HashMap;
@@ -87,7 +88,7 @@ public class StorageWriteApiBatchApplicationStream extends StorageWriteApiBase {
       ErrantRecordHandler errantRecordHandler,
       SchemaManager schemaManager,
       boolean attemptSchemaUpdate,
-      String traceId) {
+      BigQuerySinkConfig config) {
     super(
         retry,
         retryWait,
@@ -96,8 +97,37 @@ public class StorageWriteApiBatchApplicationStream extends StorageWriteApiBase {
         errantRecordHandler,
         schemaManager,
         attemptSchemaUpdate,
-        traceId
+        config
     );
+    streams = new ConcurrentHashMap<>();
+    currentStreams = new ConcurrentHashMap<>();
+    tableLocks = new ConcurrentHashMap<>();
+    streamLocks = new ConcurrentHashMap<>();
+  }
+
+  /**
+   * @deprecated This constructor does not support configuration of additional write settings.
+   * Use {@link #StorageWriteApiBatchApplicationStream(int retry, long retryWait, BigQueryWriteSettings writeSettings,
+   * boolean autoCreateTables, ErrantRecordHandler errantRecordHandler, SchemaManager schemaManager,
+   * boolean attemptSchemaUpdate, BigQuerySinkConfig config)} instead.
+   */
+  @Deprecated
+  public StorageWriteApiBatchApplicationStream(
+          int retry,
+          long retryWait,
+          BigQueryWriteSettings writeSettings,
+          boolean autoCreateTables,
+          ErrantRecordHandler errantRecordHandler,
+          SchemaManager schemaManager,
+          boolean attemptSchemaUpdate) {
+    super(
+            retry,
+            retryWait,
+            writeSettings,
+            autoCreateTables,
+            errantRecordHandler,
+            schemaManager,
+            attemptSchemaUpdate);
     streams = new ConcurrentHashMap<>();
     currentStreams = new ConcurrentHashMap<>();
     tableLocks = new ConcurrentHashMap<>();

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBatchApplicationStream.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBatchApplicationStream.java
@@ -86,7 +86,8 @@ public class StorageWriteApiBatchApplicationStream extends StorageWriteApiBase {
       boolean autoCreateTables,
       ErrantRecordHandler errantRecordHandler,
       SchemaManager schemaManager,
-      boolean attemptSchemaUpdate) {
+      boolean attemptSchemaUpdate,
+      String traceId) {
     super(
         retry,
         retryWait,
@@ -94,7 +95,8 @@ public class StorageWriteApiBatchApplicationStream extends StorageWriteApiBase {
         autoCreateTables,
         errantRecordHandler,
         schemaManager,
-        attemptSchemaUpdate
+        attemptSchemaUpdate,
+        traceId
     );
     streams = new ConcurrentHashMap<>();
     currentStreams = new ConcurrentHashMap<>();

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiDefaultStream.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiDefaultStream.java
@@ -54,7 +54,8 @@ public class StorageWriteApiDefaultStream extends StorageWriteApiBase {
                                       boolean autoCreateTables,
                                       ErrantRecordHandler errantRecordHandler,
                                       SchemaManager schemaManager,
-                                      boolean attemptSchemaUpdate) {
+                                      boolean attemptSchemaUpdate,
+                                      String traceId) {
     super(
         retry,
         retryWait,
@@ -62,7 +63,8 @@ public class StorageWriteApiDefaultStream extends StorageWriteApiBase {
         autoCreateTables,
         errantRecordHandler,
         schemaManager,
-        attemptSchemaUpdate
+        attemptSchemaUpdate,
+        traceId
     );
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiDefaultStream.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiDefaultStream.java
@@ -32,6 +32,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.Descriptors;
 import com.wepay.kafka.connect.bigquery.ErrantRecordHandler;
 import com.wepay.kafka.connect.bigquery.SchemaManager;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import com.wepay.kafka.connect.bigquery.exception.BigQueryStorageWriteApiConnectException;
 import java.io.IOException;
 import java.util.List;
@@ -55,7 +56,7 @@ public class StorageWriteApiDefaultStream extends StorageWriteApiBase {
                                       ErrantRecordHandler errantRecordHandler,
                                       SchemaManager schemaManager,
                                       boolean attemptSchemaUpdate,
-                                      String traceId) {
+                                      BigQuerySinkConfig config) {
     super(
         retry,
         retryWait,
@@ -64,8 +65,32 @@ public class StorageWriteApiDefaultStream extends StorageWriteApiBase {
         errantRecordHandler,
         schemaManager,
         attemptSchemaUpdate,
-        traceId
+        config
     );
+  }
+
+  /**
+   * @deprecated This constructor does not support configuration of additional write settings.
+   * Use {@link #StorageWriteApiDefaultStream(int retry, long retryWait, BigQueryWriteSettings writeSettings,
+   * boolean autoCreateTables, ErrantRecordHandler errantRecordHandler, SchemaManager schemaManager,
+   * boolean attemptSchemaUpdate, BigQuerySinkConfig config)} instead.
+   */
+  @Deprecated
+  public StorageWriteApiDefaultStream(int retry,
+                                      long retryWait,
+                                      BigQueryWriteSettings writeSettings,
+                                      boolean autoCreateTables,
+                                      ErrantRecordHandler errantRecordHandler,
+                                      SchemaManager schemaManager,
+                                      boolean attemptSchemaUpdate) {
+    super(
+            retry,
+            retryWait,
+            writeSettings,
+            autoCreateTables,
+            errantRecordHandler,
+            schemaManager,
+            attemptSchemaUpdate);
   }
 
   @Override


### PR DESCRIPTION
This change sets traceId on the JsonStreamWriter. The AivenKafkaConnector prefix is recognized by BigQuery, allowing to identify traffic coming from the connector.