### PR TITLE
Fix: Retry-and-reconcile for concurrent schema update failures in GCS to BQ Load

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -351,7 +351,7 @@ public class BigQuerySinkTask extends SinkTask {
     Optional<List<String>> clusteringFieldName = config.getClusteringPartitionFieldNames();
     Optional<TimePartitioning.Type> timePartitioningType = config.getTimePartitioningType();
     boolean sanitizeFieldNames = config.getBoolean(BigQuerySinkConfig.SANITIZE_FIELD_NAME_CONFIG);
-    boolean allowConcurrentSchemaUpdates =
+    boolean mediateConcurrentSchemaUpdates =
         config.getBoolean(BigQuerySinkConfig.ALLOW_CONCURRENT_SCHEMA_UPDATES_CONFIG);
     long concurrentSchemaUpdateRetryWaitMs =
         config.getLong(BigQuerySinkConfig.CONCURRENT_SCHEMA_UPDATE_RETRY_WAIT_MS_CONFIG);
@@ -362,7 +362,7 @@ public class BigQuerySinkTask extends SinkTask {
         sanitizeFieldNames,
         kafkaKeyFieldName, kafkaDataFieldName,
         timestampPartitionFieldName, partitionExpiration, clusteringFieldName, timePartitioningType,
-        allowConcurrentSchemaUpdates, concurrentSchemaUpdateRetryWaitMs, concurrentSchemaUpdateMaxRetries);
+        mediateConcurrentSchemaUpdates, concurrentSchemaUpdateRetryWaitMs, concurrentSchemaUpdateMaxRetries);
   }
 
   private BigQueryWriter getBigQueryWriter(ErrantRecordHandler errantRecordHandler) {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -352,7 +352,7 @@ public class BigQuerySinkTask extends SinkTask {
     Optional<TimePartitioning.Type> timePartitioningType = config.getTimePartitioningType();
     boolean sanitizeFieldNames = config.getBoolean(BigQuerySinkConfig.SANITIZE_FIELD_NAME_CONFIG);
     boolean mediateConcurrentSchemaUpdates =
-        config.getBoolean(BigQuerySinkConfig.ALLOW_CONCURRENT_SCHEMA_UPDATES_CONFIG);
+        config.getBoolean(BigQuerySinkConfig.MEDIATE_CONCURRENT_SCHEMA_UPDATES_CONFIG);
     long concurrentSchemaUpdateRetryWaitMs =
         config.getLong(BigQuerySinkConfig.CONCURRENT_SCHEMA_UPDATE_RETRY_WAIT_MS_CONFIG);
     int concurrentSchemaUpdateMaxRetries =

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -351,11 +351,18 @@ public class BigQuerySinkTask extends SinkTask {
     Optional<List<String>> clusteringFieldName = config.getClusteringPartitionFieldNames();
     Optional<TimePartitioning.Type> timePartitioningType = config.getTimePartitioningType();
     boolean sanitizeFieldNames = config.getBoolean(BigQuerySinkConfig.SANITIZE_FIELD_NAME_CONFIG);
+    boolean allowConcurrentSchemaUpdates =
+        config.getBoolean(BigQuerySinkConfig.ALLOW_CONCURRENT_SCHEMA_UPDATES_CONFIG);
+    long concurrentSchemaUpdateRetryWaitMs =
+        config.getLong(BigQuerySinkConfig.CONCURRENT_SCHEMA_UPDATE_RETRY_WAIT_MS_CONFIG);
+    int concurrentSchemaUpdateMaxRetries =
+        config.getInt(BigQuerySinkConfig.CONCURRENT_SCHEMA_UPDATE_MAX_RETRIES_CONFIG);
     return new SchemaManager(schemaRetriever, schemaConverter, getBigQuery(),
         allowNewBigQueryFields, allowRequiredFieldRelaxation, allowSchemaUnionization,
         sanitizeFieldNames,
         kafkaKeyFieldName, kafkaDataFieldName,
-        timestampPartitionFieldName, partitionExpiration, clusteringFieldName, timePartitioningType);
+        timestampPartitionFieldName, partitionExpiration, clusteringFieldName, timePartitioningType,
+        allowConcurrentSchemaUpdates, concurrentSchemaUpdateRetryWaitMs, concurrentSchemaUpdateMaxRetries);
   }
 
   private BigQueryWriter getBigQueryWriter(ErrantRecordHandler errantRecordHandler) {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -81,7 +81,7 @@ public class SchemaManager {
   private final ConcurrentMap<TableId, Object> tableCreateLocks;
   private final ConcurrentMap<TableId, Object> tableUpdateLocks;
   private final ConcurrentMap<TableId, com.google.cloud.bigquery.Schema> schemaCache;
-  private final boolean allowConcurrentSchemaUpdates;
+  private final boolean mediateConcurrentSchemaUpdates;
   private final long concurrentSchemaUpdateRetryWaitMs;
   private final int concurrentSchemaUpdateMaxRetries;
 
@@ -119,7 +119,7 @@ public class SchemaManager {
       Optional<Long> partitionExpiration,
       Optional<List<String>> clusteringFieldName,
       Optional<TimePartitioning.Type> timePartitioningType,
-      boolean allowConcurrentSchemaUpdates,
+      boolean mediateConcurrentSchemaUpdates,
       long concurrentSchemaUpdateRetryWaitMs,
       int concurrentSchemaUpdateMaxRetries) {
     this(
@@ -136,7 +136,7 @@ public class SchemaManager {
         partitionExpiration,
         clusteringFieldName,
         timePartitioningType,
-        allowConcurrentSchemaUpdates,
+        mediateConcurrentSchemaUpdates,
         concurrentSchemaUpdateRetryWaitMs,
         concurrentSchemaUpdateMaxRetries,
         false,
@@ -159,7 +159,7 @@ public class SchemaManager {
       Optional<Long> partitionExpiration,
       Optional<List<String>> clusteringFieldName,
       Optional<TimePartitioning.Type> timePartitioningType,
-      boolean allowConcurrentSchemaUpdates,
+      boolean mediateConcurrentSchemaUpdates,
       long concurrentSchemaUpdateRetryWaitMs,
       int concurrentSchemaUpdateMaxRetries,
       boolean intermediateTables,
@@ -179,7 +179,7 @@ public class SchemaManager {
     this.partitionExpiration = partitionExpiration;
     this.clusteringFieldName = clusteringFieldName;
     this.timePartitioningType = timePartitioningType;
-    this.allowConcurrentSchemaUpdates = allowConcurrentSchemaUpdates;
+    this.mediateConcurrentSchemaUpdates = mediateConcurrentSchemaUpdates;
     this.concurrentSchemaUpdateRetryWaitMs = concurrentSchemaUpdateRetryWaitMs;
     this.concurrentSchemaUpdateMaxRetries = concurrentSchemaUpdateMaxRetries;
     this.intermediateTables = intermediateTables;
@@ -203,7 +203,7 @@ public class SchemaManager {
         partitionExpiration,
         clusteringFieldName,
         timePartitioningType,
-        allowConcurrentSchemaUpdates,
+        mediateConcurrentSchemaUpdates,
         concurrentSchemaUpdateRetryWaitMs,
         concurrentSchemaUpdateMaxRetries,
         true,
@@ -303,7 +303,7 @@ public class SchemaManager {
           logger.debug("Successfully updated {}", table(table));
           schemaCache.put(table, tableInfo.getDefinition().getSchema());
         } catch (BigQueryException e) {
-          if (!allowConcurrentSchemaUpdates) {
+          if (!mediateConcurrentSchemaUpdates) {
             throw e;
           }
           handleConcurrentSchemaUpdateFailure(table, records, tableInfo, e);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -235,7 +235,7 @@ public class SchemaManager {
   public void createOrUpdateTable(TableId table, List<SinkRecord> records) {
     synchronized (lock(tableCreateLocks, table)) {
       if (bigQuery.getTable(table) == null) {
-        logger.debug("{} doesn't exist; creating instead of updating", table(table));
+        logger.info("{} doesn't exist; creating instead of updating", table(table));
         if (createTable(table, records)) {
           return;
         }
@@ -243,7 +243,7 @@ public class SchemaManager {
     }
 
     // Table already existed; attempt to update instead
-    logger.debug("{} already exists; updating instead of creating", table(table));
+    logger.info("{} already exists; updating instead of creating", table(table));
     updateSchema(table, records);
   }
 
@@ -309,7 +309,7 @@ public class SchemaManager {
           handleConcurrentSchemaUpdateFailure(table, records, tableInfo, e);
         }
       } else {
-        logger.debug("Skipping update of {} since current schema should be compatible", table(table));
+        logger.info("Skipping update of {} since current schema should be compatible", table(table));
       }
     }
   }
@@ -358,7 +358,7 @@ public class SchemaManager {
       try {
         TableInfo retryTableInfo = getTableInfo(table, records, false);
         bigQuery.update(retryTableInfo);
-        logger.debug("Successfully updated {} on concurrent-update retry (attempt {}/{}).",
+        logger.info("Successfully updated {} on concurrent-update retry (attempt {}/{}).",
             table(table), attempt, concurrentSchemaUpdateMaxRetries);
         schemaCache.put(table, retryTableInfo.getDefinition().getSchema());
         return;

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -81,6 +81,9 @@ public class SchemaManager {
   private final ConcurrentMap<TableId, Object> tableCreateLocks;
   private final ConcurrentMap<TableId, Object> tableUpdateLocks;
   private final ConcurrentMap<TableId, com.google.cloud.bigquery.Schema> schemaCache;
+  private final boolean allowConcurrentSchemaUpdates;
+  private final long concurrentSchemaUpdateRetryWaitMs;
+  private final int concurrentSchemaUpdateMaxRetries;
 
   /**
    * @param schemaRetriever                Used to determine the Kafka Connect Schema that should be used for a
@@ -115,7 +118,10 @@ public class SchemaManager {
       Optional<String> timestampPartitionFieldName,
       Optional<Long> partitionExpiration,
       Optional<List<String>> clusteringFieldName,
-      Optional<TimePartitioning.Type> timePartitioningType) {
+      Optional<TimePartitioning.Type> timePartitioningType,
+      boolean allowConcurrentSchemaUpdates,
+      long concurrentSchemaUpdateRetryWaitMs,
+      int concurrentSchemaUpdateMaxRetries) {
     this(
         schemaRetriever,
         schemaConverter,
@@ -130,6 +136,9 @@ public class SchemaManager {
         partitionExpiration,
         clusteringFieldName,
         timePartitioningType,
+        allowConcurrentSchemaUpdates,
+        concurrentSchemaUpdateRetryWaitMs,
+        concurrentSchemaUpdateMaxRetries,
         false,
         new ConcurrentHashMap<>(),
         new ConcurrentHashMap<>(),
@@ -150,6 +159,9 @@ public class SchemaManager {
       Optional<Long> partitionExpiration,
       Optional<List<String>> clusteringFieldName,
       Optional<TimePartitioning.Type> timePartitioningType,
+      boolean allowConcurrentSchemaUpdates,
+      long concurrentSchemaUpdateRetryWaitMs,
+      int concurrentSchemaUpdateMaxRetries,
       boolean intermediateTables,
       ConcurrentMap<TableId, Object> tableCreateLocks,
       ConcurrentMap<TableId, Object> tableUpdateLocks,
@@ -167,6 +179,9 @@ public class SchemaManager {
     this.partitionExpiration = partitionExpiration;
     this.clusteringFieldName = clusteringFieldName;
     this.timePartitioningType = timePartitioningType;
+    this.allowConcurrentSchemaUpdates = allowConcurrentSchemaUpdates;
+    this.concurrentSchemaUpdateRetryWaitMs = concurrentSchemaUpdateRetryWaitMs;
+    this.concurrentSchemaUpdateMaxRetries = concurrentSchemaUpdateMaxRetries;
     this.intermediateTables = intermediateTables;
     this.tableCreateLocks = tableCreateLocks;
     this.tableUpdateLocks = tableUpdateLocks;
@@ -188,6 +203,9 @@ public class SchemaManager {
         partitionExpiration,
         clusteringFieldName,
         timePartitioningType,
+        allowConcurrentSchemaUpdates,
+        concurrentSchemaUpdateRetryWaitMs,
+        concurrentSchemaUpdateMaxRetries,
         true,
         tableCreateLocks,
         tableUpdateLocks,
@@ -277,15 +295,88 @@ public class SchemaManager {
       }
 
       if (!schemaCache.get(table).equals(tableInfo.getDefinition().getSchema())) {
+
         logger.info("Attempting to update {} with schema {}",
             table(table), tableInfo.getDefinition().getSchema());
-        bigQuery.update(tableInfo);
-        logger.debug("Successfully updated {}", table(table));
-        schemaCache.put(table, tableInfo.getDefinition().getSchema());
+        try {
+          bigQuery.update(tableInfo);
+          logger.debug("Successfully updated {}", table(table));
+          schemaCache.put(table, tableInfo.getDefinition().getSchema());
+        } catch (BigQueryException e) {
+          if (!allowConcurrentSchemaUpdates) {
+            throw e;
+          }
+          handleConcurrentSchemaUpdateFailure(table, records, tableInfo, e);
+        }
       } else {
         logger.debug("Skipping update of {} since current schema should be compatible", table(table));
       }
     }
+  }
+
+  private void handleConcurrentSchemaUpdateFailure(
+      TableId table,
+      List<SinkRecord> records,
+      TableInfo firstAttemptTableInfo,
+      BigQueryException originalException) {
+
+    logger.warn(
+        "Schema update failed for {} ({}); another connector may have updated the schema concurrently. "
+            + "Will retry up to {} time(s) with {} ms wait between attempts.",
+        table(table), originalException.getMessage(),
+        concurrentSchemaUpdateMaxRetries, concurrentSchemaUpdateRetryWaitMs);
+
+    com.google.cloud.bigquery.Schema proposedSchema = firstAttemptTableInfo.getDefinition().getSchema();
+    BigQueryException lastException = originalException;
+
+    for (int attempt = 1; attempt <= concurrentSchemaUpdateMaxRetries; attempt++) {
+
+      if (concurrentSchemaUpdateRetryWaitMs > 0) {
+        try {
+          Thread.sleep(concurrentSchemaUpdateRetryWaitMs);
+        } catch (InterruptedException ie) {
+          Thread.currentThread().interrupt();
+          throw new BigQueryConnectException(
+              "Interrupted while waiting for concurrent schema update reconciliation for " + table(table), ie);
+        }
+      }
+
+      com.google.cloud.bigquery.Schema currentBqSchema = readTableSchema(table);
+      schemaCache.put(table, currentBqSchema);
+
+      if (proposedSchema.equals(currentBqSchema)) {
+        logger.info(
+            "Schema for {} was already updated by another connector instance (attempt {}/{}). "
+                + "Reconciled; continuing.",
+            table(table), attempt, concurrentSchemaUpdateMaxRetries);
+        return;
+      }
+
+      logger.info(
+          "Schema for {} still differs after wait (attempt {}/{}); retrying update with latest BQ schema as base...",
+          table(table), attempt, concurrentSchemaUpdateMaxRetries);
+      try {
+        TableInfo retryTableInfo = getTableInfo(table, records, false);
+        bigQuery.update(retryTableInfo);
+        logger.debug("Successfully updated {} on concurrent-update retry (attempt {}/{}).",
+            table(table), attempt, concurrentSchemaUpdateMaxRetries);
+        schemaCache.put(table, retryTableInfo.getDefinition().getSchema());
+        return;
+      } catch (BigQueryException retryEx) {
+        lastException = retryEx;
+        logger.warn("Schema update retry {}/{} failed for {}: {}",
+            attempt, concurrentSchemaUpdateMaxRetries, table(table), retryEx.getMessage());
+      }
+    }
+
+    logger.error(
+        "Schema update failed for {} after {} retry attempt(s) and concurrent schema update reconciliation.",
+        table(table), concurrentSchemaUpdateMaxRetries);
+    throw new BigQueryConnectException(
+        String.format(
+            "Failed to update schema for %s after %d concurrent schema update retry attempt(s)",
+            table(table), concurrentSchemaUpdateMaxRetries),
+        lastException);
   }
 
   /**

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -538,7 +538,9 @@ public class BigQuerySinkConfig extends AbstractConfig {
       "Milliseconds to wait between each retry attempt when mediateConcurrentSchemaUpdates is true. "
           + "After a failed schema update, the connector waits this long before re-reading the BigQuery "
           + "table schema and retrying. Applied before every attempt, including the first. "
-          + "Must be between 0 and 300000 (5 minutes). Default 10000.";
+          + "Must be between 0 and 300000 (5 minutes). Default 10000. "
+          + "WARNING: BigQuery allows at most 5 table metadata update requests per 10 seconds per table. "
+          + "Setting this value too low across multiple connector instances may exhaust that quota and cause repeated failures.";
   private static final ConfigDef.Type CONCURRENT_SCHEMA_UPDATE_MAX_RETRIES_TYPE = ConfigDef.Type.INT;
   private static final ConfigDef.Validator CONCURRENT_SCHEMA_UPDATE_MAX_RETRIES_VALIDATOR =
       ConfigDef.Range.atLeast(1);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -158,7 +158,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
   public static final Integer BIGQUERY_RETRY_DEFAULT = 0;
   public static final String BIGQUERY_RETRY_WAIT_CONFIG = "bigQueryRetryWait";
   public static final Long BIGQUERY_RETRY_WAIT_DEFAULT = 1000L;
-  public static final String ALLOW_CONCURRENT_SCHEMA_UPDATES_CONFIG = "mediateConcurrentSchemaUpdates";
+  public static final String MEDIATE_CONCURRENT_SCHEMA_UPDATES_CONFIG = "mediateConcurrentSchemaUpdates";
   public static final Boolean ALLOW_CONCURRENT_SCHEMA_UPDATES_DEFAULT = false;
   public static final String CONCURRENT_SCHEMA_UPDATE_RETRY_WAIT_MS_CONFIG = "concurrentSchemaUpdateRetryWaitMs";
   public static final Long CONCURRENT_SCHEMA_UPDATE_RETRY_WAIT_MS_DEFAULT = 10000L;
@@ -913,7 +913,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
                     BIGQUERY_RETRY_WAIT_IMPORTANCE,
                     BIGQUERY_RETRY_WAIT_DOC
             ).define(
-                    ALLOW_CONCURRENT_SCHEMA_UPDATES_CONFIG,
+                    MEDIATE_CONCURRENT_SCHEMA_UPDATES_CONFIG,
                     ALLOW_CONCURRENT_SCHEMA_UPDATES_TYPE,
                     ALLOW_CONCURRENT_SCHEMA_UPDATES_DEFAULT,
                     ALLOW_CONCURRENT_SCHEMA_UPDATES_IMPORTANCE,

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -531,13 +531,14 @@ public class BigQuerySinkConfig extends AbstractConfig {
           + "the current batch. Default false (disabled).";
   private static final ConfigDef.Type CONCURRENT_SCHEMA_UPDATE_RETRY_WAIT_MS_TYPE = ConfigDef.Type.LONG;
   private static final ConfigDef.Validator CONCURRENT_SCHEMA_UPDATE_RETRY_WAIT_MS_VALIDATOR =
-      ConfigDef.Range.atLeast(0);
+      ConfigDef.Range.between(0, 300_000);
   private static final ConfigDef.Importance CONCURRENT_SCHEMA_UPDATE_RETRY_WAIT_MS_IMPORTANCE =
       ConfigDef.Importance.MEDIUM;
   private static final String CONCURRENT_SCHEMA_UPDATE_RETRY_WAIT_MS_DOC =
       "Milliseconds to wait between each retry attempt when mediateConcurrentSchemaUpdates is true. "
           + "After a failed schema update, the connector waits this long before re-reading the BigQuery "
-          + "table schema and retrying. Applied before every attempt, including the first. Default 5000.";
+          + "table schema and retrying. Applied before every attempt, including the first. "
+          + "Must be between 0 and 300000 (5 minutes). Default 10000.";
   private static final ConfigDef.Type CONCURRENT_SCHEMA_UPDATE_MAX_RETRIES_TYPE = ConfigDef.Type.INT;
   private static final ConfigDef.Validator CONCURRENT_SCHEMA_UPDATE_MAX_RETRIES_VALIDATOR =
       ConfigDef.Range.atLeast(1);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -158,6 +158,12 @@ public class BigQuerySinkConfig extends AbstractConfig {
   public static final Integer BIGQUERY_RETRY_DEFAULT = 0;
   public static final String BIGQUERY_RETRY_WAIT_CONFIG = "bigQueryRetryWait";
   public static final Long BIGQUERY_RETRY_WAIT_DEFAULT = 1000L;
+  public static final String ALLOW_CONCURRENT_SCHEMA_UPDATES_CONFIG = "allowConcurrentSchemaUpdates";
+  public static final Boolean ALLOW_CONCURRENT_SCHEMA_UPDATES_DEFAULT = false;
+  public static final String CONCURRENT_SCHEMA_UPDATE_RETRY_WAIT_MS_CONFIG = "concurrentSchemaUpdateRetryWaitMs";
+  public static final Long CONCURRENT_SCHEMA_UPDATE_RETRY_WAIT_MS_DEFAULT = 10000L;
+  public static final String CONCURRENT_SCHEMA_UPDATE_MAX_RETRIES_CONFIG = "concurrentSchemaUpdateMaxRetries";
+  public static final Integer CONCURRENT_SCHEMA_UPDATE_MAX_RETRIES_DEFAULT = 3;
   public static final String BIGQUERY_MESSAGE_TIME_PARTITIONING_CONFIG =
       "bigQueryMessageTimePartitioning";
   public static final Boolean BIGQUERY_MESSAGE_TIME_PARTITIONING_DEFAULT = false;
@@ -514,6 +520,34 @@ public class BigQuerySinkConfig extends AbstractConfig {
           + "exceeded error retry attempts. "
           + "For GCS batch load(see enableBatchLoad): base delay for exponential backoff with jitter (capped at 10s). "
           + "For other writers: constant wait time between retries.";
+  private static final ConfigDef.Type ALLOW_CONCURRENT_SCHEMA_UPDATES_TYPE = ConfigDef.Type.BOOLEAN;
+  private static final ConfigDef.Importance ALLOW_CONCURRENT_SCHEMA_UPDATES_IMPORTANCE =
+      ConfigDef.Importance.MEDIUM;
+  private static final String ALLOW_CONCURRENT_SCHEMA_UPDATES_DOC =
+      "When true, enables a retry-and-reconcile path for schema updates to handle concurrent schema "
+          + "changes from multiple connector instances writing to the same BigQuery table. On a schema "
+          + "update failure, the connector waits concurrentSchemaUpdateRetryWaitMs milliseconds, "
+          + "re-reads the table schema from BigQuery, and checks whether it is already compatible with "
+          + "the current batch. Default false (disabled).";
+  private static final ConfigDef.Type CONCURRENT_SCHEMA_UPDATE_RETRY_WAIT_MS_TYPE = ConfigDef.Type.LONG;
+  private static final ConfigDef.Validator CONCURRENT_SCHEMA_UPDATE_RETRY_WAIT_MS_VALIDATOR =
+      ConfigDef.Range.atLeast(0);
+  private static final ConfigDef.Importance CONCURRENT_SCHEMA_UPDATE_RETRY_WAIT_MS_IMPORTANCE =
+      ConfigDef.Importance.MEDIUM;
+  private static final String CONCURRENT_SCHEMA_UPDATE_RETRY_WAIT_MS_DOC =
+      "Milliseconds to wait between each retry attempt when allowConcurrentSchemaUpdates is true. "
+          + "After a failed schema update, the connector waits this long before re-reading the BigQuery "
+          + "table schema and retrying. Applied before every attempt, including the first. Default 5000.";
+  private static final ConfigDef.Type CONCURRENT_SCHEMA_UPDATE_MAX_RETRIES_TYPE = ConfigDef.Type.INT;
+  private static final ConfigDef.Validator CONCURRENT_SCHEMA_UPDATE_MAX_RETRIES_VALIDATOR =
+      ConfigDef.Range.atLeast(1);
+  private static final ConfigDef.Importance CONCURRENT_SCHEMA_UPDATE_MAX_RETRIES_IMPORTANCE =
+      ConfigDef.Importance.MEDIUM;
+  private static final String CONCURRENT_SCHEMA_UPDATE_MAX_RETRIES_DOC =
+      "Maximum number of retry attempts for schema updates when allowConcurrentSchemaUpdates is true. "
+          + "Before each attempt the connector waits concurrentSchemaUpdateRetryWaitMs milliseconds, "
+          + "re-reads the BigQuery table schema, and checks whether it is already compatible. "
+          + "Must be at least 1. Default 3.";
   private static final ConfigDef.Type BIGQUERY_MESSAGE_TIME_PARTITIONING_CONFIG_TYPE =
       ConfigDef.Type.BOOLEAN;
   private static final ConfigDef.Importance BIGQUERY_MESSAGE_TIME_PARTITIONING_IMPORTANCE =
@@ -878,6 +912,26 @@ public class BigQuerySinkConfig extends AbstractConfig {
                     BIGQUERY_RETRY_WAIT_VALIDATOR,
                     BIGQUERY_RETRY_WAIT_IMPORTANCE,
                     BIGQUERY_RETRY_WAIT_DOC
+            ).define(
+                    ALLOW_CONCURRENT_SCHEMA_UPDATES_CONFIG,
+                    ALLOW_CONCURRENT_SCHEMA_UPDATES_TYPE,
+                    ALLOW_CONCURRENT_SCHEMA_UPDATES_DEFAULT,
+                    ALLOW_CONCURRENT_SCHEMA_UPDATES_IMPORTANCE,
+                    ALLOW_CONCURRENT_SCHEMA_UPDATES_DOC
+            ).define(
+                    CONCURRENT_SCHEMA_UPDATE_RETRY_WAIT_MS_CONFIG,
+                    CONCURRENT_SCHEMA_UPDATE_RETRY_WAIT_MS_TYPE,
+                    CONCURRENT_SCHEMA_UPDATE_RETRY_WAIT_MS_DEFAULT,
+                    CONCURRENT_SCHEMA_UPDATE_RETRY_WAIT_MS_VALIDATOR,
+                    CONCURRENT_SCHEMA_UPDATE_RETRY_WAIT_MS_IMPORTANCE,
+                    CONCURRENT_SCHEMA_UPDATE_RETRY_WAIT_MS_DOC
+            ).define(
+                    CONCURRENT_SCHEMA_UPDATE_MAX_RETRIES_CONFIG,
+                    CONCURRENT_SCHEMA_UPDATE_MAX_RETRIES_TYPE,
+                    CONCURRENT_SCHEMA_UPDATE_MAX_RETRIES_DEFAULT,
+                    CONCURRENT_SCHEMA_UPDATE_MAX_RETRIES_VALIDATOR,
+                    CONCURRENT_SCHEMA_UPDATE_MAX_RETRIES_IMPORTANCE,
+                    CONCURRENT_SCHEMA_UPDATE_MAX_RETRIES_DOC
             ).define(
                     BIGQUERY_MESSAGE_TIME_PARTITIONING_CONFIG,
                     BIGQUERY_MESSAGE_TIME_PARTITIONING_CONFIG_TYPE,

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -158,7 +158,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
   public static final Integer BIGQUERY_RETRY_DEFAULT = 0;
   public static final String BIGQUERY_RETRY_WAIT_CONFIG = "bigQueryRetryWait";
   public static final Long BIGQUERY_RETRY_WAIT_DEFAULT = 1000L;
-  public static final String ALLOW_CONCURRENT_SCHEMA_UPDATES_CONFIG = "allowConcurrentSchemaUpdates";
+  public static final String ALLOW_CONCURRENT_SCHEMA_UPDATES_CONFIG = "mediateConcurrentSchemaUpdates";
   public static final Boolean ALLOW_CONCURRENT_SCHEMA_UPDATES_DEFAULT = false;
   public static final String CONCURRENT_SCHEMA_UPDATE_RETRY_WAIT_MS_CONFIG = "concurrentSchemaUpdateRetryWaitMs";
   public static final Long CONCURRENT_SCHEMA_UPDATE_RETRY_WAIT_MS_DEFAULT = 10000L;
@@ -535,7 +535,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
   private static final ConfigDef.Importance CONCURRENT_SCHEMA_UPDATE_RETRY_WAIT_MS_IMPORTANCE =
       ConfigDef.Importance.MEDIUM;
   private static final String CONCURRENT_SCHEMA_UPDATE_RETRY_WAIT_MS_DOC =
-      "Milliseconds to wait between each retry attempt when allowConcurrentSchemaUpdates is true. "
+      "Milliseconds to wait between each retry attempt when mediateConcurrentSchemaUpdates is true. "
           + "After a failed schema update, the connector waits this long before re-reading the BigQuery "
           + "table schema and retrying. Applied before every attempt, including the first. Default 5000.";
   private static final ConfigDef.Type CONCURRENT_SCHEMA_UPDATE_MAX_RETRIES_TYPE = ConfigDef.Type.INT;
@@ -544,7 +544,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
   private static final ConfigDef.Importance CONCURRENT_SCHEMA_UPDATE_MAX_RETRIES_IMPORTANCE =
       ConfigDef.Importance.MEDIUM;
   private static final String CONCURRENT_SCHEMA_UPDATE_MAX_RETRIES_DOC =
-      "Maximum number of retry attempts for schema updates when allowConcurrentSchemaUpdates is true. "
+      "Maximum number of retry attempts for schema updates when mediateConcurrentSchemaUpdates is true. "
           + "Before each attempt the connector waits concurrentSchemaUpdateRetryWaitMs milliseconds, "
           + "re-reads the BigQuery table schema, and checks whether it is already compatible. "
           + "Must be at least 1. Default 3.";

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
@@ -856,12 +856,12 @@ public class SchemaManagerTest {
 
   private SchemaManager createSchemaManagerWithConcurrentRetry(
       boolean allowNewFields, boolean allowFieldRelaxation,
-      boolean allowConcurrentSchemaUpdates, long concurrentRetryWaitMs, int maxRetries) {
+      boolean mediateConcurrentSchemaUpdates, long concurrentRetryWaitMs, int maxRetries) {
     return new SchemaManager(new IdentitySchemaRetriever(), mockSchemaConverter, mockBigQuery,
         allowNewFields, allowFieldRelaxation, false, false,
         Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
         Optional.of(TimePartitioning.Type.DAY),
-        allowConcurrentSchemaUpdates, concurrentRetryWaitMs, maxRetries);
+        mediateConcurrentSchemaUpdates, concurrentRetryWaitMs, maxRetries);
   }
 
   private void testGetAndValidateProposedSchema(

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
@@ -27,11 +27,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.Field.Mode;
 import com.google.cloud.bigquery.LegacySQLTypeName;
@@ -92,7 +95,8 @@ public class SchemaManagerTest {
     Optional<String> kafkaDataFieldName = Optional.of("kafkaData");
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, kafkaKeyFieldName, kafkaDataFieldName,
-        Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(TimePartitioning.Type.DAY));
+        Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(TimePartitioning.Type.DAY),
+        false, 0L, 1);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
@@ -120,7 +124,8 @@ public class SchemaManagerTest {
     Optional<String> testField = Optional.of("testField");
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), testField,
-        Optional.empty(), Optional.empty(), Optional.of(TimePartitioning.Type.DAY));
+        Optional.empty(), Optional.empty(), Optional.of(TimePartitioning.Type.DAY),
+        false, 0L, 1);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
@@ -151,7 +156,8 @@ public class SchemaManagerTest {
   public void testAlternativeTimestampPartitionType() {
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), Optional.empty(),
-        Optional.empty(), Optional.empty(), Optional.of(TimePartitioning.Type.HOUR));
+        Optional.empty(), Optional.empty(), Optional.of(TimePartitioning.Type.HOUR),
+        false, 0L, 1);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
@@ -173,7 +179,8 @@ public class SchemaManagerTest {
   public void testNoTimestampPartitionType() {
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), Optional.empty(),
-        Optional.empty(), Optional.empty(), Optional.empty());
+        Optional.empty(), Optional.empty(), Optional.empty(),
+        false, 0L, 1);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
@@ -195,7 +202,8 @@ public class SchemaManagerTest {
     Optional<String> testField = Optional.of("testField");
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), testField,
-        Optional.empty(), Optional.empty(), Optional.of(TimePartitioning.Type.DAY));
+        Optional.empty(), Optional.empty(), Optional.of(TimePartitioning.Type.DAY),
+        false, 0L, 1);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
@@ -219,7 +227,8 @@ public class SchemaManagerTest {
     Optional<String> testField = Optional.of("testField");
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), testField,
-        Optional.empty(), Optional.empty(), Optional.of(TimePartitioning.Type.DAY));
+        Optional.empty(), Optional.empty(), Optional.of(TimePartitioning.Type.DAY),
+        false, 0L, 1);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
@@ -243,7 +252,8 @@ public class SchemaManagerTest {
     Optional<String> updateField = Optional.of("testUpdateField");
     schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), updateField, Optional.empty(), Optional.empty(),
-        Optional.of(TimePartitioning.Type.DAY));
+        Optional.of(TimePartitioning.Type.DAY),
+        false, 0L, 1);
 
     tableInfo = schemaManager
         .constructTableInfo(tableId, fakeBigQuerySchema, testDoc, false);
@@ -259,7 +269,8 @@ public class SchemaManagerTest {
     Optional<Long> testExpirationMs = Optional.of(86400000L);
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), Optional.empty(),
-        testExpirationMs, Optional.empty(), Optional.of(TimePartitioning.Type.DAY));
+        testExpirationMs, Optional.empty(), Optional.of(TimePartitioning.Type.DAY),
+        false, 0L, 1);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
@@ -290,7 +301,8 @@ public class SchemaManagerTest {
     Optional<String> testField = Optional.of("testField");
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), testField,
-        testExpirationMs, Optional.empty(), Optional.of(TimePartitioning.Type.DAY));
+        testExpirationMs, Optional.empty(), Optional.of(TimePartitioning.Type.DAY),
+        false, 0L, 1);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
@@ -322,7 +334,8 @@ public class SchemaManagerTest {
     Optional<List<String>> testField = Optional.of(Arrays.asList("column1", "column2"));
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), timestampPartitionFieldName,
-        Optional.empty(), testField, Optional.of(TimePartitioning.Type.DAY));
+        Optional.empty(), testField, Optional.of(TimePartitioning.Type.DAY),
+        false, 0L, 1);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
@@ -350,7 +363,8 @@ public class SchemaManagerTest {
     Optional<List<String>> testField = Optional.of(Arrays.asList("column1", "column2"));
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), timestampPartitionFieldName,
-        Optional.empty(), testField, Optional.of(TimePartitioning.Type.DAY));
+        Optional.empty(), testField, Optional.of(TimePartitioning.Type.DAY),
+        false, 0L, 1);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
@@ -376,7 +390,8 @@ public class SchemaManagerTest {
     Optional<List<String>> testField = Optional.of(Arrays.asList("column1", "column2"));
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), timestampPartitionFieldName,
-        Optional.empty(), testField, Optional.of(TimePartitioning.Type.DAY));
+        Optional.empty(), testField, Optional.of(TimePartitioning.Type.DAY),
+        false, 0L, 1);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
@@ -400,7 +415,8 @@ public class SchemaManagerTest {
     Optional<List<String>> updateTestField = Optional.of(Arrays.asList("column3", "column4"));
     schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), timestampPartitionFieldName,
-        Optional.empty(), updateTestField, Optional.of(TimePartitioning.Type.DAY));
+        Optional.empty(), updateTestField, Optional.of(TimePartitioning.Type.DAY),
+        false, 0L, 1);
 
     tableInfo = schemaManager
         .constructTableInfo(tableId, fakeBigQuerySchema, testDoc, false);
@@ -825,7 +841,8 @@ public class SchemaManagerTest {
     return new SchemaManager(new IdentitySchemaRetriever(), converter, mockBigQuery,
         allowNewFields, allowFieldRelaxation, allowUnionization, sanitizeFieldNames,
         Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
-        Optional.of(TimePartitioning.Type.DAY));
+        Optional.of(TimePartitioning.Type.DAY),
+        false, 0L, 1);
   }
 
   private SchemaManager createSchemaManager(
@@ -833,7 +850,18 @@ public class SchemaManagerTest {
     return new SchemaManager(new IdentitySchemaRetriever(), mockSchemaConverter, mockBigQuery,
         allowNewFields, allowFieldRelaxation, allowUnionization, false,
         Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
-        Optional.of(TimePartitioning.Type.DAY));
+        Optional.of(TimePartitioning.Type.DAY),
+        false, 0L, 1);
+  }
+
+  private SchemaManager createSchemaManagerWithConcurrentRetry(
+      boolean allowNewFields, boolean allowFieldRelaxation,
+      boolean allowConcurrentSchemaUpdates, long concurrentRetryWaitMs, int maxRetries) {
+    return new SchemaManager(new IdentitySchemaRetriever(), mockSchemaConverter, mockBigQuery,
+        allowNewFields, allowFieldRelaxation, false, false,
+        Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+        Optional.of(TimePartitioning.Type.DAY),
+        allowConcurrentSchemaUpdates, concurrentRetryWaitMs, maxRetries);
   }
 
   private void testGetAndValidateProposedSchema(
@@ -1026,6 +1054,129 @@ public class SchemaManagerTest {
       assertEquals(sanitizedName, actualSchema.getFields().get(sanitizedName).getName());
     }
     assertEquals("embedded_invalid", actualSchema.getFields().get("embedded").getSubFields().get(0).getName());
+  }
+
+  @Test
+  public void testConcurrentUpdateReconciled() {
+    com.google.cloud.bigquery.Schema existingSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.NULLABLE).build()
+    );
+    com.google.cloud.bigquery.Schema proposedSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.NULLABLE).build(),
+        Field.newBuilder("f2", LegacySQLTypeName.STRING).setMode(Field.Mode.NULLABLE).build()
+    );
+    // Pre-create mocks before any when() chain to avoid UnfinishedStubbingException
+    Table existingTable = tableWithSchema(existingSchema);
+    Table reconciledTable = tableWithSchema(proposedSchema);
+
+    when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(proposedSchema);
+    when(mockBigQuery.getTable(tableId))
+        .thenReturn(existingTable)    // getAndValidateProposedSchema
+        .thenReturn(existingTable)    // updateSchema cache miss
+        // retry loop attempt 1:
+        .thenReturn(reconciledTable); // reconcile check: proposed == current → reconciled, no further update
+    when(mockBigQuery.update(any(TableInfo.class)))
+        .thenThrow(new BigQueryException(409, "concurrent modification"));
+
+    // maxRetries=1: one loop iteration is sufficient to demonstrate reconcile
+    SchemaManager schemaManager = createSchemaManagerWithConcurrentRetry(true, false, true, 0L, 1);
+    List<SinkRecord> records = Collections.singletonList(recordWithValueSchema(mockKafkaSchema));
+
+    // Should not throw — another connector already applied the proposed schema
+    schemaManager.updateSchema(tableId, records);
+
+    verify(mockBigQuery, times(1)).update(any(TableInfo.class));
+  }
+
+  @Test
+  public void testConcurrentUpdateRetrySucceeds() {
+    com.google.cloud.bigquery.Schema existingSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.NULLABLE).build()
+    );
+    com.google.cloud.bigquery.Schema proposedSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.NULLABLE).build(),
+        Field.newBuilder("f2", LegacySQLTypeName.STRING).setMode(Field.Mode.NULLABLE).build()
+    );
+    Table existingTable = tableWithSchema(existingSchema);
+    Table successTable = mock(Table.class);
+
+    when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(proposedSchema);
+    when(mockBigQuery.getTable(tableId))
+        .thenReturn(existingTable)   // getAndValidateProposedSchema
+        .thenReturn(existingTable)   // updateSchema cache miss
+        // retry loop attempt 1:
+        .thenReturn(existingTable)   // reconcile check: not equal → attempt update
+        .thenReturn(existingTable);  // retry getAndValidateProposedSchema (inside getTableInfo)
+    when(mockBigQuery.update(any(TableInfo.class)))
+        .thenThrow(new BigQueryException(409, "concurrent modification")) // initial attempt
+        .thenReturn(successTable);                                         // loop attempt 1
+
+    // maxRetries=1: the single retry attempt succeeds
+    SchemaManager schemaManager = createSchemaManagerWithConcurrentRetry(true, false, true, 0L, 1);
+    List<SinkRecord> records = Collections.singletonList(recordWithValueSchema(mockKafkaSchema));
+
+    // Should not throw — retry succeeds
+    schemaManager.updateSchema(tableId, records);
+
+    verify(mockBigQuery, times(2)).update(any(TableInfo.class));
+  }
+
+  @Test
+  public void testConcurrentUpdateRetryFails() {
+    com.google.cloud.bigquery.Schema existingSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.NULLABLE).build()
+    );
+    com.google.cloud.bigquery.Schema proposedSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.NULLABLE).build(),
+        Field.newBuilder("f2", LegacySQLTypeName.STRING).setMode(Field.Mode.NULLABLE).build()
+    );
+    Table existingTable = tableWithSchema(existingSchema);
+
+    when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(proposedSchema);
+    when(mockBigQuery.getTable(tableId))
+        .thenReturn(existingTable)   // getAndValidateProposedSchema
+        .thenReturn(existingTable)   // updateSchema cache miss
+        // retry loop attempt 1:
+        .thenReturn(existingTable)   // reconcile check: not equal → attempt update
+        .thenReturn(existingTable);  // retry getAndValidateProposedSchema
+    when(mockBigQuery.update(any(TableInfo.class)))
+        .thenThrow(new BigQueryException(409, "concurrent modification")); // all attempts throw
+
+    // maxRetries=1: one retry attempt exhausted → BigQueryConnectException
+    SchemaManager schemaManager = createSchemaManagerWithConcurrentRetry(true, false, true, 0L, 1);
+    List<SinkRecord> records = Collections.singletonList(recordWithValueSchema(mockKafkaSchema));
+
+    assertThrows(BigQueryConnectException.class, () -> schemaManager.updateSchema(tableId, records));
+
+    verify(mockBigQuery, times(2)).update(any(TableInfo.class));
+  }
+
+  @Test
+  public void testConcurrentUpdateDisabledRethrowsBigQueryException() {
+    com.google.cloud.bigquery.Schema existingSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.NULLABLE).build()
+    );
+    com.google.cloud.bigquery.Schema proposedSchema = com.google.cloud.bigquery.Schema.of(
+        Field.newBuilder("f1", LegacySQLTypeName.BOOLEAN).setMode(Field.Mode.NULLABLE).build(),
+        Field.newBuilder("f2", LegacySQLTypeName.STRING).setMode(Field.Mode.NULLABLE).build()
+    );
+    Table existingTable = tableWithSchema(existingSchema);
+
+    when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(proposedSchema);
+    when(mockBigQuery.getTable(tableId))
+        .thenReturn(existingTable)   // getAndValidateProposedSchema
+        .thenReturn(existingTable);  // updateSchema cache miss
+    when(mockBigQuery.update(any(TableInfo.class)))
+        .thenThrow(new BigQueryException(409, "concurrent modification"));
+
+    // Flag disabled: no retry loop is entered regardless of maxRetries
+    SchemaManager schemaManager = createSchemaManagerWithConcurrentRetry(true, false, false, 0L, 3);
+    List<SinkRecord> records = Collections.singletonList(recordWithValueSchema(mockKafkaSchema));
+
+    // BigQueryException propagates directly, unwrapped
+    assertThrows(BigQueryException.class, () -> schemaManager.updateSchema(tableId, records));
+
+    verify(mockBigQuery, times(1)).update(any(TableInfo.class));
   }
 
   private com.google.cloud.bigquery.Schema makeNullable(com.google.cloud.bigquery.Schema s) {


### PR DESCRIPTION
## Overview
Ticket no: 103740

This PR adds a feature-flagged retry-and-reconcile mechanism inside SchemaManager.updateSchema() to handle concurrent schema update failures in deployments where multiple independent Kafka connector instances write to the same BigQuery destination table.

Three new configuration keys are introduced, and SchemaManager is updated with a bounded retry loop that checks whether a competing connector already applied the required schema change before retrying and retry update Schema job if it hits the metadata update limit of Bigquery. Four new unit tests cover each branch of the new code path.

Side note: As debug logs are not visible to us in the log explorer, I converted the type of the ones that will be helpful for further investigation into info logs, fyi.

## Problem
Each BigQuerySinkTask creates its own SchemaManager instance. The internal state (schemaCache, tableCreateLocks, and tableUpdateLocks) is local to that instance only. It is not shared across connector instances, Kafka Connect workers, or regions.

When multiple connectors target the same BigQuery table and operate with cold or stale local caches, they can independently evaluate the table schema, compute the same proposed schema change, and issue repeated bigQuery.update(tableInfo) calls within a short time window.

These repeated update requests hit the [BigQuery metadata quota limit](https://docs.cloud.google.com/bigquery/quotas#standard_tables).
`Your project can make up to five table metadata update operations per 10 seconds per table.`

As a result, some update calls fail with:

```
Exceeded rate limits: too many table update operations for this table
```

## Trigger conditions
The race is most likely when schemaCache is cold:
- After a connector restart or consumer group rebalance, all tasks start with empty local caches at the same time. SchemaManager.createOrUpdateTable() is called on every rebalance: if the table exists, it unconditionally calls updateSchema(), making every rebalance a race trigger.


## New configuration keys
**mediateConcurrentSchemaUpdates (boolean, default false)**
This flag gates the entire new code path. When false, a BigQueryException from bigQuery.update() propagates exactly as before — the behaviour of existing deployments is completely unchanged.

The flag defaults to false because the retry-and-reconcile behaviour is only relevant in deployments where multiple connectors share destination tables. Enabling it unconditionally would add unnecessary latency to single-connector deployments on schema update failures.

**concurrentSchemaUpdateRetryWaitMs (long, default 10000, validator atLeast(0))**
Controls how long the connector sleeps before each retry iteration. The wait serves two purposes: it gives any in-progress concurrent update time to complete and become visible via readTableSchema(), and it reduces the rate of BigQuery Metadata API calls during a race.
Setting this to 0 disables the sleep entirely. This is intentional, it allows unit tests to exercise the retry loop without real delays. The validator enforces atLeast(0). It is not effective if mediateConcurrentSchemaUpdates is False.

**concurrentSchemaUpdateMaxRetries (int, default 3, validator atLeast(1))**
Bounds the number of retry iterations. Each iteration includes one reconcile check and, optionally, one bigQuery.update() call. Without an upper bound, a genuine schema incompatibility (not a timing race) could loop until the connector is stopped. The validator enforces atLeast(1), zero would mean the flag is enabled, but no retries are ever attempted, which would be misleading.



## Modified updateSchema()

The single bigQuery.update(tableInfo) call is wrapped in a try/catch (BigQueryException e). On success, the path is unchanged — schemaCache is updated and the method returns. On failure, if mediateConcurrentSchemaUpdates=false, the exception is re-thrown immediately (existing behaviour). If mediateConcurrentSchemaUpdates=true, control passes to handleConcurrentSchemaUpdateFailure().

## New private method handleConcurrentSchemaUpdateFailure()

This method implements the bounded retry loop. For each attempt 1..concurrentSchemaUpdateMaxRetries:

1. Sleep concurrentSchemaUpdateRetryWaitMs ms (skipped when 0). An interrupted sleep sets the interrupt flag and throws BigQueryConnectException.
2. Re-read the live schema via readTableSchema(table) and overwrite schemaCache. The cache must reflect the current state before deciding whether to retry.
3. Reconcile check: compare proposedSchema (captured from the first attempt's TableInfo before the loop) against the freshly read currentBqSchema. If equal, another connector has already applied the required change. Log at INFO and return immediately — no further bigQuery.update() call is made.
4. Retry update: call getTableInfo(table, records, false) to recompute a fresh TableInfo. getTableInfo internally calls getAndValidateProposedSchema() → readTableSchema(), ensuring the retry's proposed schema is computed against the most recent BQ state as the unionization base. This is important: by the time a retry is attempted, another connector may have added fields that this connector should not try to re-add.
5. If bigQuery.update() succeeds, update schemaCache and return.
6. If it throws BigQueryException, store it as lastException, log a WARN with the attempt index, and continue.

After all iterations are exhausted, throw BigQueryConnectException wrapping lastException (the exception from the final retry, which is typically more diagnostic than the original).

Why proposedSchema is captured once before the loop: the target schema is derived from the unchanged Kafka records. Capturing it once keeps the reconcile comparison consistent across iterations and avoids redundant recomputation.


## Tests

#### Unit Tests
```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.638 s -- in com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiWriterTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.090 s -- in com.wepay.kafka.connect.bigquery.write.storage.BigQueryBuilderTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.013 s -- in com.wepay.kafka.connect.bigquery.write.storage.BigQueryWriteSettingsBuilderTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.046 s -- in com.wepay.kafka.connect.bigquery.write.storage.GcsBuilderTest
[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.203 s -- in com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiBatchApplicationStreamTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s -- in com.wepay.kafka.connect.bigquery.write.storage.StorageApiBatchModeHandlerTest
[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.057 s -- in com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiDefaultStreamTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.235 s -- in com.wepay.kafka.connect.bigquery.write.row.BigQueryWriterTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s -- in com.wepay.kafka.connect.bigquery.write.row.GcsToBqWriterTest$JsonSerializationTests
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.046 s -- in com.wepay.kafka.connect.bigquery.write.row.GcsToBqWriterTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.120 s -- in com.wepay.kafka.connect.bigquery.write.batch.GcsBatchTableWriterTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.166 s -- in com.wepay.kafka.connect.bigquery.GcpClientBuilderProjectTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.035 s -- in com.wepay.kafka.connect.bigquery.config.GcsBucketValidatorTest
[INFO] Tests run: 33, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.029 s -- in com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfigTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s -- in com.wepay.kafka.connect.bigquery.config.PartitioningModeValidatorTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s -- in com.wepay.kafka.connect.bigquery.config.MultiPropertyValidatorTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.023 s -- in com.wepay.kafka.connect.bigquery.config.CredentialsValidatorTest
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s -- in com.wepay.kafka.connect.bigquery.config.StorageWriteApiValidatorTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s -- in com.wepay.kafka.connect.bigquery.config.PartitioningTypeValidatorTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s -- in com.wepay.kafka.connect.bigquery.utils.PartitionedTableIdTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s -- in com.wepay.kafka.connect.bigquery.utils.FieldNameSanitizerTest
[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.055 s -- in com.wepay.kafka.connect.bigquery.RecordTableResolverTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s -- in com.wepay.kafka.connect.bigquery.ErrantRecordHandlerTest
[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.163 s -- in com.wepay.kafka.connect.bigquery.BigQuerySinkTaskTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.180 s -- in com.wepay.kafka.connect.bigquery.BigQueryStorageApiBatchSinkTaskTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s -- in com.wepay.kafka.connect.bigquery.BigQuerySinkConnectorTest
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.068 s -- in com.wepay.kafka.connect.bigquery.MergeQueriesTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.112 s -- in com.wepay.kafka.connect.bigquery.BigQueryStorageApiSinkTaskTest
[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s -- in com.wepay.kafka.connect.bigquery.exception.BigQueryStorageWriteApiErrorResponsesTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s -- in com.wepay.kafka.connect.bigquery.exception.BigQueryErrorResponsesTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s -- in com.wepay.kafka.connect.bigquery.exception.BigQueryStorageWriteApiConnectExceptionTest
[INFO] Tests run: 43, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.069 s -- in com.wepay.kafka.connect.bigquery.SchemaManagerTest
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.080 s -- in com.wepay.kafka.connect.bigquery.GcsToBqLoadRunnableTest
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s -- in com.wepay.kafka.connect.bigquery.convert.KafkaDataConverterTest
[INFO] Tests run: 42, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.117 s -- in com.wepay.kafka.connect.bigquery.convert.BigQuerySchemaConverterTest
[INFO] Tests run: 38, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.029 s -- in com.wepay.kafka.connect.bigquery.convert.BigQueryRecordConverterTest
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s -- in com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConvertersTest
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s -- in com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConvertersTest
[INFO] Results:
[INFO] Tests run: 379, Failures: 0, Errors: 0, Skipped: 0
```


#### Integration Tests

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 34.84 s -- in com.wepay.kafka.connect.bigquery.integration.GcsBatchSchemaEvolutionIT
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- failsafe:3.5.3:verify (embedded-integration-test) @ kcbq-connector ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  37.644 s
[INFO] Finished at: 2026-04-20T16:33:43+02:00
[INFO] ------------------------------------------------------------------------
```
<img width="657" height="210" alt="image" src="https://github.com/user-attachments/assets/0f7c6b9b-6913-4f33-a6d0-272ee4e4dad5" />

