### PR TITLE
Fix ByteBuffer serialization in GcsToBqWriter (avoid Gson reflection crash on Java 9+)

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/GsonUtils.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/GsonUtils.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024 Copyright 2022 Aiven Oy and
+ * bigquery-connector-for-apache-kafka project contributors
+ *
+ * This software contains code derived from the Confluent BigQuery
+ * Kafka Connector, Copyright Confluent, Inc, which in turn
+ * contains code derived from the WePay BigQuery Kafka Connector,
+ * Copyright WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wepay.kafka.connect.bigquery.utils;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Base64;
+
+/**
+ * Gson utilities for safe JSON handling on Java 9+.
+ *
+ * <p>Exposes a preconfigured {@link Gson} instance that registers a hierarchy adapter for {@link ByteBuffer}
+ * , ensuring serialization does not rely on illegal reflection into JDK internals (e.g.,
+ * ByteBuffer#hb) which would otherwise throw {@code InaccessibleObjectException} on Java 9+.
+ */
+public final class GsonUtils {
+
+  /** A ready-to-use Gson that safely serializes ByteBuffer (as Base64 strings). */
+  public static final Gson SAFE_GSON =
+      new GsonBuilder()
+          // Use hierarchy adapter so HeapByteBuffer/DirectByteBuffer subclasses are covered.
+          .registerTypeHierarchyAdapter(ByteBuffer.class, new ByteBufferTypeAdapter())
+          .create();
+
+  private GsonUtils() {
+    // no instances
+  }
+
+  /**
+   * Serializes {@link ByteBuffer} values as Base64 strings and deserializes them back. Registered
+   * as a hierarchy adapter so it handles all ByteBuffer subclasses.
+   */
+  static final class ByteBufferTypeAdapter extends TypeAdapter<ByteBuffer> {
+
+    @Override
+    public void write(JsonWriter out, ByteBuffer value) throws IOException {
+      if (value == null) {
+        out.nullValue();
+        return;
+      }
+      // Duplicate to avoid mutating the original buffer's position/limit.
+      ByteBuffer dup = value.duplicate();
+      byte[] bytes = new byte[dup.remaining()];
+      dup.get(bytes);
+      out.value(Base64.getEncoder().encodeToString(bytes));
+    }
+
+    @Override
+    public ByteBuffer read(JsonReader in) throws IOException {
+      if (in.peek() == JsonToken.NULL) {
+        in.nextNull();
+        return null;
+      }
+      byte[] bytes = Base64.getDecoder().decode(in.nextString());
+      return ByteBuffer.wrap(bytes);
+    }
+  }
+}

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/GcsToBqWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/GcsToBqWriter.java
@@ -35,6 +35,7 @@ import com.google.gson.Gson;
 import com.wepay.kafka.connect.bigquery.SchemaManager;
 import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 import com.wepay.kafka.connect.bigquery.exception.GcsConnectException;
+import com.wepay.kafka.connect.bigquery.utils.GsonUtils;
 import com.wepay.kafka.connect.bigquery.utils.Time;
 import java.io.UnsupportedEncodingException;
 import java.time.Duration;
@@ -60,7 +61,7 @@ public class GcsToBqWriter {
   private static final int WAIT_MAX_JITTER = 1000;
   private static final long MAX_BACKOFF_MS = 10_000L;
   private static final Random random = new Random();
-  private static Gson gson = new Gson();
+  private static final Gson gson = GsonUtils.SAFE_GSON;
   private final Storage storage;
   private final BigQuery bigQuery;
   private final SchemaManager schemaManager;


### PR DESCRIPTION
### Summary

This PR fixes #139: a crash in `GcsToBqWriter` when serializing Debezium’s `VariableScaleDecimal` (#76) and other `ByteBuffer`-backed logical types.  
On Java 9+, vanilla Gson attempts to reflect into `ByteBuffer.hb` and fails with:


```
java.lang.reflect.InaccessibleObjectException: 
Unable to make field final byte[] java.nio.ByteBuffer.hb accessible
```


### Changes

* Introduced `GsonUtils.SAFE_GSON` with a custom `ByteBufferTypeAdapter` that serializes ByteBuffer as base64.
* Updated `GcsToBqWriter` to use `SAFE_GSON` instead of `new Gson()`.
* Added a `@Nested` test suite to `GcsToBqWriterTest`:

  * **gsonFailsOnByteBuffer**: proves vanilla Gson crashes on Debezium `VariableScaleDecimal` (Java 9+).
  * **safeGsonPassesOnByteBuffer**: verifies SAFE\_GSON encodes ByteBuffer safely as base64.
  * **safeGsonPassesOnRegularTypes**: ensures no regressions for primitive/collection types.


### Notes

* Root cause matches google/gson#2485.
* Keeping Java 8 compatibility: tests skip the vanilla failure case on JDK 8.
* SAFE\_GSON only alters ByteBuffer serialization; other types remain unaffected.


### Issue References
- Fixes #139  
- Related to #76