### PR TITLE
fix: skip test on kcbq-api build

### DIFF
--- a/kcbq-api/pom.xml
+++ b/kcbq-api/pom.xml
@@ -79,6 +79,13 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
i got error when following build script in README.md. i think it's because kcbq-api module has no test dependancies but maven-surefire trying to test it. so i append skip configuration.

i got this result when i ran `mvn install -DskipITs`
<img width="848" height="400" alt="Screenshot from 2025-10-03 18-12-28" src="https://github.com/user-attachments/assets/c46c5b9c-0d48-4e1e-b5aa-5bc964046241" />

and after append configuration

<img width="855" height="209" alt="Screenshot from 2025-10-03 18-11-35" src="https://github.com/user-attachments/assets/02a682ce-4db3-4ed2-abbd-209e22275304" />
