### PR TITLE
Update project id of BQ target table when useCredentialsProjectId is enabled

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -225,15 +225,9 @@ public class BigQuerySinkTask extends SinkTask {
 
   private PartitionedTableId getStorageApiRecordTable(String topic) {
     return topicToPartitionTableId.computeIfAbsent(topic, topicName -> {
+      String project = config.getString(BigQuerySinkConfig.PROJECT_CONFIG);
       String[] datasetAndtableName = TableNameUtils.getDataSetAndTableName(config, topicName);
-      TableId baseTableId;
-      if (useCredentialsProjectId) {
-        baseTableId = TableId.of(datasetAndtableName[0], datasetAndtableName[1]);
-      } else {
-        String project = config.getString(BigQuerySinkConfig.PROJECT_CONFIG);
-        baseTableId = TableId.of(project, datasetAndtableName[0], datasetAndtableName[1]);
-      }
-      return new PartitionedTableId.Builder(baseTableId).build();
+      return new PartitionedTableId.Builder(TableId.of(project, datasetAndtableName[0], datasetAndtableName[1])).build();
     });
 
   }
@@ -252,7 +246,7 @@ public class BigQuerySinkTask extends SinkTask {
 
 
     String project = null;
-    if (!useCredentialsProjectId) {
+    if (useCredentialsProjectId) {
       project = config.getString(BigQuerySinkConfig.PROJECT_CONFIG);
     }
     TableId baseTableId = project == null

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -407,9 +407,9 @@ public class BigQuerySinkConfig extends AbstractConfig {
   private static final ConfigDef.Type USE_CREDENTIALS_PROJECT_ID_TYPE = ConfigDef.Type.BOOLEAN;
   private static final ConfigDef.Importance USE_CREDENTIALS_PROJECT_ID_IMPORTANCE = ConfigDef.Importance.MEDIUM;
   private static final String USE_CREDENTIALS_PROJECT_ID_DOC =
-    "If true, clients use the project ID from the credentials JSON and tables use the connector's "
-  + "'project' parameter. If false (default), clients use the connector's project parameter and "
-  + "tables use the client project.";
+      "If true, clients use the project ID from the credentials JSON and tables use the connector's "
+          + "'project' parameter. If false (default), clients use the connector's project parameter and "
+          + "tables use the client project.";
   private static final ConfigDef.Type ENABLE_BATCH_MODE_TYPE = ConfigDef.Type.BOOLEAN;
   private static final ConfigDef.Importance ENABLE_BATCH_MODE_IMPORTANCE = ConfigDef.Importance.LOW;
   private static final String ENABLE_BATCH_MODE_DOC = "Use Google's New Storage Write API with batch mode";

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -407,7 +407,9 @@ public class BigQuerySinkConfig extends AbstractConfig {
   private static final ConfigDef.Type USE_CREDENTIALS_PROJECT_ID_TYPE = ConfigDef.Type.BOOLEAN;
   private static final ConfigDef.Importance USE_CREDENTIALS_PROJECT_ID_IMPORTANCE = ConfigDef.Importance.MEDIUM;
   private static final String USE_CREDENTIALS_PROJECT_ID_DOC =
-      "Use the quotaProjectId from the credentials when available.";
+    "If true, clients use the project ID from the credentials JSON and tables use the connector's "
+  + "'project' parameter. If false (default), clients use the connector's project parameter and "
+  + "tables use the client project.";
   private static final ConfigDef.Type ENABLE_BATCH_MODE_TYPE = ConfigDef.Type.BOOLEAN;
   private static final ConfigDef.Importance ENABLE_BATCH_MODE_IMPORTANCE = ConfigDef.Importance.LOW;
   private static final String ENABLE_BATCH_MODE_DOC = "Use Google's New Storage Write API with batch mode";

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
@@ -171,7 +171,7 @@ public class BigQuerySinkTaskTest {
   @Test
   public void testGetRecordTableUsesConfiguredProject() throws Exception {
     Map<String, String> properties = propertiesFactory.getProperties();
-    properties.put(BigQuerySinkConfig.USE_CREDENTIALS_PROJECT_ID_CONFIG, "false");
+    properties.put(BigQuerySinkConfig.USE_CREDENTIALS_PROJECT_ID_CONFIG, "true");
     initialize(properties);
 
     BigQuerySinkTask task = new BigQuerySinkTask(
@@ -200,7 +200,7 @@ public class BigQuerySinkTaskTest {
   @Test
   public void testGetRecordTableUsesCredentialsProject() throws Exception {
     Map<String, String> properties = propertiesFactory.getProperties();
-    properties.put(BigQuerySinkConfig.USE_CREDENTIALS_PROJECT_ID_CONFIG, "true");
+    properties.put(BigQuerySinkConfig.USE_CREDENTIALS_PROJECT_ID_CONFIG, "false");
     initialize(properties);
 
     BigQuerySinkTask task = new BigQuerySinkTask(
@@ -222,6 +222,7 @@ public class BigQuerySinkTaskTest {
         .getDeclaredMethod("getRecordTable", SinkRecord.class);
     m.setAccessible(true);
     PartitionedTableId tableId = (PartitionedTableId) m.invoke(task, record);
+    
     assertNull(tableId.getProject());
   }
 
@@ -1144,10 +1145,7 @@ public class BigQuerySinkTaskTest {
     Table table = mock(Table.class);
     when(table.getDefinition()).thenReturn(mockTableDefinition);
     Map<TableId, Table> tableCache = new HashMap<>();
-    tableCache.put(
-        TableId.of(properties.get(BigQuerySinkConfig.PROJECT_CONFIG), dataset, topic),
-        table
-    );
+    tableCache.put(TableId.of(dataset, topic), table);
     Storage storage = mock(Storage.class);
     BigQuery bigQuery = mock(BigQuery.class);
 


### PR DESCRIPTION
## Overview
When useCredentialsProjectId is True, Bigquery sink task should write data into the project set in the configuration.
This is not the current behaviour. This PR introduces changes to fix the issue.

Please also check the previous PR to comprehensive review
Previous PR: 
https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/pull/75/files

New Aiven Ticket Id : #98746

Closes #124 

## Tests

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.300 s -- in com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiWriterTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.038 s -- in com.wepay.kafka.connect.bigquery.write.storage.BigQueryBuilderTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s -- in com.wepay.kafka.connect.bigquery.write.storage.BigQueryWriteSettingsBuilderTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.032 s -- in com.wepay.kafka.connect.bigquery.write.storage.GcsBuilderTest
[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.138 s -- in com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiBatchApplicationStreamTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s -- in com.wepay.kafka.connect.bigquery.write.storage.StorageApiBatchModeHandlerTest
[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.051 s -- in com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiDefaultStreamTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.136 s -- in com.wepay.kafka.connect.bigquery.write.row.BigQueryWriterTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.019 s -- in com.wepay.kafka.connect.bigquery.write.row.GcsToBqWriterTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.176 s -- in com.wepay.kafka.connect.bigquery.GcpClientBuilderProjectTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.028 s -- in com.wepay.kafka.connect.bigquery.config.GcsBucketValidatorTest
[INFO] Tests run: 33, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.026 s -- in com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfigTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s -- in com.wepay.kafka.connect.bigquery.config.PartitioningModeValidatorTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s -- in com.wepay.kafka.connect.bigquery.config.MultiPropertyValidatorTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s -- in com.wepay.kafka.connect.bigquery.config.CredentialsValidatorTest
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s -- in com.wepay.kafka.connect.bigquery.config.StorageWriteApiValidatorTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s -- in com.wepay.kafka.connect.bigquery.config.PartitioningTypeValidatorTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s -- in com.wepay.kafka.connect.bigquery.utils.PartitionedTableIdTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s -- in com.wepay.kafka.connect.bigquery.utils.FieldNameSanitizerTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s -- in com.wepay.kafka.connect.bigquery.ErrantRecordHandlerTest
[INFO] Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.187 s -- in com.wepay.kafka.connect.bigquery.BigQuerySinkTaskTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.128 s -- in com.wepay.kafka.connect.bigquery.BigQueryStorageApiBatchSinkTaskTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s -- in com.wepay.kafka.connect.bigquery.BigQuerySinkConnectorTest
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.038 s -- in com.wepay.kafka.connect.bigquery.MergeQueriesTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.111 s -- in com.wepay.kafka.connect.bigquery.BigQueryStorageApiSinkTaskTest
[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s -- in com.wepay.kafka.connect.bigquery.exception.BigQueryStorageWriteApiErrorResponsesTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s -- in com.wepay.kafka.connect.bigquery.exception.BigQueryErrorResponsesTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s -- in com.wepay.kafka.connect.bigquery.exception.BigQueryStorageWriteApiConnectExceptionTest
[INFO] Tests run: 39, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.042 s -- in com.wepay.kafka.connect.bigquery.SchemaManagerTest
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.049 s -- in com.wepay.kafka.connect.bigquery.GcsToBqLoadRunnableTest
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 s -- in com.wepay.kafka.connect.bigquery.convert.KafkaDataConverterTest
[INFO] Tests run: 42, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.094 s -- in com.wepay.kafka.connect.bigquery.convert.BigQuerySchemaConverterTest
[INFO] Tests run: 37, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.031 s -- in com.wepay.kafka.connect.bigquery.convert.BigQueryRecordConverterTest
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s -- in com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConvertersTest
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s -- in com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConvertersTest
[INFO] Results:
[INFO] 
[INFO] Tests run: 357, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  5.324 s
[INFO] Finished at: 2025-09-15T13:16:24+02:00
[INFO] ------------------------------------------------------------------------

```