### PR TITLE
Allow opt-in to use original message metadata

### DIFF
--- a/docs/sink-connector-config-options.rst
+++ b/docs/sink-connector-config-options.rst
@@ -306,6 +306,13 @@ BigQuery Sink Connector Configuration Options
   * Default: false
   * Importance: low
 
+``preserveKafkaTopicPartitionOffset``
+  If True and Kafka v3.6 or higher is in use will use the original topic, partition, and offset values as specified before any message transformation occurs.
+
+  * Type: boolean
+  * Default: false
+  * Importance: low
+
 Common
 ^^^^^^
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GcpClientBuilder.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GcpClientBuilder.java
@@ -152,7 +152,7 @@ public abstract class GcpClientBuilder<ClientT> {
           logger.debug("Attempting to use application default credentials");
           return GoogleCredentials.getApplicationDefault();
         } catch (IOException e) {
-          throw new BigQueryConnectException("Failed to create Application Default Credentials", e);
+          throw new BigQueryConnectException("Failed to create Application Default Credentials: " + e.getMessage(), e);
         }
       default:
         throw new IllegalArgumentException("Unexpected value for KeySource enum: " + keySource);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -30,6 +30,7 @@ import com.wepay.kafka.connect.bigquery.GcpClientBuilder;
 import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
 import com.wepay.kafka.connect.bigquery.convert.BigQueryRecordConverter;
 import com.wepay.kafka.connect.bigquery.convert.BigQuerySchemaConverter;
+import com.wepay.kafka.connect.bigquery.convert.KafkaDataBuilder;
 import com.wepay.kafka.connect.bigquery.convert.RecordConverter;
 import com.wepay.kafka.connect.bigquery.convert.SchemaConverter;
 import com.wepay.kafka.connect.bigquery.retrieve.IdentitySchemaRetriever;
