### PR TITLE
fix(SchemaManager): deduplicate key fields already present in value schema

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -229,6 +229,7 @@ public class BigQuerySinkTask extends SinkTask {
                 storageApiWriter,
                 table,
                 recordConverter,
+                config,
                 batchHandler
             );
           } else if (config.getList(BigQuerySinkConfig.ENABLE_BATCH_CONFIG).contains(record.topic())) {
@@ -351,11 +352,15 @@ public class BigQuerySinkTask extends SinkTask {
     Optional<List<String>> clusteringFieldName = config.getClusteringPartitionFieldNames();
     Optional<TimePartitioning.Type> timePartitioningType = config.getTimePartitioningType();
     boolean sanitizeFieldNames = config.getBoolean(BigQuerySinkConfig.SANITIZE_FIELD_NAME_CONFIG);
+    boolean kafkaKeyAsPrimaryKey = config.isUpsertEnabled()
+        && config.getBoolean(BigQuerySinkConfig.USE_STORAGE_WRITE_API_CONFIG);
+
     return new SchemaManager(schemaRetriever, schemaConverter, getBigQuery(),
         allowNewBigQueryFields, allowRequiredFieldRelaxation, allowSchemaUnionization,
         sanitizeFieldNames,
         kafkaKeyFieldName, kafkaDataFieldName,
-        timestampPartitionFieldName, partitionExpiration, clusteringFieldName, timePartitioningType);
+        timestampPartitionFieldName, partitionExpiration, clusteringFieldName, timePartitioningType,
+        kafkaKeyAsPrimaryKey);
   }
 
   private BigQueryWriter getBigQueryWriter(ErrantRecordHandler errantRecordHandler) {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -32,7 +32,11 @@ import com.google.cloud.bigquery.Clustering;
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.Field.Mode;
 import com.google.cloud.bigquery.LegacySQLTypeName;
+import com.google.cloud.bigquery.PrimaryKey;
 import com.google.cloud.bigquery.StandardTableDefinition;
+import com.google.cloud.bigquery.Table;
+import com.google.cloud.bigquery.TableConstraints;
+import com.google.cloud.bigquery.TableDefinition;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableInfo;
 import com.google.cloud.bigquery.TimePartitioning;
@@ -46,12 +50,14 @@ import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 import com.wepay.kafka.connect.bigquery.utils.FieldNameSanitizer;
 import com.wepay.kafka.connect.bigquery.utils.TableNameUtils;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
@@ -80,7 +86,8 @@ public class SchemaManager {
   private final boolean intermediateTables;
   private final ConcurrentMap<TableId, Object> tableCreateLocks;
   private final ConcurrentMap<TableId, Object> tableUpdateLocks;
-  private final ConcurrentMap<TableId, com.google.cloud.bigquery.Schema> schemaCache;
+  private final boolean kafkaKeyAsPrimaryKey;
+  private final ConcurrentMap<TableId, SchemaAndPrimaryKeyColumns> schemaCache;
 
   /**
    * @param schemaRetriever                Used to determine the Kafka Connect Schema that should be used for a
@@ -115,7 +122,8 @@ public class SchemaManager {
       Optional<String> timestampPartitionFieldName,
       Optional<Long> partitionExpiration,
       Optional<List<String>> clusteringFieldName,
-      Optional<TimePartitioning.Type> timePartitioningType) {
+      Optional<TimePartitioning.Type> timePartitioningType,
+      boolean kafkaKeyAsPrimaryKey) {
     this(
         schemaRetriever,
         schemaConverter,
@@ -130,6 +138,7 @@ public class SchemaManager {
         partitionExpiration,
         clusteringFieldName,
         timePartitioningType,
+        kafkaKeyAsPrimaryKey,
         false,
         new ConcurrentHashMap<>(),
         new ConcurrentHashMap<>(),
@@ -150,10 +159,11 @@ public class SchemaManager {
       Optional<Long> partitionExpiration,
       Optional<List<String>> clusteringFieldName,
       Optional<TimePartitioning.Type> timePartitioningType,
+      boolean kafkaKeyAsPrimaryKey,
       boolean intermediateTables,
       ConcurrentMap<TableId, Object> tableCreateLocks,
       ConcurrentMap<TableId, Object> tableUpdateLocks,
-      ConcurrentMap<TableId, com.google.cloud.bigquery.Schema> schemaCache) {
+      ConcurrentMap<TableId, SchemaAndPrimaryKeyColumns> schemaCache) {
     this.schemaRetriever = schemaRetriever;
     this.schemaConverter = schemaConverter;
     this.bigQuery = bigQuery;
@@ -167,6 +177,10 @@ public class SchemaManager {
     this.partitionExpiration = partitionExpiration;
     this.clusteringFieldName = clusteringFieldName;
     this.timePartitioningType = timePartitioningType;
+    this.kafkaKeyAsPrimaryKey = kafkaKeyAsPrimaryKey;
+    if (kafkaKeyAsPrimaryKey) {
+      assert Optional.of("").equals(kafkaKeyFieldName);
+    }
     this.intermediateTables = intermediateTables;
     this.tableCreateLocks = tableCreateLocks;
     this.tableUpdateLocks = tableUpdateLocks;
@@ -188,6 +202,7 @@ public class SchemaManager {
         partitionExpiration,
         clusteringFieldName,
         timePartitioningType,
+        kafkaKeyAsPrimaryKey,
         true,
         tableCreateLocks,
         tableUpdateLocks,
@@ -204,7 +219,7 @@ public class SchemaManager {
    * been created or updated by this schema manager
    */
   public com.google.cloud.bigquery.Schema cachedSchema(TableId table) {
-    return schemaCache.get(table);
+    return schemaCache.containsKey(table) ? schemaCache.get(table).getSchema() : null;
   }
 
   /**
@@ -250,7 +265,7 @@ public class SchemaManager {
       try {
         bigQuery.create(tableInfo);
         logger.debug("Successfully created {}", table(table));
-        schemaCache.put(table, tableInfo.getDefinition().getSchema());
+        schemaCache.put(table, SchemaAndPrimaryKeyColumns.of(tableInfo));
         return true;
       } catch (BigQueryException e) {
         if (e.getCode() == 409) {
@@ -276,12 +291,12 @@ public class SchemaManager {
         schemaCache.put(table, readTableSchema(table));
       }
 
-      if (!schemaCache.get(table).equals(tableInfo.getDefinition().getSchema())) {
+      if (!schemaCache.get(table).getSchema().equals(tableInfo.getDefinition().getSchema())) {
         logger.info("Attempting to update {} with schema {}",
             table(table), tableInfo.getDefinition().getSchema());
         bigQuery.update(tableInfo);
         logger.debug("Successfully updated {}", table(table));
-        schemaCache.put(table, tableInfo.getDefinition().getSchema());
+        schemaCache.put(table, SchemaAndPrimaryKeyColumns.of(tableInfo));
       } else {
         logger.debug("Skipping update of {} since current schema should be compatible", table(table));
       }
@@ -297,7 +312,7 @@ public class SchemaManager {
    * @return The resulting BigQuery table information
    */
   private TableInfo getTableInfo(TableId table, List<SinkRecord> records, Boolean createSchema) {
-    com.google.cloud.bigquery.Schema proposedSchema;
+    SchemaAndPrimaryKeyColumns proposedSchema;
     String tableDescription;
     try {
       proposedSchema = getAndValidateProposedSchema(table, records);
@@ -309,14 +324,14 @@ public class SchemaManager {
   }
 
   @VisibleForTesting
-  com.google.cloud.bigquery.Schema getAndValidateProposedSchema(
+  SchemaAndPrimaryKeyColumns getAndValidateProposedSchema(
       TableId table, List<SinkRecord> records) {
-    com.google.cloud.bigquery.Schema result;
+    SchemaAndPrimaryKeyColumns result;
     if (allowSchemaUnionization) {
-      List<com.google.cloud.bigquery.Schema> bigQuerySchemas = getSchemasList(table, records);
+      List<SchemaAndPrimaryKeyColumns> bigQuerySchemas = getSchemasList(table, records);
       result = getUnionizedSchema(bigQuerySchemas);
     } else {
-      com.google.cloud.bigquery.Schema existingSchema = readTableSchema(table);
+      SchemaAndPrimaryKeyColumns existingSchema = readTableSchema(table);
       SinkRecord recordToConvert = getRecordToConvert(records);
       if (recordToConvert == null) {
         String errorMessage = "Could not convert to BigQuery schema with a batch of tombstone records.";
@@ -328,9 +343,12 @@ public class SchemaManager {
       }
       result = convertRecordSchema(recordToConvert);
       if (existingSchema != null) {
-        validateSchemaChange(existingSchema, result);
+        validateSchemaChange(existingSchema.getSchema(), result.getSchema());
         if (allowBqRequiredFieldRelaxation) {
-          result = relaxFieldsWhereNecessary(existingSchema, result);
+          result = new SchemaAndPrimaryKeyColumns(
+              relaxFieldsWhereNecessary(existingSchema.getSchema(), result.getSchema()),
+              result.getPrimaryKeyColumns()
+          );
         }
       }
     }
@@ -344,8 +362,8 @@ public class SchemaManager {
    * @param records The sink records' schemas to add to the list of schemas
    * @return List of BigQuery schemas
    */
-  private List<com.google.cloud.bigquery.Schema> getSchemasList(TableId table, List<SinkRecord> records) {
-    List<com.google.cloud.bigquery.Schema> bigQuerySchemas = new ArrayList<>();
+  private List<SchemaAndPrimaryKeyColumns> getSchemasList(TableId table, List<SinkRecord> records) {
+    List<SchemaAndPrimaryKeyColumns> bigQuerySchemas = new ArrayList<>();
     Optional.ofNullable(readTableSchema(table)).ifPresent(bigQuerySchemas::add);
     for (SinkRecord record : records) {
       Schema kafkaValueSchema = schemaRetriever.retrieveValueSchema(record);
@@ -375,10 +393,10 @@ public class SchemaManager {
     return null;
   }
 
-  private com.google.cloud.bigquery.Schema convertRecordSchema(SinkRecord record) {
+  private SchemaAndPrimaryKeyColumns convertRecordSchema(SinkRecord record) {
     Schema kafkaValueSchema = schemaRetriever.retrieveValueSchema(record);
     Schema kafkaKeySchema = kafkaKeyFieldName.isPresent() ? schemaRetriever.retrieveKeySchema(record) : null;
-    com.google.cloud.bigquery.Schema result = getBigQuerySchema(kafkaKeySchema, kafkaValueSchema);
+    SchemaAndPrimaryKeyColumns result = getBigQuerySchema(kafkaKeySchema, kafkaValueSchema);
     return result;
   }
 
@@ -388,15 +406,18 @@ public class SchemaManager {
    * @param schemas The list of BigQuery schemas to unionize
    * @return The resulting unionized BigQuery schema
    */
-  private com.google.cloud.bigquery.Schema getUnionizedSchema(List<com.google.cloud.bigquery.Schema> schemas) {
-    com.google.cloud.bigquery.Schema currentSchema = schemas.get(0);
+  private SchemaAndPrimaryKeyColumns getUnionizedSchema(List<SchemaAndPrimaryKeyColumns> schemas) {
+    com.google.cloud.bigquery.Schema currentSchema = schemas.get(0).getSchema();
     com.google.cloud.bigquery.Schema proposedSchema;
     for (int i = 1; i < schemas.size(); i++) {
-      proposedSchema = unionizeSchemas(currentSchema, schemas.get(i));
+      proposedSchema = unionizeSchemas(currentSchema, schemas.get(i).getSchema());
       validateSchemaChange(currentSchema, proposedSchema);
       currentSchema = proposedSchema;
     }
-    return currentSchema;
+    return new SchemaAndPrimaryKeyColumns(
+        currentSchema,
+        schemas.get(schemas.size() - 1).getPrimaryKeyColumns()
+    );
   }
 
   private Field unionizeFields(Field firstField, Field secondField) {
@@ -603,10 +624,11 @@ public class SchemaManager {
   }
 
   // package private for testing.
-  TableInfo constructTableInfo(TableId table, com.google.cloud.bigquery.Schema bigQuerySchema, String tableDescription,
+  TableInfo constructTableInfo(TableId table, SchemaAndPrimaryKeyColumns bigQuerySchema, String tableDescription,
                                Boolean createSchema) {
     StandardTableDefinition.Builder builder = StandardTableDefinition.newBuilder()
-        .setSchema(bigQuerySchema);
+        .setSchema(bigQuerySchema.getSchema());
+    
 
     if (intermediateTables) {
       // Shameful hack: make the table ingestion time-partitioned here so that the _PARTITIONTIME
@@ -626,6 +648,19 @@ public class SchemaManager {
               .build();
           builder.setClustering(clustering);
         }
+
+        if (kafkaKeyAsPrimaryKey) {
+          assert Optional.of("").equals(kafkaKeyFieldName);
+
+          builder.setTableConstraints(
+              TableConstraints.newBuilder()
+                  .setPrimaryKey(
+                      PrimaryKey.newBuilder()
+                          .setColumns(bigQuerySchema.getPrimaryKeyColumns())
+                          .build()
+                  ).build()
+          );
+        }
       });
     }
 
@@ -641,17 +676,15 @@ public class SchemaManager {
     return tableInfoBuilder.build();
   }
 
-  private com.google.cloud.bigquery.Schema getBigQuerySchema(Schema kafkaKeySchema, Schema kafkaValueSchema) {
+  private SchemaAndPrimaryKeyColumns getBigQuerySchema(Schema kafkaKeySchema, Schema kafkaValueSchema) {
     com.google.cloud.bigquery.Schema valueSchema = schemaConverter.convertSchema(kafkaValueSchema);
 
-    List<Field> schemaFields = intermediateTables
-        ? getIntermediateSchemaFields(valueSchema, kafkaKeySchema)
-        : getRegularSchemaFields(valueSchema, kafkaKeySchema);
-
-    return com.google.cloud.bigquery.Schema.of(schemaFields);
+    return intermediateTables
+        ? getIntermediateSchema(valueSchema, kafkaKeySchema)
+        : getRegularSchema(valueSchema, kafkaKeySchema);
   }
 
-  private List<Field> getIntermediateSchemaFields(com.google.cloud.bigquery.Schema valueSchema, Schema kafkaKeySchema) {
+  private SchemaAndPrimaryKeyColumns getIntermediateSchema(com.google.cloud.bigquery.Schema valueSchema, Schema kafkaKeySchema) {
     if (kafkaKeySchema == null) {
       throw new BigQueryConnectException(String.format(
           "Cannot create intermediate table without specifying a value for '%s'",
@@ -659,7 +692,7 @@ public class SchemaManager {
       ));
     }
 
-    List<Field> result = new ArrayList<>();
+    List<Field> fields = new ArrayList<>();
 
     List<Field> valueFields = new ArrayList<>(valueSchema.getFields());
     if (kafkaDataFieldName.isPresent()) {
@@ -675,59 +708,77 @@ public class SchemaManager {
         .newBuilder(MergeQueries.INTERMEDIATE_TABLE_VALUE_FIELD_NAME, LegacySQLTypeName.RECORD, valueFields.toArray(new Field[0]))
         .setMode(Field.Mode.NULLABLE)
         .build();
-    result.add(wrappedValueField);
+    fields.add(wrappedValueField);
 
     com.google.cloud.bigquery.Schema keySchema = schemaConverter.convertSchema(kafkaKeySchema);
     Field kafkaKeyField = Field.newBuilder(MergeQueries.INTERMEDIATE_TABLE_KEY_FIELD_NAME, LegacySQLTypeName.RECORD, keySchema.getFields())
         .setMode(Field.Mode.REQUIRED)
         .build();
-    result.add(kafkaKeyField);
+    fields.add(kafkaKeyField);
 
     Field iterationField = Field
         .newBuilder(MergeQueries.INTERMEDIATE_TABLE_ITERATION_FIELD_NAME, LegacySQLTypeName.INTEGER)
         .setMode(Field.Mode.REQUIRED)
         .build();
-    result.add(iterationField);
+    fields.add(iterationField);
 
     Field partitionTimeField = Field
         .newBuilder(MergeQueries.INTERMEDIATE_TABLE_PARTITION_TIME_FIELD_NAME, LegacySQLTypeName.TIMESTAMP)
         .setMode(Field.Mode.NULLABLE)
         .build();
-    result.add(partitionTimeField);
+    fields.add(partitionTimeField);
 
     Field batchNumberField = Field
         .newBuilder(MergeQueries.INTERMEDIATE_TABLE_BATCH_NUMBER_FIELD, LegacySQLTypeName.INTEGER)
         .setMode(Field.Mode.REQUIRED)
         .build();
-    result.add(batchNumberField);
+    fields.add(batchNumberField);
 
-    return result;
+    return new SchemaAndPrimaryKeyColumns(
+        com.google.cloud.bigquery.Schema.of(fields),
+        Collections.emptyList()
+    );
   }
 
-  private List<Field> getRegularSchemaFields(com.google.cloud.bigquery.Schema valueSchema, Schema kafkaKeySchema) {
-    List<Field> result = new ArrayList<>(valueSchema.getFields());
+  private SchemaAndPrimaryKeyColumns getRegularSchema(com.google.cloud.bigquery.Schema valueSchema, Schema kafkaKeySchema) {
+    List<Field> fields = new ArrayList<>(valueSchema.getFields());
+    List<String> primaryKeyColumns;
 
     if (kafkaDataFieldName.isPresent()) {
       String dataFieldName = sanitizeFieldNames
           ? FieldNameSanitizer.sanitizeName(kafkaDataFieldName.get())
           : kafkaDataFieldName.get();
       Field kafkaDataField = KafkaDataBuilder.buildKafkaDataField(dataFieldName);
-      result.add(kafkaDataField);
+      fields.add(kafkaDataField);
     }
 
     if (kafkaKeyFieldName.isPresent()) {
       com.google.cloud.bigquery.Schema keySchema = schemaConverter.convertSchema(kafkaKeySchema);
-      String keyFieldName = sanitizeFieldNames
-          ? FieldNameSanitizer.sanitizeName(kafkaKeyFieldName.get())
-          : kafkaKeyFieldName.get();
-      Field kafkaKeyField = Field.newBuilder(
-          keyFieldName,
-          LegacySQLTypeName.RECORD,
-          keySchema.getFields()).setMode(Field.Mode.NULLABLE).build();
-      result.add(kafkaKeyField);
+      if (kafkaKeyFieldName.get().isEmpty()) {
+        // TODO: Gracefully handle collisions with value/TPO field names
+        fields.addAll(keySchema.getFields());
+        primaryKeyColumns = keySchema.getFields().stream()
+            .map(Field::getName)
+            .collect(Collectors.toList());
+      } else {
+        String keyFieldName = sanitizeFieldNames
+            ? FieldNameSanitizer.sanitizeName(kafkaKeyFieldName.get())
+            : kafkaKeyFieldName.get();
+        Field kafkaKeyField = Field.newBuilder(
+            keyFieldName,
+            LegacySQLTypeName.RECORD,
+            keySchema.getFields()).setMode(Field.Mode.NULLABLE).build();
+        fields.add(kafkaKeyField);
+        primaryKeyColumns = Collections.emptyList();
+      }
+    } else {
+      primaryKeyColumns = Collections.emptyList();
     }
 
-    return result;
+    return new SchemaAndPrimaryKeyColumns(
+        com.google.cloud.bigquery.Schema.of(fields),
+        primaryKeyColumns
+    );
   }
 
   private String table(TableId table) {
@@ -736,14 +787,52 @@ public class SchemaManager {
         : TableNameUtils.table(table);
   }
 
-  private com.google.cloud.bigquery.Schema readTableSchema(TableId table) {
+  private SchemaAndPrimaryKeyColumns readTableSchema(TableId table) {
     logger.trace("Reading schema for {}", table(table));
     return Optional.ofNullable(bigQuery.getTable(table))
-        .map(t -> t.getDefinition().getSchema())
+        .map(SchemaAndPrimaryKeyColumns::of)
         .orElse(null);
   }
 
   private Object lock(ConcurrentMap<TableId, Object> locks, TableId table) {
     return locks.computeIfAbsent(table, t -> new Object());
+  }
+
+  static class SchemaAndPrimaryKeyColumns {
+
+    private final com.google.cloud.bigquery.Schema schema;
+    private final List<String> primaryKeyColumns;
+
+    public static SchemaAndPrimaryKeyColumns of(Table table) {
+      return of(table.getDefinition(), table.getTableConstraints());
+    }
+
+    public static SchemaAndPrimaryKeyColumns of(TableInfo tableInfo) {
+      return of(tableInfo.getDefinition(), tableInfo.getTableConstraints());
+    }
+
+    private static SchemaAndPrimaryKeyColumns of(TableDefinition tableDefinition, TableConstraints tableConstraints) {
+      com.google.cloud.bigquery.Schema schema = tableDefinition.getSchema();
+
+      List<String> primaryKeyColumns = Optional.ofNullable(tableConstraints)
+          .map(TableConstraints::getPrimaryKey)
+          .map(PrimaryKey::getColumns)
+          .orElseGet(Collections::emptyList);
+
+      return new SchemaAndPrimaryKeyColumns(schema, primaryKeyColumns);
+    }
+
+    public SchemaAndPrimaryKeyColumns(com.google.cloud.bigquery.Schema schema, List<String> primaryKeyColumns) {
+      this.schema = schema;
+      this.primaryKeyColumns = primaryKeyColumns;
+    }
+
+    public com.google.cloud.bigquery.Schema getSchema() {
+      return schema;
+    }
+
+    public List<String> getPrimaryKeyColumns() {
+      return primaryKeyColumns;
+    }
   }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -55,6 +55,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
@@ -755,8 +756,17 @@ public class SchemaManager {
     if (kafkaKeyFieldName.isPresent()) {
       com.google.cloud.bigquery.Schema keySchema = schemaConverter.convertSchema(kafkaKeySchema);
       if (kafkaKeyFieldName.get().isEmpty()) {
-        // TODO: Gracefully handle collisions with value/TPO field names
-        fields.addAll(keySchema.getFields());
+        // Deduplicate: skip key fields already present in the value schema.
+        // When using Debezium with ExtractNewRecordState SMT, the value payload already
+        // contains all columns (including primary keys), so a naive addAll() of the
+        // flattened key schema produces duplicate field names and BigQuery rejects
+        // the CREATE TABLE with "Field X already exists in schema".
+        Set<String> existingFieldNames = fields.stream()
+            .map(Field::getName)
+            .collect(Collectors.toSet());
+        keySchema.getFields().stream()
+            .filter(kf -> !existingFieldNames.contains(kf.getName()))
+            .forEach(fields::add);
         primaryKeyColumns = keySchema.getFields().stream()
             .map(Field::getName)
             .collect(Collectors.toList());

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -351,10 +351,10 @@ public class BigQuerySinkConfig extends AbstractConfig {
           + "front of field name. Note: field a.b and a_b will have same value after sanitizing, "
           + "and might cause key duplication error.";
   private static final ConfigDef.Type KAFKA_KEY_FIELD_NAME_TYPE = ConfigDef.Type.STRING;
-  private static final ConfigDef.Validator KAFKA_KEY_FIELD_NAME_VALIDATOR = new ConfigDef.NonEmptyString();
   private static final ConfigDef.Importance KAFKA_KEY_FIELD_NAME_IMPORTANCE = ConfigDef.Importance.LOW;
   private static final String KAFKA_KEY_FIELD_NAME_DOC = "The name of the field of Kafka key. "
-      + "Default to be null, which means Kafka Key Field will not be included.";
+      + "Default to be null, which means Kafka Key Field will not be included. "
+      + "To include all fields from the key in the top-level record, specify a blank string for this property.";
   private static final ConfigDef.Type KAFKA_DATA_FIELD_NAME_TYPE = ConfigDef.Type.STRING;
   private static final ConfigDef.Validator KAFKA_DATA_FIELD_NAME_VALIDATOR = new ConfigDef.NonEmptyString();
   private static final ConfigDef.Importance KAFKA_DATA_FIELD_NAME_IMPORTANCE = ConfigDef.Importance.LOW;
@@ -754,7 +754,6 @@ public class BigQuerySinkConfig extends AbstractConfig {
                     KAFKA_KEY_FIELD_NAME_CONFIG,
                     KAFKA_KEY_FIELD_NAME_TYPE,
                     KAFKA_KEY_FIELD_NAME_DEFAULT,
-                    KAFKA_KEY_FIELD_NAME_VALIDATOR,
                     KAFKA_KEY_FIELD_NAME_IMPORTANCE,
                     KAFKA_KEY_FIELD_NAME_DOC
             ).define(
@@ -1224,6 +1223,14 @@ public class BigQuerySinkConfig extends AbstractConfig {
 
   public boolean isUpsertDeleteEnabled() {
     return getBoolean(UPSERT_ENABLED_CONFIG) || getBoolean(DELETE_ENABLED_CONFIG);
+  }
+
+  public boolean isUpsertEnabled() {
+    return getBoolean(UPSERT_ENABLED_CONFIG);
+  }
+
+  public boolean isDeleteEnabled() {
+    return getBoolean(DELETE_ENABLED_CONFIG);
   }
 
   public boolean isIgnoreUnknownFields() {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/StorageWriteApiValidator.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/StorageWriteApiValidator.java
@@ -24,10 +24,8 @@
 package com.wepay.kafka.connect.bigquery.config;
 
 import static com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.BIGQUERY_PARTITION_DECORATOR_CONFIG;
-import static com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.DELETE_ENABLED_CONFIG;
 import static com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.ENABLE_BATCH_CONFIG;
 import static com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.ENABLE_BATCH_MODE_CONFIG;
-import static com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.UPSERT_ENABLED_CONFIG;
 import static com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.USE_STORAGE_WRITE_API_CONFIG;
 
 import java.util.Arrays;
@@ -37,18 +35,14 @@ import java.util.Optional;
 
 public class StorageWriteApiValidator extends MultiPropertyValidator<BigQuerySinkConfig> {
 
-  public static final String upsertNotSupportedError = "Upsert mode is not supported with Storage Write API."
-      + " Either disable Upsert mode or disable Storage Write API";
   public static final String legacyBatchNotSupportedError = "Legacy Batch mode is not supported with Storage Write API."
       + " Either disable Legacy Batch mode or disable Storage Write API";
   public static final String newBatchNotSupportedError = "Storage Write Api Batch load is supported only when useStorageWriteApi is "
       + "enabled. Either disable batch mode or enable Storage Write API";
-  public static final String deleteNotSupportedError = "Delete mode is not supported with Storage Write API. Either disable Delete mode "
-      + "or disable Storage Write API";
   public static final String partitionDecoratorNewBatchNotSupported = "Partition decorator syntax is not supported with Storage Write API Batch Load. "
                   + "It is currently only available when using the Storage Write API default stream.";
   private static final Collection<String> DEPENDENTS = Collections.unmodifiableCollection(Arrays.asList(
-      UPSERT_ENABLED_CONFIG, DELETE_ENABLED_CONFIG, ENABLE_BATCH_CONFIG
+      ENABLE_BATCH_CONFIG
   ));
 
   protected StorageWriteApiValidator(String propertyName) {
@@ -73,11 +67,7 @@ public class StorageWriteApiValidator extends MultiPropertyValidator<BigQuerySin
       //No legacy modes validation needed if not using new api
       return Optional.empty();
     }
-    if (config.getBoolean(UPSERT_ENABLED_CONFIG)) {
-      return Optional.of(upsertNotSupportedError);
-    } else if (config.getBoolean(DELETE_ENABLED_CONFIG)) {
-      return Optional.of(deleteNotSupportedError);
-    } else if (!config.getList(ENABLE_BATCH_CONFIG).isEmpty()) {
+    if (!config.getList(ENABLE_BATCH_CONFIG).isEmpty()) {
       return Optional.of(legacyBatchNotSupportedError);
     } else if (config.originals().containsKey(BIGQUERY_PARTITION_DECORATOR_CONFIG)
         && config.getBoolean(BIGQUERY_PARTITION_DECORATOR_CONFIG) && config.getBoolean(ENABLE_BATCH_MODE_CONFIG)
@@ -96,3 +86,4 @@ public class StorageWriteApiValidator extends MultiPropertyValidator<BigQuerySin
     }
   }
 }
+

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/UpsertDeleteValidator.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/UpsertDeleteValidator.java
@@ -28,6 +28,7 @@ import static com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.KAFKA_K
 import static com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.MERGE_INTERVAL_MS_CONFIG;
 import static com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.MERGE_RECORDS_THRESHOLD_CONFIG;
 import static com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.UPSERT_ENABLED_CONFIG;
+import static com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig.USE_STORAGE_WRITE_API_CONFIG;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -38,7 +39,9 @@ import org.slf4j.LoggerFactory;
 
 public abstract class UpsertDeleteValidator extends MultiPropertyValidator<BigQuerySinkConfig> {
   private static final Collection<String> DEPENDENTS = Collections.unmodifiableCollection(Arrays.asList(
-      MERGE_INTERVAL_MS_CONFIG, MERGE_RECORDS_THRESHOLD_CONFIG, KAFKA_KEY_FIELD_NAME_CONFIG
+      MERGE_INTERVAL_MS_CONFIG, MERGE_RECORDS_THRESHOLD_CONFIG,
+      KAFKA_KEY_FIELD_NAME_CONFIG,
+      USE_STORAGE_WRITE_API_CONFIG
   ));
   private static final Logger logger = LoggerFactory.getLogger(UpsertDeleteValidator.class);
 
@@ -57,31 +60,75 @@ public abstract class UpsertDeleteValidator extends MultiPropertyValidator<BigQu
       return Optional.empty();
     }
 
-    long mergeInterval = config.getLong(MERGE_INTERVAL_MS_CONFIG);
-    long mergeRecordsThreshold = config.getLong(MERGE_RECORDS_THRESHOLD_CONFIG);
+    if (!config.getBoolean(USE_STORAGE_WRITE_API_CONFIG)) {
+      // Classic MERGE path: merge interval, threshold and kafkaKeyFieldName are all required
+      long mergeInterval = config.getLong(MERGE_INTERVAL_MS_CONFIG);
+      long mergeRecordsThreshold = config.getLong(MERGE_RECORDS_THRESHOLD_CONFIG);
 
-    if (mergeInterval == -1 && mergeRecordsThreshold == -1) {
-      return Optional.of(String.format(
-          "%s and %s cannot both be -1",
-          MERGE_INTERVAL_MS_CONFIG,
-          MERGE_RECORDS_THRESHOLD_CONFIG
-      ));
-    }
+      if (mergeInterval == -1 && mergeRecordsThreshold == -1) {
+        return Optional.of(String.format(
+            "%s and %s cannot both be -1",
+            MERGE_INTERVAL_MS_CONFIG,
+            MERGE_RECORDS_THRESHOLD_CONFIG
+        ));
+      }
 
-    if (mergeInterval != -1 && mergeInterval < 10_000L) {
-      logger.warn(String.format(
-          "%s should not be set to less than 10 seconds. A validation would be introduced in a future release to "
-              + "this effect.",
-          MERGE_INTERVAL_MS_CONFIG
-      ));
-    }
+      if (mergeInterval != -1 && mergeInterval < 10_000L) {
+        logger.warn(
+            "{} should not be set to less than 10 seconds. "
+                + "A validation would be introduced in a future release to this effect.",
+            MERGE_INTERVAL_MS_CONFIG
+        );
+      }
 
-    if (!config.getKafkaKeyFieldName().isPresent()) {
-      return Optional.of(String.format(
-          "%s must be specified when %s is set to true",
-          KAFKA_KEY_FIELD_NAME_CONFIG,
-          propertyName()
-      ));
+      if (!config.getKafkaKeyFieldName().isPresent()) {
+        return Optional.of(String.format(
+            "%s must be specified when %s is set to true",
+            KAFKA_KEY_FIELD_NAME_CONFIG,
+            propertyName()
+        ));
+      }
+    } else {
+      // Storage Write API CDC path
+      for (String property : Arrays.asList(MERGE_INTERVAL_MS_CONFIG, MERGE_RECORDS_THRESHOLD_CONFIG)) {
+        if (config.originals().containsKey(property)) {
+          logger.warn("The {} property will be ignored because {} is set to true",
+              property,
+              USE_STORAGE_WRITE_API_CONFIG
+          );
+        }
+      }
+
+      // Delete-only mode is not supported with the Storage Write API
+      if (!config.isUpsertEnabled() && config.isDeleteEnabled()) {
+        return Optional.of(String.format(
+            "Delete-only mode is not supported when the Storage Write API is enabled "
+                + "(%s = true); please either disable delete support (set %s to false) "
+                + "or enable upsert support (set %s to true)",
+            USE_STORAGE_WRITE_API_CONFIG,
+            DELETE_ENABLED_CONFIG,
+            UPSERT_ENABLED_CONFIG
+        ));
+      }
+
+      // When using Storage Write API + upsert, kafkaKeyFieldName must be empty string (or null,
+      // in which case we default to empty string and warn). Any non-empty value is rejected because
+      // key fields must be flattened into the top-level record to serve as primary keys.
+      Optional<String> kafkaKeyFieldName = config.getKafkaKeyFieldName();
+      if (!kafkaKeyFieldName.isPresent()) {
+        logger.warn(
+            "Defaulting to a value of '' for the {} property because both "
+                + "upsert/delete support and the Storage Write API are both enabled",
+            KAFKA_KEY_FIELD_NAME_CONFIG
+        );
+      } else if (!"".equals(kafkaKeyFieldName.get())) {
+        return Optional.of(String.format(
+            "The only accepted value for the %s property is '' (empty string) when "
+                + "upsert/delete support and the Storage Write API are both enabled. "
+                + "Key fields will be flattened into the top-level record and used as primary keys.",
+            KAFKA_KEY_FIELD_NAME_CONFIG
+        ));
+      }
     }
 
     return Optional.empty();

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBase.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBase.java
@@ -29,9 +29,14 @@ import com.google.cloud.bigquery.storage.v1.AppendRowsResponse;
 import com.google.cloud.bigquery.storage.v1.BigQueryWriteClient;
 import com.google.cloud.bigquery.storage.v1.BigQueryWriteSettings;
 import com.google.cloud.bigquery.storage.v1.Exceptions;
+import com.google.cloud.bigquery.storage.v1.GetWriteStreamRequest;
 import com.google.cloud.bigquery.storage.v1.JsonStreamWriter;
 import com.google.cloud.bigquery.storage.v1.RowError;
+import com.google.cloud.bigquery.storage.v1.TableFieldSchema;
 import com.google.cloud.bigquery.storage.v1.TableName;
+import com.google.cloud.bigquery.storage.v1.TableSchema;
+import com.google.cloud.bigquery.storage.v1.WriteStream;
+import com.google.cloud.bigquery.storage.v1.WriteStreamView;
 import com.google.common.annotations.VisibleForTesting;
 import com.wepay.kafka.connect.bigquery.ErrantRecordHandler;
 import com.wepay.kafka.connect.bigquery.SchemaManager;
@@ -52,6 +57,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.json.JSONArray;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.threeten.bp.Duration;
@@ -62,6 +68,7 @@ import org.threeten.bp.Duration;
 public abstract class StorageWriteApiBase {
 
   private static final Logger logger = LoggerFactory.getLogger(StorageWriteApiBase.class);
+  protected static final String CHANGE_TYPE_PSEUDO_COLUMN = "_CHANGE_TYPE";
   private static final double RETRY_DELAY_MULTIPLIER = 1.1;
   private static final int MAX_RETRY_DELAY_MINUTES = 1;
   public static final String TRACE_ID_FORMAT = "AivenKafkaConnector:%s";
@@ -72,6 +79,8 @@ public abstract class StorageWriteApiBase {
   private final boolean ignoreUnknownFields;
   private final BigQueryWriteSettings writeSettings;
   private final boolean attemptSchemaUpdate;
+  protected final boolean upsertEnabled;
+  protected final boolean deleteEnabled;
   protected SchemaManager schemaManager;
   @VisibleForTesting
   protected Time time;
@@ -101,6 +110,8 @@ public abstract class StorageWriteApiBase {
     this.errantRecordHandler = errantRecordHandler;
     this.schemaManager = schemaManager;
     this.attemptSchemaUpdate = attemptSchemaUpdate;
+    this.upsertEnabled = config.isUpsertEnabled();
+    this.deleteEnabled = config.isDeleteEnabled();
     this.ignoreUnknownFields = config.isIgnoreUnknownFields();
     try {
       this.writeClient = getWriteClient();
@@ -140,6 +151,8 @@ public abstract class StorageWriteApiBase {
     this.schemaManager = schemaManager;
     this.attemptSchemaUpdate = attemptSchemaUpdate;
     this.ignoreUnknownFields = false;
+    this.upsertEnabled = false;
+    this.deleteEnabled = false;
     try {
       this.writeClient = getWriteClient();
     } catch (IOException e) {
@@ -365,6 +378,32 @@ public abstract class StorageWriteApiBase {
     return String.format(TRACE_ID_FORMAT, "default");
   }
 
+  private TableSchema getTableSchemaWithPseudoColumns(String streamName) {
+    try {
+      GetWriteStreamRequest writeStreamRequest = GetWriteStreamRequest.newBuilder()
+          .setName(streamName)
+          .setView(WriteStreamView.FULL)
+          .build();
+      WriteStream writeStream = writeClient.getWriteStream(writeStreamRequest);
+      TableSchema.Builder writeSchema = writeStream.hasTableSchema()
+          ? writeStream.getTableSchema().toBuilder()
+          : TableSchema.newBuilder();
+      if (upsertEnabled || deleteEnabled) {
+        writeSchema.addFields(
+            TableFieldSchema.newBuilder()
+                .setName(CHANGE_TYPE_PSEUDO_COLUMN)
+                .setType(TableFieldSchema.Type.STRING)
+                .setMode(TableFieldSchema.Mode.NULLABLE)
+                .build()
+        );
+      }
+      return writeSchema.build();
+    } catch (Exception e) {
+      logger.warn("Failed to fetch schema for stream " + streamName, e);
+      return null;
+    }
+  }
+
   /**
    * Returns a {@link JsonStreamWriterFactory} for creating configured {@link JsonStreamWriter} instances
    *
@@ -378,8 +417,20 @@ public abstract class StorageWriteApiBase {
             .setMaxRetryDelay(Duration.ofMinutes(MAX_RETRY_DELAY_MINUTES))
             .build();
     return streamOrTableName -> {
-      JsonStreamWriter.Builder builder = JsonStreamWriter.newBuilder(streamOrTableName, writeClient)
-              .setRetrySettings(retrySettings)
+      String streamNameForSchema = streamOrTableName;
+      if (!streamNameForSchema.contains("/streams/")) {
+        streamNameForSchema += "/_default";
+      }
+
+      TableSchema tableSchema = getTableSchemaWithPseudoColumns(streamNameForSchema);
+
+      JsonStreamWriter.Builder builder;
+      if (tableSchema != null) {
+        builder = JsonStreamWriter.newBuilder(streamOrTableName, tableSchema, writeClient);
+      } else {
+        builder = JsonStreamWriter.newBuilder(streamOrTableName, writeClient);
+      }
+      builder.setRetrySettings(retrySettings)
               .setIgnoreUnknownFields(ignoreUnknownFields)
               .setTraceId(generateTraceId());
       updateJsonStreamWriterBuilder(builder);
@@ -493,7 +544,13 @@ public abstract class StorageWriteApiBase {
   private JSONArray getJsonRecords(List<ConvertedRecord> rows) {
     JSONArray jsonRecords = new JSONArray();
     for (ConvertedRecord item : rows) {
-      jsonRecords.put(item.converted());
+      JSONObject converted = item.converted();
+      if (item.original().value() != null && upsertEnabled) {
+        converted.put(CHANGE_TYPE_PSEUDO_COLUMN, "UPSERT");
+      } else if (item.original().value() == null && deleteEnabled) {
+        converted.put(CHANGE_TYPE_PSEUDO_COLUMN, "DELETE");
+      }
+      jsonRecords.put(converted);
     }
     return jsonRecords;
   }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiWriter.java
@@ -25,11 +25,13 @@ package com.wepay.kafka.connect.bigquery.write.storage;
 
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.storage.v1.TableName;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
 import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
 import com.wepay.kafka.connect.bigquery.utils.SinkRecordConverter;
 import com.wepay.kafka.connect.bigquery.utils.TableNameUtils;
 import com.wepay.kafka.connect.bigquery.write.batch.TableWriterBuilder;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -91,6 +93,7 @@ public class StorageWriteApiWriter implements Runnable {
   public static class Builder implements TableWriterBuilder {
     private final List<ConvertedRecord> records = new ArrayList<>();
     private final SinkRecordConverter recordConverter;
+    private final BigQuerySinkTaskConfig config;
     private final PartitionedTableId table;
     private final StorageWriteApiBase streamWriter;
     private final StorageApiBatchModeHandler batchModeHandler;
@@ -103,16 +106,26 @@ public class StorageWriteApiWriter implements Runnable {
                    TableName tableName,
                    SinkRecordConverter recordConverter,
                    StorageApiBatchModeHandler batchModeHandler) {
-      this(streamWriter, TableNameUtils.partitionedTableId(tableName), recordConverter, batchModeHandler);
+      this(streamWriter, TableNameUtils.partitionedTableId(tableName), recordConverter, null, batchModeHandler);
+    }
+
+    @Deprecated
+    public Builder(StorageWriteApiBase streamWriter,
+                   PartitionedTableId table,
+                   SinkRecordConverter recordConverter,
+                   StorageApiBatchModeHandler batchModeHandler) {
+      this(streamWriter, table, recordConverter, null, batchModeHandler);
     }
 
     public Builder(StorageWriteApiBase streamWriter,
                    PartitionedTableId table,
                    SinkRecordConverter recordConverter,
+                   BigQuerySinkTaskConfig config,
                    StorageApiBatchModeHandler batchModeHandler) {
       this.streamWriter = streamWriter;
       this.table = table;
       this.recordConverter = recordConverter;
+      this.config = config;
       this.batchModeHandler = batchModeHandler;
     }
 
@@ -147,7 +160,19 @@ public class StorageWriteApiWriter implements Runnable {
         TableName tableName = TableNameUtils.tableName(table.getBaseTableId());
         streamName = batchModeHandler.updateOffsetsOnStream(tableName.toString(), records);
       }
-      return new StorageWriteApiWriter(table, streamWriter, records, streamName);
+
+      final List<ConvertedRecord> recordsToWrite;
+      if (config != null && config.isUpsertEnabled()) {
+        Map<Object, ConvertedRecord> compactedRecords = new LinkedHashMap<>(16, 0.75f, true);
+        for (ConvertedRecord convertedRecord : records) {
+          compactedRecords.put(convertedRecord.original().key(), convertedRecord);
+        }
+        recordsToWrite = new ArrayList<>(compactedRecords.values());
+      } else {
+        recordsToWrite = this.records;
+      }
+
+      return new StorageWriteApiWriter(table, streamWriter, recordsToWrite, streamName);
     }
 
     private JSONObject getJsonFromMap(Map<String, Object> map) {

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
@@ -92,13 +92,13 @@ public class SchemaManagerTest {
     Optional<String> kafkaDataFieldName = Optional.of("kafkaData");
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, kafkaKeyFieldName, kafkaDataFieldName,
-        Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(TimePartitioning.Type.DAY));
+        Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(TimePartitioning.Type.DAY), false);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
 
     TableInfo tableInfo = schemaManager
-        .constructTableInfo(tableId, fakeBigQuerySchema, testDoc, true);
+        .constructTableInfo(tableId, new SchemaManager.SchemaAndPrimaryKeyColumns(fakeBigQuerySchema, java.util.Collections.emptyList()), testDoc, true);
 
     assertEquals(
         testDoc,
@@ -120,13 +120,13 @@ public class SchemaManagerTest {
     Optional<String> testField = Optional.of("testField");
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), testField,
-        Optional.empty(), Optional.empty(), Optional.of(TimePartitioning.Type.DAY));
+        Optional.empty(), Optional.empty(), Optional.of(TimePartitioning.Type.DAY), false);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
 
     TableInfo tableInfo = schemaManager
-        .constructTableInfo(tableId, fakeBigQuerySchema, testDoc, true);
+        .constructTableInfo(tableId, new SchemaManager.SchemaAndPrimaryKeyColumns(fakeBigQuerySchema, java.util.Collections.emptyList()), testDoc, true);
 
     assertEquals(
         testDoc,
@@ -151,13 +151,13 @@ public class SchemaManagerTest {
   public void testAlternativeTimestampPartitionType() {
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), Optional.empty(),
-        Optional.empty(), Optional.empty(), Optional.of(TimePartitioning.Type.HOUR));
+        Optional.empty(), Optional.empty(), Optional.of(TimePartitioning.Type.HOUR), false);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
 
     TableInfo tableInfo = schemaManager
-        .constructTableInfo(tableId, fakeBigQuerySchema, testDoc, true);
+        .constructTableInfo(tableId, new SchemaManager.SchemaAndPrimaryKeyColumns(fakeBigQuerySchema, java.util.Collections.emptyList()), testDoc, true);
 
     assertEquals(
         testDoc,
@@ -173,13 +173,13 @@ public class SchemaManagerTest {
   public void testNoTimestampPartitionType() {
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), Optional.empty(),
-        Optional.empty(), Optional.empty(), Optional.empty());
+        Optional.empty(), Optional.empty(), Optional.empty(), false);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
 
     TableInfo tableInfo = schemaManager
-        .constructTableInfo(tableId, fakeBigQuerySchema, testDoc, true);
+        .constructTableInfo(tableId, new SchemaManager.SchemaAndPrimaryKeyColumns(fakeBigQuerySchema, java.util.Collections.emptyList()), testDoc, true);
 
     assertEquals(
         testDoc,
@@ -195,13 +195,13 @@ public class SchemaManagerTest {
     Optional<String> testField = Optional.of("testField");
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), testField,
-        Optional.empty(), Optional.empty(), Optional.of(TimePartitioning.Type.DAY));
+        Optional.empty(), Optional.empty(), Optional.of(TimePartitioning.Type.DAY), false);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
 
     TableInfo tableInfo = schemaManager
-        .constructTableInfo(tableId, fakeBigQuerySchema, testDoc, false);
+        .constructTableInfo(tableId, new SchemaManager.SchemaAndPrimaryKeyColumns(fakeBigQuerySchema, java.util.Collections.emptyList()), testDoc, false);
 
     assertEquals(
         testDoc,
@@ -219,13 +219,13 @@ public class SchemaManagerTest {
     Optional<String> testField = Optional.of("testField");
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), testField,
-        Optional.empty(), Optional.empty(), Optional.of(TimePartitioning.Type.DAY));
+        Optional.empty(), Optional.empty(), Optional.of(TimePartitioning.Type.DAY), false);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
 
     TableInfo tableInfo = schemaManager
-        .constructTableInfo(tableId, fakeBigQuerySchema, testDoc, true);
+        .constructTableInfo(tableId, new SchemaManager.SchemaAndPrimaryKeyColumns(fakeBigQuerySchema, java.util.Collections.emptyList()), testDoc, true);
 
     assertEquals(
         testDoc,
@@ -243,10 +243,10 @@ public class SchemaManagerTest {
     Optional<String> updateField = Optional.of("testUpdateField");
     schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), updateField, Optional.empty(), Optional.empty(),
-        Optional.of(TimePartitioning.Type.DAY));
+        Optional.of(TimePartitioning.Type.DAY), false);
 
     tableInfo = schemaManager
-        .constructTableInfo(tableId, fakeBigQuerySchema, testDoc, false);
+        .constructTableInfo(tableId, new SchemaManager.SchemaAndPrimaryKeyColumns(fakeBigQuerySchema, java.util.Collections.emptyList()), testDoc, false);
     definition = tableInfo.getDefinition();
     assertNull(
         ((StandardTableDefinition) tableInfo.getDefinition()).getTimePartitioning(),
@@ -259,13 +259,13 @@ public class SchemaManagerTest {
     Optional<Long> testExpirationMs = Optional.of(86400000L);
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), Optional.empty(),
-        testExpirationMs, Optional.empty(), Optional.of(TimePartitioning.Type.DAY));
+        testExpirationMs, Optional.empty(), Optional.of(TimePartitioning.Type.DAY), false);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
 
     TableInfo tableInfo = schemaManager
-        .constructTableInfo(tableId, fakeBigQuerySchema, testDoc, true);
+        .constructTableInfo(tableId, new SchemaManager.SchemaAndPrimaryKeyColumns(fakeBigQuerySchema, java.util.Collections.emptyList()), testDoc, true);
 
     assertEquals(
         testDoc,
@@ -290,13 +290,13 @@ public class SchemaManagerTest {
     Optional<String> testField = Optional.of("testField");
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), testField,
-        testExpirationMs, Optional.empty(), Optional.of(TimePartitioning.Type.DAY));
+        testExpirationMs, Optional.empty(), Optional.of(TimePartitioning.Type.DAY), false);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
 
     TableInfo tableInfo = schemaManager
-        .constructTableInfo(tableId, fakeBigQuerySchema, testDoc, true);
+        .constructTableInfo(tableId, new SchemaManager.SchemaAndPrimaryKeyColumns(fakeBigQuerySchema, java.util.Collections.emptyList()), testDoc, true);
 
     assertEquals(
         testDoc,
@@ -322,13 +322,13 @@ public class SchemaManagerTest {
     Optional<List<String>> testField = Optional.of(Arrays.asList("column1", "column2"));
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), timestampPartitionFieldName,
-        Optional.empty(), testField, Optional.of(TimePartitioning.Type.DAY));
+        Optional.empty(), testField, Optional.of(TimePartitioning.Type.DAY), false);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
 
     TableInfo tableInfo = schemaManager
-        .constructTableInfo(tableId, fakeBigQuerySchema, testDoc, true);
+        .constructTableInfo(tableId, new SchemaManager.SchemaAndPrimaryKeyColumns(fakeBigQuerySchema, java.util.Collections.emptyList()), testDoc, true);
 
     assertEquals(
         testDoc,
@@ -350,13 +350,13 @@ public class SchemaManagerTest {
     Optional<List<String>> testField = Optional.of(Arrays.asList("column1", "column2"));
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), timestampPartitionFieldName,
-        Optional.empty(), testField, Optional.of(TimePartitioning.Type.DAY));
+        Optional.empty(), testField, Optional.of(TimePartitioning.Type.DAY), false);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
 
     TableInfo tableInfo = schemaManager
-        .constructTableInfo(tableId, fakeBigQuerySchema, testDoc, false);
+        .constructTableInfo(tableId, new SchemaManager.SchemaAndPrimaryKeyColumns(fakeBigQuerySchema, java.util.Collections.emptyList()), testDoc, false);
 
     assertEquals(
         testDoc,
@@ -376,13 +376,13 @@ public class SchemaManagerTest {
     Optional<List<String>> testField = Optional.of(Arrays.asList("column1", "column2"));
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), timestampPartitionFieldName,
-        Optional.empty(), testField, Optional.of(TimePartitioning.Type.DAY));
+        Optional.empty(), testField, Optional.of(TimePartitioning.Type.DAY), false);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
 
     TableInfo tableInfo = schemaManager
-        .constructTableInfo(tableId, fakeBigQuerySchema, testDoc, true);
+        .constructTableInfo(tableId, new SchemaManager.SchemaAndPrimaryKeyColumns(fakeBigQuerySchema, java.util.Collections.emptyList()), testDoc, true);
 
     assertEquals(
         testDoc,
@@ -400,10 +400,10 @@ public class SchemaManagerTest {
     Optional<List<String>> updateTestField = Optional.of(Arrays.asList("column3", "column4"));
     schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), timestampPartitionFieldName,
-        Optional.empty(), updateTestField, Optional.of(TimePartitioning.Type.DAY));
+        Optional.empty(), updateTestField, Optional.of(TimePartitioning.Type.DAY), false);
 
     tableInfo = schemaManager
-        .constructTableInfo(tableId, fakeBigQuerySchema, testDoc, false);
+        .constructTableInfo(tableId, new SchemaManager.SchemaAndPrimaryKeyColumns(fakeBigQuerySchema, java.util.Collections.emptyList()), testDoc, false);
     definition = tableInfo.getDefinition();
     assertNull(
         definition.getClustering(),
@@ -825,7 +825,7 @@ public class SchemaManagerTest {
     return new SchemaManager(new IdentitySchemaRetriever(), converter, mockBigQuery,
         allowNewFields, allowFieldRelaxation, allowUnionization, sanitizeFieldNames,
         Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
-        Optional.of(TimePartitioning.Type.DAY));
+        Optional.of(TimePartitioning.Type.DAY), false);
   }
 
   private SchemaManager createSchemaManager(
@@ -833,7 +833,7 @@ public class SchemaManagerTest {
     return new SchemaManager(new IdentitySchemaRetriever(), mockSchemaConverter, mockBigQuery,
         allowNewFields, allowFieldRelaxation, allowUnionization, false,
         Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
-        Optional.of(TimePartitioning.Type.DAY));
+        Optional.of(TimePartitioning.Type.DAY), false);
   }
 
   private void testGetAndValidateProposedSchema(
@@ -874,7 +874,7 @@ public class SchemaManagerTest {
     }
 
     com.google.cloud.bigquery.Schema proposedSchema =
-        schemaManager.getAndValidateProposedSchema(tableId, incomingSinkRecords);
+        schemaManager.getAndValidateProposedSchema(tableId, incomingSinkRecords).getSchema();
 
     if (expectedSchema != null) {
       assertEquals(expectedSchema, proposedSchema);

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/StorageWriteApiValidatorTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/StorageWriteApiValidatorTest.java
@@ -62,7 +62,7 @@ public class StorageWriteApiValidatorTest {
   }
 
   @Test
-  public void testUpsertModeEnabled() {
+  public void testUpsertAndStorageWriteApiEnabled() {
     BigQuerySinkConfig config = mock(BigQuerySinkConfig.class);
 
     when(config.getBoolean(USE_STORAGE_WRITE_API_CONFIG)).thenReturn(true);
@@ -71,12 +71,12 @@ public class StorageWriteApiValidatorTest {
     when(config.getList(ENABLE_BATCH_CONFIG)).thenReturn(Collections.emptyList());
 
     assertEquals(
-        Optional.of(upsertNotSupportedError),
+        Optional.empty(),
         new StorageWriteApiValidator().doValidate(config));
   }
 
   @Test
-  public void testDeleteModeEnabled() {
+  public void testDeleteAndStorageWriteApiEnabled() {
     BigQuerySinkConfig config = mock(BigQuerySinkConfig.class);
 
     when(config.getBoolean(USE_STORAGE_WRITE_API_CONFIG)).thenReturn(true);
@@ -84,7 +84,7 @@ public class StorageWriteApiValidatorTest {
     when(config.getBoolean(DELETE_ENABLED_CONFIG)).thenReturn(true);
     when(config.getList(ENABLE_BATCH_CONFIG)).thenReturn(Collections.emptyList());
 
-    assertEquals(Optional.of(deleteNotSupportedError), new StorageWriteApiValidator().doValidate(config));
+    assertEquals(Optional.empty(), new StorageWriteApiValidator().doValidate(config));
   }
 
   @Test

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/StorageWriteApiUpsertDeleteIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/StorageWriteApiUpsertDeleteIT.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright 2020 Confluent, Inc.
+ *
+ * This software contains code derived from the WePay BigQuery Kafka Connector, Copyright WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wepay.kafka.connect.bigquery.integration;
+
+import static org.apache.kafka.clients.consumer.ConsumerConfig.MAX_POLL_RECORDS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
+import com.wepay.kafka.connect.bigquery.integration.utils.TableClearer;
+import com.wepay.kafka.connect.bigquery.retrieve.IdentitySchemaRetriever;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.json.JsonConverterConfig;
+import org.apache.kafka.connect.runtime.ConnectorConfig;
+import org.apache.kafka.connect.runtime.SinkConnectorConfig;
+import org.apache.kafka.connect.storage.Converter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Tag("integration")
+public class StorageWriteApiUpsertDeleteIT extends BaseConnectorIT {
+
+  private static final Logger logger = LoggerFactory.getLogger(StorageWriteApiUpsertDeleteIT.class);
+
+  private static final String CONNECTOR_NAME = "kcbq-sink-connector";
+  private static final int TASKS_MAX = 5;
+  private static final long NUM_RECORDS_PRODUCED = 100 * TASKS_MAX;
+
+  private BigQuery bigQuery;
+
+  @BeforeEach
+  public void setup() {
+    bigQuery = newBigQuery();
+    startConnect();
+  }
+
+  @AfterEach
+  public void close() {
+    bigQuery = null;
+    stopConnect();
+  }
+
+  private Map<String, String> upsertDeleteProps(
+      boolean upsert,
+      boolean delete) {
+    if (!upsert && !delete) {
+      throw new IllegalArgumentException("At least one of upsert or delete must be enabled");
+    }
+
+    Map<String, String> result = new HashMap<>();
+
+    // use the JSON converter with schemas enabled
+    result.put(KEY_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
+    result.put(VALUE_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
+    // Ensure that records are delivered across several different batches, so that preflight
+    // compaction doesn't handle all upsert logic before anything hits BigQuery
+    result.put(
+        CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX + MAX_POLL_RECORDS_CONFIG,
+        Long.toString(Math.max(1, NUM_RECORDS_PRODUCED / 10))
+    );
+
+    if (upsert) {
+      result.put(BigQuerySinkConfig.UPSERT_ENABLED_CONFIG, "true");
+    }
+    if (delete) {
+      result.put(BigQuerySinkConfig.DELETE_ENABLED_CONFIG, "true");
+    }
+
+    result.put(BigQuerySinkConfig.KAFKA_KEY_FIELD_NAME_CONFIG, "");
+
+    return result;
+  }
+
+  @Test
+  public void testUpsert() throws Throwable {
+    // create topic in Kafka
+    final String topic = suffixedTableOrTopic("test-upsert" + System.nanoTime());
+    // Make sure each task gets to read from at least one partition
+    connect.kafka().createTopic(topic, TASKS_MAX);
+
+    final String table = sanitizedTable(topic);
+    TableClearer.clearTables(bigQuery, dataset(), table);
+
+    // setup props for the sink connector
+    Map<String, String> props = baseConnectorProps(TASKS_MAX);
+    props.put(BigQuerySinkConfig.USE_STORAGE_WRITE_API_CONFIG, "true");
+    props.put(SinkConnectorConfig.TOPICS_CONFIG, topic);
+
+    props.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
+    props.put(BigQuerySinkConfig.SCHEMA_RETRIEVER_CONFIG, IdentitySchemaRetriever.class.getName());
+    props.put(BigQuerySinkConfig.TABLE_CREATE_CONFIG, "true");
+
+    // Enable only upsert and not delete
+    props.putAll(upsertDeleteProps(true, false));
+
+    // start a sink connector
+    connect.configureConnector(CONNECTOR_NAME, props);
+
+    // wait for tasks to spin up
+    waitForConnectorToStart(CONNECTOR_NAME, TASKS_MAX);
+
+    // Instantiate the converters we'll use to send records to the connector
+    Converter keyConverter = converter(true);
+    Converter valueConverter = converter(false);
+
+    // Send records to Kafka
+    for (int i = 0; i < NUM_RECORDS_PRODUCED; i++) {
+      // Each pair of records will share a key. Only the second record of each pair should be
+      // present in the table at the end of the test
+      String kafkaKey = key(keyConverter, topic, i / 2);
+      String kafkaValue = value(valueConverter, topic, i, false);
+      logger.debug("Sending message with key '{}' and value '{}' to topic '{}'", kafkaKey, kafkaValue, topic);
+      connect.kafka().produce(topic, kafkaKey, kafkaValue);
+    }
+
+    // wait for tasks to write to BigQuery and commit offsets for their records
+    waitForCommittedRecords(CONNECTOR_NAME, topic, NUM_RECORDS_PRODUCED, TASKS_MAX);
+
+    List<List<Object>> allRows = readAllRows(bigQuery, table, "k1");
+    List<List<Object>> expectedRows = LongStream.range(0, NUM_RECORDS_PRODUCED / 2)
+        .mapToObj(i -> Arrays.<Object>asList(
+            "another string",
+            (i - 1) % 3 == 0,
+            (i * 2 + 1) / 0.69,
+            i))
+        .collect(Collectors.toList());
+    assertEquals(expectedRows, allRows);
+  }
+
+  @Test
+  public void testUpsertDelete() throws Throwable {
+    // create topic in Kafka
+    final String topic = suffixedTableOrTopic("test-upsert-delete" + System.nanoTime());
+    // Make sure each task gets to read from at least one partition
+    connect.kafka().createTopic(topic, TASKS_MAX);
+
+    final String table = sanitizedTable(topic);
+    TableClearer.clearTables(bigQuery, dataset(), table);
+
+    // setup props for the sink connector
+    Map<String, String> props = baseConnectorProps(TASKS_MAX);
+    props.put(BigQuerySinkConfig.USE_STORAGE_WRITE_API_CONFIG, "true");
+    props.put(SinkConnectorConfig.TOPICS_CONFIG, topic);
+
+    props.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
+    props.put(BigQuerySinkConfig.SCHEMA_RETRIEVER_CONFIG, IdentitySchemaRetriever.class.getName());
+    props.put(BigQuerySinkConfig.TABLE_CREATE_CONFIG, "true");
+    props.put(BigQuerySinkConfig.ALL_BQ_FIELDS_NULLABLE_CONFIG, "true");
+
+    // Enable upsert and delete
+    props.putAll(upsertDeleteProps(true, true));
+
+    // start a sink connector
+    connect.configureConnector(CONNECTOR_NAME, props);
+
+    // wait for tasks to spin up
+    waitForConnectorToStart(CONNECTOR_NAME, TASKS_MAX);
+
+    // Instantiate the converters we'll use to send records to the connector
+    Converter keyConverter = converter(true);
+    Converter valueConverter = converter(false);
+
+    // Send records to Kafka
+    for (int i = 0; i < NUM_RECORDS_PRODUCED; i++) {
+      // Each pair of records will share a key. Only the second record of each pair should be
+      // present in the table at the end of the test
+      String kafkaKey = key(keyConverter, topic, i / 2);
+      // Every fourth record will be a tombstone, so every record pair with an odd-numbered key will be dropped
+      String kafkaValue = value(valueConverter, topic, i, i % 4 == 3);
+      logger.debug("Sending message with key '{}' and value '{}' to topic '{}'", kafkaKey, kafkaValue, topic);
+      connect.kafka().produce(topic, kafkaKey, kafkaValue);
+    }
+
+    // wait for tasks to write to BigQuery and commit offsets for their records
+    waitForCommittedRecords(CONNECTOR_NAME, topic, NUM_RECORDS_PRODUCED, TASKS_MAX);
+
+    // Since we have multiple rows per key, order by key and the f3 field (which should be
+    // monotonically increasing in insertion order)
+    List<List<Object>> allRows = readAllRows(bigQuery, table, "k1, f3");
+    List<List<Object>> expectedRows = LongStream.range(0, NUM_RECORDS_PRODUCED)
+        .filter(i -> i % 4 == 1)
+        .mapToObj(i -> Arrays.<Object>asList(
+            "another string",
+            i % 3 == 0,
+            i / 0.69,
+            i * 2 / 4))
+        .collect(Collectors.toList());
+    assertEquals(expectedRows, allRows);
+  }
+
+  @Test
+  @Disabled("Skipped during regular testing; comment-out annotation to run")
+  public void testUpsertDeleteHighThroughput() throws Throwable {
+    final long numRecords = 1_000_000L;
+    final int numPartitions = 10;
+    final int tasksMax = 1;
+
+    // create topic in Kafka
+    final String topic = suffixedTableOrTopic("test-upsert-delete-throughput");
+    connect.kafka().createTopic(topic, numPartitions);
+
+    final String table = sanitizedTable(topic);
+    TableClearer.clearTables(bigQuery, dataset(), table);
+
+    // Instantiate the converters we'll use to send records to the connector
+    Converter keyConverter = converter(true);
+    Converter valueConverter = converter(false);
+
+    // Send records to Kafka. Pre-populate Kafka before starting the connector as we want to measure
+    // the connector's throughput cleanly
+    logger.info("Pre-populating Kafka with test data");
+    for (int i = 0; i < numRecords; i++) {
+      if (i % 10000 == 0) {
+        logger.info("{} records produced so far", i);
+      }
+      // Each pair of records will share a key. Only the second record of each pair should be
+      // present in the table at the end of the test
+      String kafkaKey = key(keyConverter, topic, i / 2);
+      // Every fourth record will be a tombstone, so every record pair with an odd-numbered key will
+      // be dropped
+      String kafkaValue = value(valueConverter, topic, i, i % 4 == 3);
+      connect.kafka().produce(topic, kafkaKey, kafkaValue);
+    }
+
+    // setup props for the sink connector
+    // use a single task
+    Map<String, String> props = baseConnectorProps(tasksMax);
+    props.put(BigQuerySinkConfig.USE_STORAGE_WRITE_API_CONFIG, "true");
+    props.put(SinkConnectorConfig.TOPICS_CONFIG, topic);
+    // Allow for at most 10,000 records per call to poll
+    props.put(ConnectorConfig.CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX
+            + MAX_POLL_RECORDS_CONFIG,
+        "10000");
+    // Try to get at least 1 MB per partition with each request
+    props.put(ConnectorConfig.CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX
+            + ConsumerConfig.FETCH_MIN_BYTES_CONFIG,
+        Integer.toString(ConsumerConfig.DEFAULT_MAX_PARTITION_FETCH_BYTES * numPartitions));
+    // Wait up to one second for each batch to reach the requested size
+    props.put(ConnectorConfig.CONNECTOR_CLIENT_CONSUMER_OVERRIDES_PREFIX
+            + ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG,
+        "1000"
+    );
+
+    props.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
+    props.put(BigQuerySinkConfig.SCHEMA_RETRIEVER_CONFIG, IdentitySchemaRetriever.class.getName());
+    props.put(BigQuerySinkConfig.TABLE_CREATE_CONFIG, "true");
+
+    // Enable upsert and delete
+    props.putAll(upsertDeleteProps(true, true));
+
+    logger.info("Pre-population complete; creating connector");
+    long start = System.currentTimeMillis();
+    // start a sink connector
+    connect.configureConnector(CONNECTOR_NAME, props);
+
+    // wait for tasks to spin up
+    waitForConnectorToStart(CONNECTOR_NAME, tasksMax);
+
+    // wait for tasks to write to BigQuery and commit offsets for their records
+    waitForCommittedRecords(
+        CONNECTOR_NAME, Collections.singleton(topic), numRecords, tasksMax, TimeUnit.MINUTES.toMillis(10));
+    long time = System.currentTimeMillis() - start;
+    logger.info("All records have been read and committed by the connector; "
+        + "total time from start to finish: {} seconds", time / 1000.0);
+
+    // Since we have multiple rows per key, order by key and the f3 field (which should be
+    // monotonically increasing in insertion order)
+    List<List<Object>> allRows = readAllRows(bigQuery, table, "k1, f3");
+    List<List<Object>> expectedRows = LongStream.range(0, numRecords)
+        .filter(i -> i % 4 == 1)
+        .mapToObj(i -> Arrays.asList(
+            "another string",
+            i % 3 == 0,
+            i / 0.69,
+            Collections.singletonList(i * 2 / 4)))
+        .collect(Collectors.toList());
+    assertEquals(expectedRows, allRows);
+  }
+
+  private Converter converter(boolean isKey) {
+    Map<String, Object> props = new HashMap<>();
+    props.put(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, true);
+    Converter result = new JsonConverter();
+    result.configure(props, isKey);
+    return result;
+  }
+
+  private String key(Converter converter, String topic, long iteration) {
+    final Schema schema = SchemaBuilder.struct()
+        .field("k1", Schema.INT64_SCHEMA)
+        .build();
+
+    final Struct struct = new Struct(schema)
+        .put("k1", iteration);
+
+    return new String(converter.fromConnectData(topic, schema, struct));
+  }
+
+  private String value(Converter converter, String topic, long iteration, boolean tombstone) {
+    final Schema schema = SchemaBuilder.struct()
+        .optional()
+        .field("f1", Schema.STRING_SCHEMA)
+        .field("f2", Schema.BOOLEAN_SCHEMA)
+        .field("f3", Schema.FLOAT64_SCHEMA)
+        .build();
+
+    if (tombstone) {
+      return new String(converter.fromConnectData(topic, schema, null));
+    }
+
+    final Struct struct = new Struct(schema)
+        .put("f1", iteration % 2 == 0 ? "a string" : "another string")
+        .put("f2", iteration % 3 == 0)
+        .put("f3", iteration / 0.69);
+
+    return new String(converter.fromConnectData(topic, schema, struct));
+  }
+}


### PR DESCRIPTION
## Problem

When using this connector with **Debezium** and the `ExtractNewRecordState` (EoT) SMT, the value payload already contains all columns — including primary keys. The flatten-key path introduced in #185 calls `fields.addAll(keySchema.getFields())` without checking for duplicates, which causes BigQuery to reject the `CREATE TABLE` with:

```
Field <X> already exists in schema
```

The `TODO` comment in the code acknowledges this gap:
```java
// TODO: Gracefully handle collisions with value/TPO field names
fields.addAll(keySchema.getFields());
```

## Fix

Filter key fields to only add those whose names are not already present in the accumulated field list:

```java
Set<String> existingFieldNames = fields.stream()
    .map(Field::getName)
    .collect(Collectors.toSet());
keySchema.getFields().stream()
    .filter(kf -> !existingFieldNames.contains(kf.getName()))
    .forEach(fields::add);
```

This resolves the collision without changing behavior when there are no duplicates (i.e. non-Debezium setups where the key and value schemas don't overlap).

## Testing

Verified against a live MariaDB → Debezium → Kafka → BigQuery pipeline using `kafkaKeyFieldName` set to `""` (flatten mode). Before this fix the connector failed at table creation; after the fix it creates the table and syncs rows correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)