### PR TITLE
Fix null documentation for deprecated configs to avoid DecodingFailure in clients

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -1018,6 +1018,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
                             .deprecatedInfo(ExtendedConfigKey.DeprecatedInfo.builder().setSince("2.8.0")
                                     .setDescription(String.format("Use %s instead.", DEBEZIUM_VARIABLE_SCALE_DECIMAL_HANDLING_MODE_CONFIG))
                             )
+                            .documentation("")
                             .since("2.7.0").build()
             ).define(
                     DECIMAL_HANDLING_MODE_CONFIG,


### PR DESCRIPTION
### Description

Some configs (e.g., `convertDebeziumVariableScaleDecimal`) have `"documentation": null`.  

When using the Kafka Connect UI, this prevents creating or validating the connector because the UI expects documentation to be a string.

### Proposed Fix

Set a non-null documentation string for these configs, for example:

```java
.documentation("")
```