### PR TITLE
Revert "Release version 2.10.1"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     </modules>
 
     <properties>
-        <latestRelease>2.10.1</latestRelease>
+        <latestRelease>2.10.0</latestRelease>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>8</java.version>


### PR DESCRIPTION
Reverts Aiven-Open/bigquery-connector-for-apache-kafka#158

We will add the 1.10.1 release notes before creating this release.