### PR TITLE
Fix intermittent test failures for StorageWriteApiBigQuerySinkConnectorIT

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiDefaultStream.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiDefaultStream.java
@@ -80,14 +80,16 @@ public class StorageWriteApiDefaultStream extends StorageWriteApiBase {
    * @param tableName The table name for which stream has to be removed.
    */
   private void closeAndDelete(String tableName) {
-    logger.debug("Closing stream on table {}", tableName);
-    if (tableToStream.containsKey(tableName)) {
-      synchronized (tableToStream) {
-        tableToStream.get(tableName).close();
-        tableToStream.remove(tableName);
+    tableToStream.computeIfPresent(tableName, (t, writer) -> {
+      logger.debug("Closing stream on table {}", t);
+      try {
+        writer.close();
+        logger.debug("Closed stream on table {}", t);
+      } catch (Throwable e) {
+        logger.warn("Error closing stream for table {}", t, e);
       }
-      logger.debug("Closed stream on table {}", tableName);
-    }
+      return null;
+    });
   }
 
   /**


### PR DESCRIPTION
### Overview
Integration tests for the Storage Write API default stream fail intermittently due StorageWriteApiDefaultStream.closeAndDelete allowing multiple threads to attempt closing the same JsonStreamWriter:

`[2025-08-27 06:32:49,930] DEBUG [bigquery-storage-api-sink-connector|task-2] A write thread has failed with an unrecoverable error (com.wepay.kafka.connect.bigquery.write.batch.KcbqThreadPoolExecutor:77)
java.lang.NullPointerException: Cannot invoke "com.google.cloud.bigquery.storage.v1.JsonStreamWriter.close()" because the return value of "java.util.concurrent.ConcurrentMap.get(Object)" is null
	at com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiDefaultStream.closeAndDelete(StorageWriteApiDefaultStream.java:86)
	at com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiDefaultStream$DefaultStreamWriter.refresh(StorageWriteApiDefaultStream.java:163)
	at com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiBase.writeBatch(StorageWriteApiBase.java:230)
	at com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiBase.initializeAndWriteRecords(StorageWriteApiBase.java:146)
	at com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiWriter.run(StorageWriteApiWriter.java:77)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at com.wepay.kafka.connect.bigquery.BigQuerySinkTask$MdcContextThreadFactory.lambda$newThread$0(BigQuerySinkTask.java:793)
	at java.base/java.lang.Thread.run(Thread.java:842)`

### Fix
Made closing and removal in StorageWriteApiDefaultStream.closeAndDelete atomic