### PR TITLE
GcsToBqWriter: fix retry logic

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/GcsToBqWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/GcsToBqWriter.java
@@ -24,8 +24,9 @@
 package com.wepay.kafka.connect.bigquery.write.row;
 
 import com.google.cloud.bigquery.BigQuery;
-import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.BaseServiceException;
 import com.google.cloud.bigquery.InsertAllRequest.RowToInsert;
+import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
@@ -38,13 +39,14 @@ import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 import com.wepay.kafka.connect.bigquery.exception.GcsConnectException;
 import com.wepay.kafka.connect.bigquery.utils.Time;
 import java.io.UnsupportedEncodingException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.SortedMap;
+import java.util.function.Supplier;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
@@ -57,6 +59,7 @@ public class GcsToBqWriter {
   public static final String GCS_METADATA_TABLE_KEY = "sinkTable";
   private static final Logger logger = LoggerFactory.getLogger(GcsToBqWriter.class);
   private static final int WAIT_MAX_JITTER = 1000;
+  private static final long MAX_BACKOFF_MS = 10_000L;
   private static final Random random = new Random();
   private static Gson gson = new Gson();
   private final Storage storage;
@@ -70,11 +73,15 @@ public class GcsToBqWriter {
   /**
    * Initializes a batch GCS writer with a full list of rows to write.
    *
-   * @param storage     GCS Storage
-   * @param bigQuery    {@link BigQuery} Object used to perform upload
-   * @param retries     Maximum number of retries
-   * @param retryWaitMs Minimum number of milliseconds to wait before retrying
-   * @param time        used to wait during backoff periods
+   * @param storage GCS Storage
+   * @param bigQuery {@link BigQuery} Object used to perform upload
+   * @param retries Maximum number of retry attempts after the initial call.
+   *                <p>Note that this is an upper bound: the actual number of retries may be lower if the
+   *                computed exponential backoff delays (based on {@code retryWaitMs}) plus jitter cause the
+   *                total timeout budget to be exceeded.
+   * @param retryWaitMs Base wait time in milliseconds before the first retry. Each subsequent retry
+   *                    doubles this delay, up to a maximum per-sleep cap of {@value #MAX_BACKOFF_MS} milliseconds.
+   * @param time used to wait during backoff periods
    */
   public GcsToBqWriter(Storage storage,
                        BigQuery bigQuery,
@@ -126,31 +133,39 @@ public class GcsToBqWriter {
     BlobInfo blobInfo =
         BlobInfo.newBuilder(blobId).setContentType("text/json").setMetadata(metadata).build();
 
+    // Compute a time budget that still guarantees at least one attempt even if retryWaitMs == 0.
+    Duration timeout = Duration.ofMillis(Math.max(0L, retryWaitMs * Math.max(1, retries)));
+    if (retries == 0) {
+      timeout = Duration.ofMillis(retryWaitMs);
+    }
+
     // Check if the table specified exists
     // This error shouldn't be thrown. All tables should be created by the connector at startup
-    int lookupAttempts = 0;
-    boolean lookupSuccess = bigQuery.getTable(tableId) != null;
-    BigQueryException lookupException = null;
+    Table table = executeWithRetry(() -> bigQuery.getTable(tableId), timeout);
+    boolean lookupSuccess = table != null;
 
     if (autoCreateTables && !lookupSuccess) {
       logger.info("Table {} was not found. Creating the table automatically.", tableId);
-      schemaManager.createTable(tableId, new ArrayList<>(rows.keySet()));
-      while (!lookupSuccess && lookupAttempts <= retries) {
-        logger.warn("Exceptions occurred for table {}, attempting retry. Attempt {}/{}", tableId, lookupAttempts, retries);
-        waitRandomTime();
-        lookupSuccess = bigQuery.getTable(tableId) != null;
-        lookupAttempts++;
+      Boolean created =
+          executeWithRetry(
+              () -> schemaManager.createTable(tableId, new ArrayList<>(rows.keySet())), timeout);
+      if (created == null || !created) {
+        throw new BigQueryConnectException("Failed to create table " + tableId);
       }
+      table = executeWithRetry(() -> bigQuery.getTable(tableId), timeout);
+      lookupSuccess = table != null;
     }
+
     if (!lookupSuccess) {
-      throw new BigQueryConnectException("Failed to lookup table " + tableId, lookupException);
+      throw new BigQueryConnectException("Failed to lookup table " + tableId);
     }
 
     int attemptCount = 0;
     boolean success = false;
     while (!success && (attemptCount <= retries)) {
       if (attemptCount > 0) {
-        waitRandomTime();
+        // use capped exponential backoff w/ jitter for GCS upload retries
+        waitRandomTime(attemptCount - 1);
       }
       // Perform GCS Upload
       try {
@@ -206,12 +221,123 @@ public class GcsToBqWriter {
   }
 
   /**
-   * Wait at least {@link #retryWaitMs}, with up to an additional 1 second of random jitter.
+   * Execute the supplied function with retries and exponential backoff within a time budget. Ensure
+   * at least one attempt even if timeout == 0; clamp sleeps to remaining time; use attempt-indexed
+   * backoff capped by MAX_BACKOFF_MS; and respect the configured `retries`.
    *
-   * @throws InterruptedException if interrupted.
+   * @param func the operation to execute
+   * @param timeout maximum time to keep retrying (sleep is clamped by remaining time)
+   * @return result of the function, or {@code null} if timeout expires before a successful call
    */
-  private void waitRandomTime() throws InterruptedException {
-    time.sleep(retryWaitMs + random.nextInt(WAIT_MAX_JITTER));
+  private <T> T executeWithRetry(Supplier<T> func, Duration timeout) throws InterruptedException {
+    final long start = time.milliseconds(); // explicit clock to compute remaining
+    final long budget = timeout == null ? 0L : Math.max(0L, timeout.toMillis());
+
+    int attempt = 0; // number of retries already performed (sleep count)
+    // Always make the first attempt, regardless of budget.
+    while (true) {
+      try {
+        return func.get();
+      } catch (BaseServiceException e) {
+        if (!e.isRetryable()) {
+          logger.error("Non-retryable exception on attempt {}", attempt + 1, e);
+          throw e;
+        }
+        if (attempt >= retries) {
+          // Out of configured retries
+          logger.error("Operation failed after {} attempts (no retries left).", attempt + 1);
+          throw e;
+        }
+
+        // Compute next backoff = min(MAX_BACKOFF_MS, retryWaitMs * 2^attempt)
+        long base = Math.max(0L, retryWaitMs);
+        long delay = computeBackoff(base, attempt, MAX_BACKOFF_MS);
+
+        // Clamp to remaining time if a budget is provided
+        if (budget > 0) {
+          long elapsed = time.milliseconds() - start;
+          long remaining = budget - elapsed;
+          if (remaining <= 0) {
+            logger.error(
+                "Timeout expired after {} attempts within {} ms budget.", attempt + 1, budget);
+            return null;
+          }
+          delay = Math.min(delay, Math.max(0L, remaining));
+        }
+
+        // Add up to 1s jitter
+        delay += (delay > 0 ? random.nextInt(WAIT_MAX_JITTER) : 0);
+
+        logger.warn(
+            "Retryable exception on attempt {}: {}. Backing off {} ms",
+            attempt + 1,
+            e.getMessage(),
+            delay);
+
+        if (delay > 0) {
+          time.sleep(delay);
+        }
+        attempt++;
+      }
+    }
   }
 
+  /**
+   * Computes the exponential backoff delay for a given retry attempt. The delay is calculated as:
+   *
+   * <pre>
+   *   delay = baseDelayMs * (2 ^ attemptIndex)
+   * </pre>
+   *
+   * but is clamped to an upper bound {@code capMs}. This ensures that the backoff grows
+   * exponentially with each retry, but never exceeds the configured cap.
+   *
+   * <p>Examples (baseDelayMs = 100, capMs = 10_000):
+   *
+   * <ul>
+   *   <li>attemptIndex = 0 → 100 ms
+   *   <li>attemptIndex = 1 → 200 ms
+   *   <li>attemptIndex = 2 → 400 ms
+   *   <li>attemptIndex = 6 → 6,400 ms
+   *   <li>attemptIndex = 7 → 10,000 ms (clamped)
+   * </ul>
+   *
+   * @param baseDelayMs the initial delay in milliseconds (typically {@code retryWaitMs}); values ≤
+   *     0 result in a delay of 0
+   * @param attemptIndex zero-based retry attempt index (0 for the first retry after the initial
+   *     attempt)
+   * @param capMs maximum delay in milliseconds for any single backoff sleep
+   * @return the computed delay in milliseconds, guaranteed to be between 0 and {@code capMs}
+   */
+  private static long computeBackoff(long baseDelayMs, int attemptIndex, long capMs) {
+    if (baseDelayMs <= 0L) {
+      return 0L;
+    }
+    long backoff = baseDelayMs;
+    for (int i = 0; i < attemptIndex; i++) {
+      if (backoff >= capMs) {
+        return capMs;
+      }
+      long next = backoff << 1;
+      if (next < 0) {
+        return capMs; // overflow guard
+      }
+      backoff = next;
+    }
+    return Math.min(backoff, capMs);
+  }
+
+  /**
+   * Wait with exponential backoff based on attempt index, capped by {@link #MAX_BACKOFF_MS}, plus
+   * up to 1s jitter.
+   *
+   * @param attemptZeroBased zero-based attempt index (0 => base delay, 1 => doubled, …)
+   * @throws InterruptedException if interrupted.
+   */
+  private void waitRandomTime(int attemptZeroBased) throws InterruptedException {
+    long base = Math.max(0L, retryWaitMs);
+    long delay = computeBackoff(base, attemptZeroBased, MAX_BACKOFF_MS);
+    delay += (delay > 0 ? random.nextInt(WAIT_MAX_JITTER) : 0);
+    time.sleep(delay);
+  }
 }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/GcsToBqWriterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/GcsToBqWriterTest.java
@@ -24,15 +24,24 @@
 package com.wepay.kafka.connect.bigquery.write.row;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.atMost;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.InsertAllRequest.RowToInsert;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
@@ -46,8 +55,12 @@ import com.wepay.kafka.connect.bigquery.utils.MockTime;
 import com.wepay.kafka.connect.bigquery.utils.Time;
 import com.wepay.kafka.connect.bigquery.write.storage.StorageApiBatchModeHandler;
 import com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiDefaultStream;
+import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.SortedMap;
 import java.util.HashMap;
+import java.util.TreeMap;
 import java.util.Map;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -186,6 +199,121 @@ public class GcsToBqWriterTest {
     verify(storage, times(4)).create((BlobInfo) anyObject(), (byte[]) anyObject());
   }
 
+  @Test
+  public void happyPathNoRetry() throws Exception {
+    // retries/wait are irrelevant when everything succeeds first try
+    int retries = 3;
+    long retryWaitMs = 100;
+    boolean autoCreate = false;
+
+    // BigQuery: table lookup succeeds immediately
+    BigQuery bigQuery = mock(BigQuery.class);
+    when(bigQuery.getTable(any(TableId.class))).thenReturn(mock(Table.class));
+
+    // GCS: upload succeeds on first call
+    Storage storage = mock(Storage.class);
+    when(storage.create(any(BlobInfo.class), any(byte[].class))).thenReturn(null);
+
+    SchemaManager schemaManager = mock(SchemaManager.class);
+    Time mockTime = new MockTime();
+
+    GcsToBqWriter writer =
+        new GcsToBqWriter(
+            storage, bigQuery, schemaManager, retries, retryWaitMs, autoCreate, mockTime);
+
+    long t0 = mockTime.milliseconds();
+    writer.writeRows(oneRow(), TableId.of("ds", "tbl"), "bucket", "blob");
+    long elapsed = mockTime.milliseconds() - t0;
+
+    // One lookup, one upload; no retries, no sleeps → elapsed should be 0
+    verify(bigQuery, times(1)).getTable(any(TableId.class));
+    verify(storage, times(1)).create(any(BlobInfo.class), any(byte[].class));
+    verifyNoMoreInteractions(storage, bigQuery);
+    assertEquals(0L, elapsed, "no backoff should occur on the happy path");
+  }
+
+  @Test
+  public void backoffIsCapped() throws Exception {
+    int retries = 4; // allow 3 sleeps then success
+    long retryWaitMs = 5000; // 5s → sequence 5s, 10s, 10s (capped)
+    boolean autoCreate = false;
+
+    Storage storage = mock(Storage.class);
+    when(storage.create(any(BlobInfo.class), any(byte[].class)))
+        .thenThrow(new StorageException(500, "t1"))
+        .thenThrow(new StorageException(500, "t2"))
+        .thenThrow(new StorageException(500, "t3"))
+        .thenReturn(null);
+
+    BigQuery bigQuery = mock(BigQuery.class);
+    when(bigQuery.getTable(any(TableId.class))).thenReturn(mock(Table.class));
+
+    SchemaManager schemaManager = mock(SchemaManager.class);
+    Time mockTime = new MockTime();
+
+    GcsToBqWriter writer =
+        new GcsToBqWriter(
+            storage, bigQuery, schemaManager, retries, retryWaitMs, autoCreate, mockTime);
+
+    long t0 = mockTime.milliseconds();
+    writer.writeRows(oneRow(), TableId.of("ds", "tbl"), "bucket", "blob");
+    long elapsed = mockTime.milliseconds() - t0;
+
+    long minExpected = 5000 + 10000 + 10000; // 25s
+    long maxExpected = minExpected + 3 * 1000; // + jitter bound
+    verify(storage, times(4)).create(any(BlobInfo.class), any(byte[].class));
+    assertTrue(elapsed >= minExpected, "elapsed too small: " + elapsed);
+    assertTrue(elapsed <= maxExpected, "elapsed too large: " + elapsed);
+  }
+
+  @Test
+  public void budgetCutsBeforeAllRetries() throws Exception {
+    /*
+     * In GcsToBqWriter.writeRows we compute:
+     *   Duration timeout = Duration.ofMillis(Math.max(0L, retryWaitMs * Math.max(1, retries)));
+     *
+     * With retryWaitMs=100 and retries=100 → timeout ≈ 10_000 ms (our “budget”).
+     * Exponential backoff sleeps (pre-cap) are ~100, 200, 400, 800, 1600, 3200, 6400...
+     * The cumulative base waits cross ~10s around the 6th/7th sleep, so the budget should
+     * cut off the loop *before* we consume all configured retries.
+     */
+
+    final int retries = 100; // very high; we want budget to be the stopping condition
+    final long retryWaitMs = 100L; // base delay ⇒ budget = 100 * 100 = 10_000 ms
+    final boolean autoCreate = false;
+
+    // BigQuery always throws a retryable error so executeWithRetry keeps retrying until budget
+    // ends.
+    BigQuery bigQuery = mock(BigQuery.class);
+    when(bigQuery.getTable(any(TableId.class)))
+        .thenThrow(new BigQueryException(500, "retryable backend error"));
+
+    // Storage is never reached because we fail during table lookup.
+    Storage storage = mock(Storage.class);
+
+    SchemaManager schemaManager = mock(SchemaManager.class);
+    Time mockTime = new MockTime(); // virtual clock; sleep() advances time but doesn’t block
+
+    GcsToBqWriter writer =
+        new GcsToBqWriter(
+            storage, bigQuery, schemaManager, retries, retryWaitMs, autoCreate, mockTime);
+
+    // Because lookup never succeeds and the time budget expires, writeRows should fail
+    // with a BigQueryConnectException (null table interpreted as lookup failure).
+    assertThrows(
+        BigQueryConnectException.class,
+        () -> writer.writeRows(oneRow(), TableId.of("ds", "tbl"), "bucket", "blob"));
+
+    // We expect multiple getTable() attempts until budget expires.
+    // Because jitter can vary up to 1s per sleep and sleeps are clamped by remaining budget,
+    // the exact attempt count can vary a little. A stable range is ~6..10 total calls.
+    verify(bigQuery, atLeast(6)).getTable(any(TableId.class));
+    verify(bigQuery, atMost(10)).getTable(any(TableId.class));
+
+    // No upload should be attempted since table resolution never succeeded.
+    verify(storage, never()).create(any(BlobInfo.class), any(byte[].class));
+  }
+
   private void expectTable(BigQuery mockBigQuery) {
     Table mockTable = mock(Table.class);
     when(mockBigQuery.getTable(anyObject())).thenReturn(mockTable);
@@ -247,4 +375,45 @@ public class GcsToBqWriterTest {
         null);
   }
 
+  /**
+   * Utility method that builds a minimal {@link SortedMap} containing exactly one {@link
+   * SinkRecord} → {@link RowToInsert} mapping.
+   *
+   * <p>The map is ordered by Kafka offset via a {@link Comparator}, which is required because
+   * {@link SinkRecord} does not implement {@link Comparable}. In this case the comparator is based
+   * on {@link SinkRecord#kafkaOffset()}.
+   *
+   * <p>The single {@code SinkRecord} created here has:
+   *
+   * <ul>
+   *   <li>topic {@code "t"}
+   *   <li>partition {@code 0}
+   *   <li>offset {@code 1}
+   *   <li>a trivial schema with one field {@code "f"} of type {@code STRING}
+   *   <li>a corresponding {@link Struct} value with {@code f = "v"}
+   * </ul>
+   *
+   * The {@link RowToInsert} mirrors this content in a simple map ({@code {"f":"v"}}).
+   *
+   * <p>This helper is used in unit tests to supply a valid row set to {@link
+   * GcsToBqWriter#writeRows}, without requiring a running Kafka cluster or real BigQuery/GCS
+   * resources.
+   *
+   * @return a {@link SortedMap} with one synthetic record-to-row mapping
+   */
+  private SortedMap<SinkRecord, RowToInsert> oneRow() {
+    // sorted by offset so TreeMap has a comparator
+    Comparator<SinkRecord> byOffset = Comparator.comparingLong(SinkRecord::kafkaOffset);
+    SortedMap<SinkRecord, RowToInsert> rows = new TreeMap<>(byOffset);
+
+    Schema schema = SchemaBuilder.struct().field("f", Schema.STRING_SCHEMA).build();
+    Struct value = new Struct(schema).put("f", "v");
+
+    SinkRecord rec = new SinkRecord("t", 0, null, null, schema, value, 1L, null, null);
+    Map<String, Object> content = new HashMap<>();
+    content.put("f", "v");
+
+    rows.put(rec, RowToInsert.of(content));
+    return rows;
+  }
 }


### PR DESCRIPTION
- Ensure first attempt always executes even with retries=0 or retryWaitMs=0
- Implement explicit exponential backoff (baseDelay * 2^n) with 10s per-sleep cap
- Clamp sleeps to remaining time budget; retries stop when either budget or count is exhausted
- Add unit tests in GcsToBqWriterTest for:
  * happy path (success on first attempt, no sleep)
  * capped backoff sequence (5s → 10s → 10s)
  * budget cutoff (~6–7 attempts despite retries=100)

```
...
[2025-09-09 16:34:29,083] WARN Exceptions occurred for table test_topic, attempting retry (com.wepay.kafka.connect.bigquery.write.row.GcsToBqWriter:175)
[2025-09-09 16:34:29,083] INFO Batch loaded 1 rows (com.wepay.kafka.connect.bigquery.write.row.GcsToBqWriter:181)
[2025-09-09 16:34:29,086] WARN Retryable exception on attempt 1: retryable backend error. Backing off 909 ms (com.wepay.kafka.connect.bigquery.write.row.GcsToBqWriter:271)
[2025-09-09 16:34:29,087] WARN Retryable exception on attempt 2: retryable backend error. Backing off 1098 ms (com.wepay.kafka.connect.bigquery.write.row.GcsToBqWriter:271)
[2025-09-09 16:34:29,087] WARN Retryable exception on attempt 3: retryable backend error. Backing off 746 ms (com.wepay.kafka.connect.bigquery.write.row.GcsToBqWriter:271)
[2025-09-09 16:34:29,087] WARN Retryable exception on attempt 4: retryable backend error. Backing off 914 ms (com.wepay.kafka.connect.bigquery.write.row.GcsToBqWriter:271)
[2025-09-09 16:34:29,087] WARN Retryable exception on attempt 5: retryable backend error. Backing off 1928 ms (com.wepay.kafka.connect.bigquery.write.row.GcsToBqWriter:271)
[2025-09-09 16:34:29,087] WARN Retryable exception on attempt 6: retryable backend error. Backing off 4100 ms (com.wepay.kafka.connect.bigquery.write.row.GcsToBqWriter:271)
[2025-09-09 16:34:29,087] WARN Retryable exception on attempt 7: retryable backend error. Backing off 661 ms (com.wepay.kafka.connect.bigquery.write.row.GcsToBqWriter:271)
[2025-09-09 16:34:29,087] ERROR Timeout expired after 8 attempts within 10000 ms budget. (com.wepay.kafka.connect.bigquery.write.row.GcsToBqWriter:261)
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.02 s - in com.wepay.kafka.connect.bigquery.write.row.GcsToBqWriterTest
...
[INFO] Results:
[INFO] 
[INFO] Tests run: 357, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for kafka-connect-bigquery-parent 2.9.0-SNAPSHOT:
[INFO] 
[INFO] kafka-connect-bigquery-parent ...................... SUCCESS [  0.060 s]
[INFO] kafka-connect-bigquery-api ......................... SUCCESS [  1.387 s]
[INFO] kafka-connect-bigquery ............................. SUCCESS [  6.905 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
```

```
...
[INFO] Checking licenses...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for kafka-connect-bigquery-parent 2.9.0-SNAPSHOT:
[INFO] 
[INFO] kafka-connect-bigquery-parent ...................... SUCCESS [  0.279 s]
[INFO] kafka-connect-bigquery-api ......................... SUCCESS [  0.007 s]
[INFO] kafka-connect-bigquery ............................. SUCCESS [  0.037 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
...
```