@@ -169,6 +170,14 @@ public class BigQuerySinkConfig extends AbstractConfig {
   public static final Boolean BIGQUERY_PARTITION_DECORATOR_DEFAULT = true;
   public static final String BIGQUERY_TIMESTAMP_PARTITION_FIELD_NAME_CONFIG = "timestampPartitionFieldName";
   public static final String BIGQUERY_CLUSTERING_FIELD_NAMES_CONFIG = "clusteringPartitionFieldNames";
+
+  public static final String USE_ORIGINAL_VALUES_CONFIG = "useOriginalValues";
+  public static final ConfigDef.Type USE_ORIGINAL_VALUES_TYPE = ConfigDef.Type.BOOLEAN;
+  public static final Boolean USE_ORIGINAL_VALUES_DEFAULT = false;
+  public static final ConfigDef.Importance USE_ORIGINAL_VALUES_IMPORTANCE = ConfigDef.Importance.LOW;
+  public static final String USE_ORIGINAL_VALUES_DOC = "If True and Kafka v3.6 or higher is in use will use the original " +
+          "topic, partition, and offset values as specified before any message transformation occurs.";
+
   public static final String CONVERT_DEBEZIUM_TIMESTAMP_TO_INTEGER_CONFIG = "convertDebeziumTimestampToInteger";
 
   public static final String DECIMAL_HANDLING_MODE_CONFIG = "decimalHandlingMode";
@@ -589,6 +598,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
   protected BigQuerySinkConfig(ConfigDef config, Map<String, String> properties) {
     super(config, properties);
     logDeprecationWarnings();
+    KafkaDataBuilder.setUseOriginalValues(getBoolean(USE_ORIGINAL_VALUES_CONFIG));
   }
 
   public BigQuerySinkConfig(Map<String, String> properties) {
@@ -960,7 +970,15 @@ public class BigQuerySinkConfig extends AbstractConfig {
             DEBEZIUM_VARIABLE_SCALE_DECIMAL_HANDLING_MODE_DEFAULT,
             DEBEZIUM_VARIABLE_SCALE_DECIMAL_HANDLING_MODE_VALIDATOR,
             DEBEZIUM_VARIABLE_SCALE_DECIMAL_HANDLING_MODE_IMPORTANCE,
-            DEBEZIUM_VARIABLE_SCALE_DECIMAL_HANDLING_MODE_DOC);
+            DEBEZIUM_VARIABLE_SCALE_DECIMAL_HANDLING_MODE_DOC
+        ).define(
+            USE_ORIGINAL_VALUES_CONFIG,
+            USE_ORIGINAL_VALUES_TYPE,
+            USE_ORIGINAL_VALUES_DEFAULT,
+            USE_ORIGINAL_VALUES_IMPORTANCE,
+            USE_ORIGINAL_VALUES_DOC
+        );
+
   }
 
   /**

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -175,8 +175,8 @@ public class BigQuerySinkConfig extends AbstractConfig {
   public static final ConfigDef.Type USE_ORIGINAL_VALUES_TYPE = ConfigDef.Type.BOOLEAN;
   public static final Boolean USE_ORIGINAL_VALUES_DEFAULT = false;
   public static final ConfigDef.Importance USE_ORIGINAL_VALUES_IMPORTANCE = ConfigDef.Importance.LOW;
-  public static final String USE_ORIGINAL_VALUES_DOC = "If True and Kafka v3.6 or higher is in use will use the original " +
-          "topic, partition, and offset values as specified before any message transformation occurs.";
+  public static final String USE_ORIGINAL_VALUES_DOC = "If True and Kafka v3.6 or higher is in use will use the original "
+          + "topic, partition, and offset values as specified before any message transformation occurs.";
 
   public static final String CONVERT_DEBEZIUM_TIMESTAMP_TO_INTEGER_CONFIG = "convertDebeziumTimestampToInteger";
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -171,11 +171,11 @@ public class BigQuerySinkConfig extends AbstractConfig {
   public static final String BIGQUERY_TIMESTAMP_PARTITION_FIELD_NAME_CONFIG = "timestampPartitionFieldName";
   public static final String BIGQUERY_CLUSTERING_FIELD_NAMES_CONFIG = "clusteringPartitionFieldNames";
 
-  public static final String USE_ORIGINAL_VALUES_CONFIG = "useOriginalValues";
-  public static final ConfigDef.Type USE_ORIGINAL_VALUES_TYPE = ConfigDef.Type.BOOLEAN;
-  public static final Boolean USE_ORIGINAL_VALUES_DEFAULT = false;
-  public static final ConfigDef.Importance USE_ORIGINAL_VALUES_IMPORTANCE = ConfigDef.Importance.LOW;
-  public static final String USE_ORIGINAL_VALUES_DOC = "If True and Kafka v3.6 or higher is in use will use the original "
+  public static final String PRESERVE_KAFKA_TOPIC_PARTITION_OFFSET__CONFIG = "preserveKafkaTopicPartitionOffset";
+  public static final ConfigDef.Type PRESERVE_KAFKA_TOPIC_PARTITION_OFFSET__TYPE = ConfigDef.Type.BOOLEAN;
+  public static final Boolean PRESERVE_KAFKA_TOPIC_PARTITION_OFFSET__DEFAULT = false;
+  public static final ConfigDef.Importance PRESERVE_KAFKA_TOPIC_PARTITION_OFFSET__IMPORTANCE = ConfigDef.Importance.LOW;
+  public static final String PRESERVE_KAFKA_TOPIC_PARTITION_OFFSET__DOC = "If True and Kafka v3.6 or higher is in use will use the original "
           + "topic, partition, and offset values as specified before any message transformation occurs.";
 
   public static final String CONVERT_DEBEZIUM_TIMESTAMP_TO_INTEGER_CONFIG = "convertDebeziumTimestampToInteger";
@@ -598,7 +598,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
   protected BigQuerySinkConfig(ConfigDef config, Map<String, String> properties) {
     super(config, properties);
     logDeprecationWarnings();
-    KafkaDataBuilder.setUseOriginalValues(getBoolean(USE_ORIGINAL_VALUES_CONFIG));
+    KafkaDataBuilder.setUseOriginalValues(getBoolean(PRESERVE_KAFKA_TOPIC_PARTITION_OFFSET__CONFIG));
   }
 
   public BigQuerySinkConfig(Map<String, String> properties) {
@@ -972,11 +972,11 @@ public class BigQuerySinkConfig extends AbstractConfig {
             DEBEZIUM_VARIABLE_SCALE_DECIMAL_HANDLING_MODE_IMPORTANCE,
             DEBEZIUM_VARIABLE_SCALE_DECIMAL_HANDLING_MODE_DOC
         ).define(
-            USE_ORIGINAL_VALUES_CONFIG,
-            USE_ORIGINAL_VALUES_TYPE,
-            USE_ORIGINAL_VALUES_DEFAULT,
-            USE_ORIGINAL_VALUES_IMPORTANCE,
-            USE_ORIGINAL_VALUES_DOC
+            PRESERVE_KAFKA_TOPIC_PARTITION_OFFSET__CONFIG,
+            PRESERVE_KAFKA_TOPIC_PARTITION_OFFSET__TYPE,
+            PRESERVE_KAFKA_TOPIC_PARTITION_OFFSET__DEFAULT,
+            PRESERVE_KAFKA_TOPIC_PARTITION_OFFSET__IMPORTANCE,
+            PRESERVE_KAFKA_TOPIC_PARTITION_OFFSET__DOC
         );
 
   }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataBuilder.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataBuilder.java
@@ -26,6 +26,7 @@ package com.wepay.kafka.connect.bigquery.convert;
 
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.LegacySQLTypeName;
+import com.google.common.annotations.VisibleForTesting;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.util.HashMap;
@@ -100,6 +101,7 @@ public class KafkaDataBuilder {
    *
    * @param post36Flag the state of the flag.
    */
