### PR TITLE
feat(TECH-260403): fix partition not assigned by rerouting topics

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+**/.git
+**/.github
+**/target
+**/.idea
+**/*.iml
+**/.vscode
+**/node_modules
+**/.DS_Store

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,10 @@
+FROM maven:3.9.9-eclipse-temurin-17
+
+WORKDIR /src
+COPY . .
+
+ARG SKIP_UNIT_TESTS=false
+ENV SKIP_UNIT_TESTS=${SKIP_UNIT_TESTS}
+
+RUN --mount=type=cache,target=/root/.m2 \
+    sh -c 'if [ "$SKIP_UNIT_TESTS" = "true" ]; then mvn -B package -DskipTests -DskipITs; else mvn -B package -DskipITs; fi'

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConnectOffsets.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConnectOffsets.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024 Copyright 2022 Aiven Oy and
+ * bigquery-connector-for-apache-kafka project contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wepay.kafka.connect.bigquery.utils;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+/**
+ * Resolves the Kafka consumer {@link TopicPartition} and offset for Connect offset commits.
+ * After SMTs that rename topics (e.g. RegexRouter), {@link SinkRecord#topic()} no longer matches
+ * the assigned partition; Connect 3.6+ exposes {@link SinkRecord#originalTopic()} and related
+ * fields for this case (see {@code SinkRecord} Javadoc).
+ */
+public final class SinkRecordConnectOffsets {
+
+  private SinkRecordConnectOffsets() {
+  }
+
+  /**
+   * Topic and partition as assigned on the consumer, before any transformation.
+   */
+  public static TopicPartition topicPartitionForCommit(SinkRecord record) {
+    String topic;
+    Integer partition;
+    try {
+      topic = record.originalTopic();
+      partition = record.originalKafkaPartition();
+    } catch (NoSuchMethodError e) {
+      topic = record.topic();
+      partition = record.kafkaPartition();
+    }
+    if (topic == null) {
+      topic = record.topic();
+    }
+    if (partition == null) {
+      partition = record.kafkaPartition();
+    }
+    if (topic == null || partition == null) {
+      throw new IllegalStateException("SinkRecord missing topic or partition for offset commit");
+    }
+    return new TopicPartition(topic, partition);
+  }
+
+  /**
+   * Next offset to resume after this record (exclusive), i.e. {@code originalKafkaOffset + 1} when available.
+   */
+  public static long nextOffsetExclusiveForCommit(SinkRecord record) {
+    try {
+      return record.originalKafkaOffset() + 1;
+    } catch (NoSuchMethodError e) {
+      return record.kafkaOffset() + 1;
+    }
+  }
+}

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/MergeBatches.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/MergeBatches.java
@@ -34,6 +34,7 @@ import com.google.common.collect.Maps;
 import com.wepay.kafka.connect.bigquery.MergeQueries;
 import com.wepay.kafka.connect.bigquery.exception.ExpectedInterruptException;
 import com.wepay.kafka.connect.bigquery.utils.FieldNameSanitizer;
