### PR TITLE
Specify Trace ID to enable BigQuery to track traffic originating from…

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBase.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBase.java
@@ -61,6 +61,7 @@ public abstract class StorageWriteApiBase {
   private static final Logger logger = LoggerFactory.getLogger(StorageWriteApiBase.class);
   private static final double RETRY_DELAY_MULTIPLIER = 1.1;
   private static final int MAX_RETRY_DELAY_MINUTES = 1;
+  public static final String TRACE_ID_FORMAT = "AivenKafkaConnector:%s";
   protected final JsonStreamWriterFactory jsonWriterFactory;
   protected final int retry;
   protected final long retryWait;
@@ -298,6 +299,10 @@ public abstract class StorageWriteApiBase {
     return this.writeClient;
   }
 
+  private String generateTraceId() {
+    return String.format(TRACE_ID_FORMAT, "default");
+  }
+
   /**
    * Returns a {@link JsonStreamWriterFactory} for creating configured {@link JsonStreamWriter} instances
    *
@@ -312,7 +317,8 @@ public abstract class StorageWriteApiBase {
             .build();
     return streamOrTableName -> {
       JsonStreamWriter.Builder builder = JsonStreamWriter.newBuilder(streamOrTableName, writeClient)
-              .setRetrySettings(retrySettings);
+              .setRetrySettings(retrySettings)
+              .setTraceId(generateTraceId());
       updateJsonStreamWriterBuilder(builder);
       return builder.build();
     };


### PR DESCRIPTION
… this connector.

This merge request will replace the earlier one that relied on accessing the config. Trace ID is a feature that enables clients to pass in an arbitrary string; this is decorated onto the first append request of a connection by the Java client library. The BigQuery server has logic to interpret the trace ID as a colon-separated set of components. For example, it might be "AivenKafkaConnector:foo:bar". Further, BigQuery recognizes certain pre-defined names, now including "AivenKafkaConnector". The names are used as an internal reporting mechanism, for example to help break down how much traffic is being generated by a given source connector. So the primary piece we need is simply the first part, namely "AivenKafkaConnector". Subsequent components that are supplied in the trace id such as "foo" and "bar" are also captured in our internal per-request server logs. If the component matches the name of a particular job that was run by the customer, for example, then this information could be used for debugging purposes during a joint collaboration session with the customer. Hence these component values should be somewhat unique but also useful to a customer. The current change only provides the pre-defined name. Additional trace components can be added in future if desired.