+  @VisibleForTesting
   static void setPost3_6Flag(boolean post36Flag) {
     KAFKA_CONNECT_API_POST_3_6 = post36Flag;
   }
@@ -124,7 +126,7 @@ public class KafkaDataBuilder {
         .setMode(com.google.cloud.bigquery.Field.Mode.NULLABLE).build();
   }
 
-  private static String tryGetOriginalTopic(SinkRecord kafkaConnectRecord) {
+  private static String maybeGetOriginalTopic(SinkRecord kafkaConnectRecord) {
     if (KAFKA_CONNECT_API_POST_3_6 && USE_ORIGINAL_VALUES) {
       return kafkaConnectRecord.originalTopic();
     } else {
@@ -132,7 +134,7 @@ public class KafkaDataBuilder {
     }
   }
 
-  private static Integer tryGetOriginalKafkaPartition(SinkRecord kafkaConnectRecord) {
+  private static Integer maybeGetOriginalKafkaPartition(SinkRecord kafkaConnectRecord) {
     if (KAFKA_CONNECT_API_POST_3_6 && USE_ORIGINAL_VALUES) {
       return kafkaConnectRecord.originalKafkaPartition();
     } else {
@@ -140,7 +142,7 @@ public class KafkaDataBuilder {
     }
   }
 
-  private static long tryGetOriginalKafkaOffset(SinkRecord kafkaConnectRecord) {
+  private static long maybeGetOriginalKafkaOffset(SinkRecord kafkaConnectRecord) {
     if (KAFKA_CONNECT_API_POST_3_6 && USE_ORIGINAL_VALUES) {
       return kafkaConnectRecord.originalKafkaOffset();
     } else {
@@ -156,9 +158,9 @@ public class KafkaDataBuilder {
    */
   public static Map<String, Object> buildKafkaDataRecord(SinkRecord kafkaConnectRecord) {
     HashMap<String, Object> kafkaData = new HashMap<>();
-    kafkaData.put(KAFKA_DATA_TOPIC_FIELD_NAME, tryGetOriginalTopic(kafkaConnectRecord));
-    kafkaData.put(KAFKA_DATA_PARTITION_FIELD_NAME, tryGetOriginalKafkaPartition(kafkaConnectRecord));
-    kafkaData.put(KAFKA_DATA_OFFSET_FIELD_NAME, tryGetOriginalKafkaOffset(kafkaConnectRecord));
+    kafkaData.put(KAFKA_DATA_TOPIC_FIELD_NAME, maybeGetOriginalTopic(kafkaConnectRecord));
+    kafkaData.put(KAFKA_DATA_PARTITION_FIELD_NAME, maybeGetOriginalKafkaPartition(kafkaConnectRecord));
+    kafkaData.put(KAFKA_DATA_OFFSET_FIELD_NAME, maybeGetOriginalKafkaOffset(kafkaConnectRecord));
     kafkaData.put(KAFKA_DATA_INSERT_TIME_FIELD_NAME, System.currentTimeMillis() / 1000.0);
     return kafkaData;
   }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataBuilder.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataBuilder.java
@@ -46,9 +46,17 @@ public class KafkaDataBuilder {
   public static final String KAFKA_DATA_OFFSET_FIELD_NAME = "offset";
   public static final String KAFKA_DATA_INSERT_TIME_FIELD_NAME = "insertTime";
 
-  // This is a marker variable for methods necessary to keep original sink record metadata.
-  // These methods in SinkRecord class are available only since Kafka Connect API version 3.6.
-  private static final boolean KAFKA_CONNECT_API_POST_3_6;
+  /**
+   * This is a marker variable for methods necessary to keep original sink record metadata.
+   * These methods in SinkRecord class are available only since Kafka Connect API version 3.6.
+   */
+  private static boolean KAFKA_CONNECT_API_POST_3_6;
+
+  /**
+   * This variable determines if the original variable or the mutated variable should be used
+   * when running in a post 3.6 Kafka.
+   */
+  private static boolean USE_ORIGINAL_VALUES = false;
 
   static {
     boolean kafkaConnectApiPost36;
@@ -79,6 +87,22 @@ public class KafkaDataBuilder {
   }
 
   /**
+   * Sets the use original values flag.
+   * @param useOriginalValues the state of the flag.
+   */
+  public static void setUseOriginalValues(boolean useOriginalValues) {
+    USE_ORIGINAL_VALUES = useOriginalValues;
+  }
+
+  /**
+   * Sets the Kafka Post 3.6 flag.  Used in testing.
+   * @param post3_6Flag the state of the flag.
+   */
+  static void setPost3_6Flag(boolean post3_6Flag) {
+    KAFKA_CONNECT_API_POST_3_6 = post3_6Flag;
+  }
+
+  /**
    * Construct schema for Kafka Data Field
    *
    * @param kafkaDataFieldName The configured name of Kafka Data Field
@@ -99,7 +123,7 @@ public class KafkaDataBuilder {
   }
 
   private static String tryGetOriginalTopic(SinkRecord kafkaConnectRecord) {
-    if (KAFKA_CONNECT_API_POST_3_6) {
+    if (KAFKA_CONNECT_API_POST_3_6 && USE_ORIGINAL_VALUES) {
       return kafkaConnectRecord.originalTopic();
     } else {
       return kafkaConnectRecord.topic();
@@ -107,7 +131,7 @@ public class KafkaDataBuilder {
   }
 
   private static Integer tryGetOriginalKafkaPartition(SinkRecord kafkaConnectRecord) {
-    if (KAFKA_CONNECT_API_POST_3_6) {
+    if (KAFKA_CONNECT_API_POST_3_6 && USE_ORIGINAL_VALUES) {
       return kafkaConnectRecord.originalKafkaPartition();
     } else {
       return kafkaConnectRecord.kafkaPartition();
@@ -115,7 +139,7 @@ public class KafkaDataBuilder {
   }
 
   private static long tryGetOriginalKafkaOffset(SinkRecord kafkaConnectRecord) {
-    if (KAFKA_CONNECT_API_POST_3_6) {
+    if (KAFKA_CONNECT_API_POST_3_6 && USE_ORIGINAL_VALUES) {
       return kafkaConnectRecord.originalKafkaOffset();
     } else {
       return kafkaConnectRecord.kafkaOffset();

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataBuilder.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataBuilder.java
@@ -88,6 +88,7 @@ public class KafkaDataBuilder {
 
   /**
    * Sets the use original values flag.
+   *
    * @param useOriginalValues the state of the flag.
    */
   public static void setUseOriginalValues(boolean useOriginalValues) {
@@ -96,10 +97,11 @@ public class KafkaDataBuilder {
 
   /**
    * Sets the Kafka Post 3.6 flag.  Used in testing.
-   * @param post3_6Flag the state of the flag.
+   *
+   * @param post36Flag the state of the flag.
    */
-  static void setPost3_6Flag(boolean post3_6Flag) {
-    KAFKA_CONNECT_API_POST_3_6 = post3_6Flag;
+  static void setPost3_6Flag(boolean post36Flag) {
+    KAFKA_CONNECT_API_POST_3_6 = post36Flag;
   }
 
   /**

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataConverterTest.java
@@ -149,14 +149,6 @@ public class KafkaDataConverterTest {
     return arguments;
   }
 
-  private static SinkRecord createPre6_5SinkRecord(String topic, int partition, long offset) {
-    return new SinkRecord(topic, partition, null, null, null, null, offset);
-  }
-
-  private static SinkRecord createPost6_5SinkRecord(String topic, int partition, long offset) {
-    return new SinkRecord(topic, partition, null, null, null, null, offset, System.currentTimeMillis(), TimestampType.CREATE_TIME, null, "origTopic", 11, 55L);
-  }
-
   @Test
   public void testBuildKafkaDataRecordStorageWriteApi() {
     SinkRecord record = new SinkRecord(kafkaDataTopicValue, kafkaDataPartitionValue, null, null, null, null, kafkaDataOffsetValue);

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataConverterTest.java
@@ -124,28 +124,28 @@ public class KafkaDataConverterTest {
     SinkRecord sinkRecord;
     Map<String, Object> expected;
 
-    // pre 6.5 record format
+    // pre 3.6 record format
     sinkRecord = new SinkRecord("topic", 1, null, null, null, null, 2L);
     expected = new HashMap<>();
     expected.put(kafkaDataTopicName, "topic");
     expected.put(kafkaDataPartitionName, 1);
     expected.put(kafkaDataOffsetName, 2L);
-    arguments.add(Arguments.of("pre 6.5",true, false, sinkRecord, expected));
-    arguments.add(Arguments.of("pre 6.5",true, true, sinkRecord, expected));
-    arguments.add(Arguments.of("pre 6.5",false, false, sinkRecord, expected));
-    arguments.add(Arguments.of("pre 6.5",false, true, sinkRecord, expected));
+    arguments.add(Arguments.of("pre 3.6",true, false, sinkRecord, expected));
+    arguments.add(Arguments.of("pre 3.6",true, true, sinkRecord, expected));
+    arguments.add(Arguments.of("pre 3.6",false, false, sinkRecord, expected));
+    arguments.add(Arguments.of("pre 3.6",false, true, sinkRecord, expected));
 
-    // post 6.5 record format
+    // post 3.6 record format
     sinkRecord = new SinkRecord( "topic", 1, null, null, null, null, 2L,
             System.currentTimeMillis(), TimestampType.CREATE_TIME, null, "origTopic", 11, 22L);
-    arguments.add(Arguments.of("post 6.5", true, false, sinkRecord, expected));
-    arguments.add(Arguments.of("post 6.5", false, false, sinkRecord, expected));
-    arguments.add(Arguments.of("post 6.5", false, true, sinkRecord, expected));
+    arguments.add(Arguments.of("post 3.6", true, false, sinkRecord, expected));
+    arguments.add(Arguments.of("post 3.6", false, false, sinkRecord, expected));
+    arguments.add(Arguments.of("post 3.6", false, true, sinkRecord, expected));
     expected = new HashMap<>();
     expected.put(kafkaDataTopicName, "origTopic");
     expected.put(kafkaDataPartitionName, 11);
     expected.put(kafkaDataOffsetName, 22L);
-    arguments.add(Arguments.of("post 6.5", true, true, sinkRecord, expected));
+    arguments.add(Arguments.of("post 3.6", true, true, sinkRecord, expected));
     return arguments;
   }
 


### PR DESCRIPTION
Related to #72 

Release 2.8.0 changed the behaviour to preserve the original topic, partition and offset of a message even if it were modified by a transformation, which causes an issue running in `enableBatchMode`, under a Kafka version 3.6 or greater.

This change introduces a flag to restore the default behaviour of 2.7.0 of using any modified topic, partition or offset, unless the `preserveKafkaTopicPartitionOffset` flag is set to **true** (default **false**). 