+import com.wepay.kafka.connect.bigquery.utils.SinkRecordConnectOffsets;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -360,11 +361,11 @@ public class MergeBatches {
 
     public void recordOffsetFor(SinkRecord record) {
       offsets.put(
-          new TopicPartition(record.topic(), record.kafkaPartition()),
+          SinkRecordConnectOffsets.topicPartitionForCommit(record),
           // Use the offset of the record plus one here since that'll be the offset that we'll
           // resume at if/when this record is the last-committed record and then the task is
           // restarted
-          record.kafkaOffset() + 1);
+          SinkRecordConnectOffsets.nextOffsetExclusiveForCommit(record));
     }
 
     /**

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBatchApplicationStream.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBatchApplicationStream.java
@@ -34,6 +34,7 @@ import com.wepay.kafka.connect.bigquery.SchemaManager;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import com.wepay.kafka.connect.bigquery.exception.BigQueryStorageWriteApiConnectException;
 import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
+import com.wepay.kafka.connect.bigquery.utils.SinkRecordConnectOffsets;
 import com.wepay.kafka.connect.bigquery.utils.TableNameUtils;
 import java.io.IOException;
 import java.util.HashMap;
@@ -411,7 +412,9 @@ public class StorageWriteApiBatchApplicationStream extends StorageWriteApiBase {
     Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
     records.forEach(record -> {
       SinkRecord sr = record.original();
-      offsets.put(new TopicPartition(sr.topic(), sr.kafkaPartition()), new OffsetAndMetadata(sr.kafkaOffset() + 1));
+      offsets.put(
+          SinkRecordConnectOffsets.topicPartitionForCommit(sr),
+          new OffsetAndMetadata(SinkRecordConnectOffsets.nextOffsetExclusiveForCommit(sr)));
     });
 
     return offsets;

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConnectOffsetsTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConnectOffsetsTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024 Copyright 2022 Aiven Oy and
+ * bigquery-connector-for-apache-kafka project contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.wepay.kafka.connect.bigquery.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.Test;
+
+class SinkRecordConnectOffsetsTest {
+
+  @Test
+  void topicPartitionAndOffsetUseOriginalKafkaValuesAfterTopicRename() {
+    String originalTopic = "pandashop.pandashop.orders";
+    String routedTopic = "orders";
+    long offset = 42L;
+    SinkRecord record = new SinkRecord(
+        routedTopic,
+        0,
+        null,
+        null,
+        Schema.BOOLEAN_SCHEMA,
+        true,
+        offset,
+        null,
+        TimestampType.NO_TIMESTAMP_TYPE,
+        null,
+        originalTopic,
+        0,
+        offset);
+
+    assertEquals(new TopicPartition(originalTopic, 0), SinkRecordConnectOffsets.topicPartitionForCommit(record));
+    assertEquals(offset + 1, SinkRecordConnectOffsets.nextOffsetExclusiveForCommit(record));
+  }
+
+  @Test
+  void withoutRenameMatchesTopicAndKafkaOffset() {
+    SinkRecord record = new SinkRecord("my.topic", 1, null, null, Schema.INT8_SCHEMA, (byte) 1, 9L);
+    assertEquals(new TopicPartition("my.topic", 1), SinkRecordConnectOffsets.topicPartitionForCommit(record));
+    assertEquals(10L, SinkRecordConnectOffsets.nextOffsetExclusiveForCommit(record));
+  }
+}

--- a/scripts/export-artifacts.sh
+++ b/scripts/export-artifacts.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Build image and copy bigquery-connector-for-apache-kafka-*.tar (+ optional .zip) to DEST (default: target/docker-artifacts).
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+IMAGE="${IMAGE:-bigquery-kafka-connect:local-build}"
+DEST="${1:-$ROOT/target/docker-artifacts}"
+
+docker build -f docker/Dockerfile -t "$IMAGE" "$ROOT"
+mkdir -p "$DEST"
+docker run --rm \
+  -v "$DEST:/out" \
+  --entrypoint sh \
+  "$IMAGE" \
+  -c 'set -e; n=0; for f in kcbq-connector/target/bigquery-connector-for-apache-kafka-*.tar; do [ -f "$f" ] && cp "$f" /out/ && n=$((n+1)); done; for f in kcbq-connector/target/bigquery-connector-for-apache-kafka-*.tar.gz; do [ -f "$f" ] && cp "$f" /out/ && n=$((n+1)); done; [ "$n" -gt 0 ] || { echo "No .tar/.tar.gz under kcbq-connector/target/ — build may have failed:"; ls -la kcbq-connector/target/ 2>&1 || true; exit 1; }; for f in kcbq-connector/target/bigquery-connector-for-apache-kafka-*.zip; do [ -f "$f" ] && cp "$f" /out/ || true; done; ls -la /out'
+echo "Artifacts: $DEST"


### PR DESCRIPTION
Resolved this issue:

```
kafka-connect-bigquery-sink-1  | [2026-04-03 10:51:39,693] WARN [pandashop-bigquery-sink-connector|task-0] WorkerSinkTask{id=pandashop-bigquery-sink-connector-0} Ignoring invalid task provided offset orders-0/OffsetAndMetadata{offset=4, leaderEpoch=null, metadata=''} -- partition not assigned, assignment=[pandashop.pandashop.orders-0] (org.apache.kafka.connect.runtime.WorkerSinkTask:459)
```