### PR TITLE
Add putAttemptId to kafka metadata struct for put()-level retry deduplication

### DIFF
--- a/kcbq-connector/pom.xml
+++ b/kcbq-connector/pom.xml
@@ -178,6 +178,10 @@
             <groupId>com.google.re2j</groupId>
             <artifactId>re2j</artifactId>
         </dependency>
+        <dependency>
+            <groupId>de.huxhorn.sulky</groupId>
+            <artifactId>de.huxhorn.sulky.ulid</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -120,6 +120,7 @@ public class BigQuerySinkTask extends SinkTask {
   private KcbqThreadPoolExecutor executor;
   private int remainingRetries;
   private boolean enableRetries;
+  private boolean trackPutAttempts;
   private ErrantRecordHandler errantRecordHandler;
   private boolean useStorageApi;
   private boolean useStorageApiBatchMode;
@@ -281,6 +282,9 @@ public class BigQuerySinkTask extends SinkTask {
 
   @Override
   public void put(Collection<SinkRecord> records) {
+    if (trackPutAttempts) {
+      recordConverter.setCurrentPutAttemptId(UUID.randomUUID().toString());
+    }
     try {
       writeSinkRecords(records);
       remainingRetries = config.getInt(BigQuerySinkConfig.MAX_RETRIES_CONFIG);
@@ -492,6 +496,7 @@ public class BigQuerySinkTask extends SinkTask {
     recordConverter = getConverter(config);
     remainingRetries = config.getInt(BigQuerySinkConfig.MAX_RETRIES_CONFIG);
     enableRetries = config.getBoolean(BigQuerySinkConfig.ENABLE_RETRIES_CONFIG);
+    trackPutAttempts = config.getBoolean(BigQuerySinkConfig.TRACK_PUT_ATTEMPTS_CONFIG);
   }
 
   private void initializeStorageApiMode() {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -59,6 +59,7 @@ import com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiBase;
 import com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiBatchApplicationStream;
 import com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiDefaultStream;
 import com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiWriter;
+import de.huxhorn.sulky.ulid.ULID;
 import io.aiven.commons.system.VersionInfo;
 import java.time.Instant;
 import java.util.Arrays;
@@ -69,7 +70,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -98,7 +98,8 @@ public class BigQuerySinkTask extends SinkTask {
   private final BigQuery testBigQuery;
   private final Storage testGcs;
   private final SchemaManager testSchemaManager;
-  private final UUID uuid = UUID.randomUUID();
+  private static final ULID ULID_GENERATOR = new ULID();
+  private final String uuid = ULID_GENERATOR.nextULID();
   private final StorageWriteApiBase testStorageWriteApi;
   private final StorageApiBatchModeHandler testStorageApiBatchHandler;
   private final Time time;
@@ -283,7 +284,7 @@ public class BigQuerySinkTask extends SinkTask {
   @Override
   public void put(Collection<SinkRecord> records) {
     if (trackPutAttempts) {
-      recordConverter.setCurrentPutAttemptId(UUID.randomUUID().toString());
+      recordConverter.setCurrentPutAttemptId(ULID_GENERATOR.nextULID());
     }
     try {
       writeSinkRecords(records);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -357,7 +357,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
   private static final String TRACK_PUT_ATTEMPTS_DOC =
       "When true and kafkaDataFieldName is set, a 'putAttemptId' field (STRING, NULLABLE) is added "
           + "to the Kafka metadata struct in every BigQuery row. Each invocation of put() by the "
-          + "Kafka Connect framework generates a fresh UUID for this field, making it possible to "
+          + "Kafka Connect framework generates a fresh ULID for this field, making it possible to "
           + "distinguish rows written in different put() attempts from rows written in the same "
           + "attempt. Useful for downstream deduplication of raw CDC tables. Has no effect if "
           + "kafkaDataFieldName is not configured. Enabling this on an existing table requires "

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -107,6 +107,8 @@ public class BigQuerySinkConfig extends AbstractConfig {
       + " with the same name as the topic name would be created";
   public static final String SANITIZE_FIELD_NAME_CONFIG = "sanitizeFieldNames";
   public static final Boolean SANITIZE_FIELD_NAME_DEFAULT = false;
+  public static final String TRACK_PUT_ATTEMPTS_CONFIG = "trackPutAttempts";
+  public static final Boolean TRACK_PUT_ATTEMPTS_DEFAULT = false;
   public static final String KAFKA_KEY_FIELD_NAME_CONFIG = "kafkaKeyFieldName";
   public static final String KAFKA_KEY_FIELD_NAME_DEFAULT = null;
   public static final String KAFKA_DATA_FIELD_NAME_CONFIG = "kafkaDataFieldName";
@@ -350,6 +352,16 @@ public class BigQuerySinkConfig extends AbstractConfig {
           + "If the field name starts with a digit, the sanitizer will add an underscore in "
           + "front of field name. Note: field a.b and a_b will have same value after sanitizing, "
           + "and might cause key duplication error.";
+  private static final ConfigDef.Type TRACK_PUT_ATTEMPTS_TYPE = ConfigDef.Type.BOOLEAN;
+  private static final ConfigDef.Importance TRACK_PUT_ATTEMPTS_IMPORTANCE = ConfigDef.Importance.LOW;
+  private static final String TRACK_PUT_ATTEMPTS_DOC =
+      "When true and kafkaDataFieldName is set, a 'putAttemptId' field (STRING, NULLABLE) is added "
+          + "to the Kafka metadata struct in every BigQuery row. Each invocation of put() by the "
+          + "Kafka Connect framework generates a fresh UUID for this field, making it possible to "
+          + "distinguish rows written in different put() attempts from rows written in the same "
+          + "attempt. Useful for downstream deduplication of raw CDC tables. Has no effect if "
+          + "kafkaDataFieldName is not configured. Enabling this on an existing table requires "
+          + "allowNewBigQueryFields=true. Default false (disabled).";
   private static final ConfigDef.Type KAFKA_KEY_FIELD_NAME_TYPE = ConfigDef.Type.STRING;
   private static final ConfigDef.Validator KAFKA_KEY_FIELD_NAME_VALIDATOR = new ConfigDef.NonEmptyString();
   private static final ConfigDef.Importance KAFKA_KEY_FIELD_NAME_IMPORTANCE = ConfigDef.Importance.LOW;
@@ -635,6 +647,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
     super(config, properties);
     logDeprecationWarnings();
     KafkaDataBuilder.setUseOriginalValues(getBoolean(PRESERVE_KAFKA_TOPIC_PARTITION_OFFSET__CONFIG));
+    KafkaDataBuilder.setTrackPutAttempts(getBoolean(TRACK_PUT_ATTEMPTS_CONFIG));
   }
 
   public BigQuerySinkConfig(Map<String, String> properties) {
@@ -750,6 +763,12 @@ public class BigQuerySinkConfig extends AbstractConfig {
                     SANITIZE_FIELD_NAME_DEFAULT,
                     SANITIZE_FIELD_NAME_IMPORTANCE,
                     SANITIZE_FIELD_NAME_DOC
+            ).define(
+                    TRACK_PUT_ATTEMPTS_CONFIG,
+                    TRACK_PUT_ATTEMPTS_TYPE,
+                    TRACK_PUT_ATTEMPTS_DEFAULT,
+                    TRACK_PUT_ATTEMPTS_IMPORTANCE,
+                    TRACK_PUT_ATTEMPTS_DOC
             ).define(
                     KAFKA_KEY_FIELD_NAME_CONFIG,
                     KAFKA_KEY_FIELD_NAME_TYPE,

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataBuilder.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataBuilder.java
@@ -29,7 +29,10 @@ import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.google.common.annotations.VisibleForTesting;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
@@ -46,6 +49,7 @@ public class KafkaDataBuilder {
   public static final String KAFKA_DATA_PARTITION_FIELD_NAME = "partition";
   public static final String KAFKA_DATA_OFFSET_FIELD_NAME = "offset";
   public static final String KAFKA_DATA_INSERT_TIME_FIELD_NAME = "insertTime";
+  public static final String KAFKA_DATA_PUT_ATTEMPT_ID_FIELD_NAME = "putAttemptId";
 
   /**
    * This is a marker variable for methods necessary to keep original sink record metadata.
@@ -58,6 +62,13 @@ public class KafkaDataBuilder {
    * when running in a post 3.6 Kafka.
    */
   private static boolean USE_ORIGINAL_VALUES = false;
+
+  /**
+   * When true, a per-put() attempt UUID is embedded as {@code putAttemptId} inside the kafka
+   * metadata struct, and the BQ schema for that struct includes the field. Controlled by
+   * {@code trackPutAttempts} connector config.
+   */
+  private static boolean trackPutAttempts = false;
 
   static {
     boolean kafkaConnectApiPost36;
@@ -97,6 +108,18 @@ public class KafkaDataBuilder {
   }
 
   /**
+   * Sets the put-attempt tracking flag. When true, {@link #buildKafkaDataField} includes a
+   * {@code putAttemptId} subfield in the BQ schema, and {@link #buildKafkaDataRecord(SinkRecord,
+   * String)} embeds the supplied attempt ID in the row map. Called from
+   * {@link com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig} constructor.
+   *
+   * @param track whether to track put() attempt IDs.
+   */
+  public static void setTrackPutAttempts(boolean track) {
+    trackPutAttempts = track;
+  }
+
+  /**
    * Sets the Kafka Post 3.6 flag.  Used in testing.
    *
    * @param post36Flag the state of the flag.
@@ -116,13 +139,21 @@ public class KafkaDataBuilder {
     Field topicField = com.google.cloud.bigquery.Field.of(KAFKA_DATA_TOPIC_FIELD_NAME, LegacySQLTypeName.STRING);
     Field partitionField = com.google.cloud.bigquery.Field.of(KAFKA_DATA_PARTITION_FIELD_NAME, LegacySQLTypeName.INTEGER);
     Field offsetField = com.google.cloud.bigquery.Field.of(KAFKA_DATA_OFFSET_FIELD_NAME, LegacySQLTypeName.INTEGER);
-    Field.Builder insertTimeBuilder = com.google.cloud.bigquery.Field.newBuilder(
+    Field insertTimeField = com.google.cloud.bigquery.Field.newBuilder(
             KAFKA_DATA_INSERT_TIME_FIELD_NAME, LegacySQLTypeName.TIMESTAMP)
-        .setMode(com.google.cloud.bigquery.Field.Mode.NULLABLE);
-    Field insertTimeField = insertTimeBuilder.build();
+        .setMode(com.google.cloud.bigquery.Field.Mode.NULLABLE).build();
+
+    List<Field> subFields = new ArrayList<>(
+        Arrays.asList(topicField, partitionField, offsetField, insertTimeField));
+
+    if (trackPutAttempts) {
+      subFields.add(com.google.cloud.bigquery.Field.newBuilder(
+              KAFKA_DATA_PUT_ATTEMPT_ID_FIELD_NAME, LegacySQLTypeName.STRING)
+          .setMode(com.google.cloud.bigquery.Field.Mode.NULLABLE).build());
+    }
 
     return Field.newBuilder(kafkaDataFieldName, LegacySQLTypeName.RECORD,
-            topicField, partitionField, offsetField, insertTimeField)
+            subFields.toArray(new Field[0]))
         .setMode(com.google.cloud.bigquery.Field.Mode.NULLABLE).build();
   }
 
@@ -151,29 +182,73 @@ public class KafkaDataBuilder {
   }
 
   /**
-   * Construct a map of Kafka Data record
+   * Construct a map of Kafka Data record. Backward-compatible overload; does not include
+   * {@code putAttemptId} even when {@code trackPutAttempts} is enabled.
    *
    * @param kafkaConnectRecord Kafka sink record to build kafka data from.
    * @return HashMap which contains the values of kafka topic, partition, offset, and insertTime.
    */
   public static Map<String, Object> buildKafkaDataRecord(SinkRecord kafkaConnectRecord) {
+    return buildKafkaDataRecord(kafkaConnectRecord, null);
+  }
+
+  /**
+   * Construct a map of Kafka Data record, optionally including a put-attempt identifier.
+   *
+   * <p>When {@code trackPutAttempts} is enabled and {@code putAttemptId} is non-null, the map
+   * includes a {@code putAttemptId} entry so that rows constructed during different
+   * {@code put()} invocations can be distinguished downstream.
+   *
+   * @param kafkaConnectRecord Kafka sink record to build kafka data from.
+   * @param putAttemptId UUID string generated at the start of the enclosing {@code put()} call,
+   *                     or {@code null} to omit the field.
+   * @return HashMap which contains the values of kafka topic, partition, offset, insertTime,
+   *         and optionally putAttemptId.
+   */
+  public static Map<String, Object> buildKafkaDataRecord(SinkRecord kafkaConnectRecord,
+                                                         String putAttemptId) {
     HashMap<String, Object> kafkaData = new HashMap<>();
     kafkaData.put(KAFKA_DATA_TOPIC_FIELD_NAME, maybeGetOriginalTopic(kafkaConnectRecord));
     kafkaData.put(KAFKA_DATA_PARTITION_FIELD_NAME, maybeGetOriginalKafkaPartition(kafkaConnectRecord));
     kafkaData.put(KAFKA_DATA_OFFSET_FIELD_NAME, maybeGetOriginalKafkaOffset(kafkaConnectRecord));
     kafkaData.put(KAFKA_DATA_INSERT_TIME_FIELD_NAME, System.currentTimeMillis() / 1000.0);
+    if (trackPutAttempts && putAttemptId != null) {
+      kafkaData.put(KAFKA_DATA_PUT_ATTEMPT_ID_FIELD_NAME, putAttemptId);
+    }
     return kafkaData;
   }
 
   /**
-   * Construct a map of Kafka Data record for sending to Storage Write API
+   * Construct a map of Kafka Data record for sending to Storage Write API.
+   * Backward-compatible overload; does not include {@code putAttemptId}.
    *
    * @param kafkaConnectRecord Kafka sink record to build kafka data from.
    * @return HashMap which contains the values of kafka topic, partition, offset, and insertTime in microseconds.
    */
   public static Map<String, Object> buildKafkaDataRecordStorageApi(SinkRecord kafkaConnectRecord) {
-    Map<String, Object> kafkaData = buildKafkaDataRecord(kafkaConnectRecord);
+    return buildKafkaDataRecordStorageApi(kafkaConnectRecord, null);
+  }
+
+  /**
+   * Construct a map of Kafka Data record for sending to Storage Write API, optionally including
+   * a put-attempt identifier.
+   *
+   * @param kafkaConnectRecord Kafka sink record to build kafka data from.
+   * @param putAttemptId UUID string generated at the start of the enclosing {@code put()} call,
+   *                     or {@code null} to omit the field.
+   * @return HashMap which contains the values of kafka topic, partition, offset, insertTime in
+   *         microseconds, and optionally putAttemptId.
+   */
+  public static Map<String, Object> buildKafkaDataRecordStorageApi(SinkRecord kafkaConnectRecord,
+                                                                   String putAttemptId) {
+    HashMap<String, Object> kafkaData = new HashMap<>();
+    kafkaData.put(KAFKA_DATA_TOPIC_FIELD_NAME, maybeGetOriginalTopic(kafkaConnectRecord));
+    kafkaData.put(KAFKA_DATA_PARTITION_FIELD_NAME, maybeGetOriginalKafkaPartition(kafkaConnectRecord));
+    kafkaData.put(KAFKA_DATA_OFFSET_FIELD_NAME, maybeGetOriginalKafkaOffset(kafkaConnectRecord));
     kafkaData.put(KAFKA_DATA_INSERT_TIME_FIELD_NAME, System.currentTimeMillis() * 1000);
+    if (trackPutAttempts && putAttemptId != null) {
+      kafkaData.put(KAFKA_DATA_PUT_ATTEMPT_ID_FIELD_NAME, putAttemptId);
+    }
     return kafkaData;
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataBuilder.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataBuilder.java
@@ -64,7 +64,7 @@ public class KafkaDataBuilder {
   private static boolean USE_ORIGINAL_VALUES = false;
 
   /**
-   * When true, a per-put() attempt UUID is embedded as {@code putAttemptId} inside the kafka
+   * When true, a per-put() attempt ULID is embedded as {@code putAttemptId} inside the kafka
    * metadata struct, and the BQ schema for that struct includes the field. Controlled by
    * {@code trackPutAttempts} connector config.
    */
@@ -200,7 +200,7 @@ public class KafkaDataBuilder {
    * {@code put()} invocations can be distinguished downstream.
    *
    * @param kafkaConnectRecord Kafka sink record to build kafka data from.
-   * @param putAttemptId UUID string generated at the start of the enclosing {@code put()} call,
+   * @param putAttemptId ULID string generated at the start of the enclosing {@code put()} call,
    *                     or {@code null} to omit the field.
    * @return HashMap which contains the values of kafka topic, partition, offset, insertTime,
    *         and optionally putAttemptId.
@@ -234,7 +234,7 @@ public class KafkaDataBuilder {
    * a put-attempt identifier.
    *
    * @param kafkaConnectRecord Kafka sink record to build kafka data from.
-   * @param putAttemptId UUID string generated at the start of the enclosing {@code put()} call,
+   * @param putAttemptId ULID string generated at the start of the enclosing {@code put()} call,
    *                     or {@code null} to omit the field.
    * @return HashMap which contains the values of kafka topic, partition, offset, insertTime in
    *         microseconds, and optionally putAttemptId.

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataBuilder.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataBuilder.java
@@ -66,9 +66,9 @@ public class KafkaDataBuilder {
   /**
    * When true, a per-put() attempt ULID is embedded as {@code putAttemptId} inside the kafka
    * metadata struct, and the BQ schema for that struct includes the field. Controlled by
-   * {@code trackPutAttempts} connector config.
+   * {@code TRACK_PUT_ATTEMPTS} connector config.
    */
-  private static boolean trackPutAttempts = false;
+  private static boolean TRACK_PUT_ATTEMPTS = false;
 
   static {
     boolean kafkaConnectApiPost36;
@@ -116,7 +116,7 @@ public class KafkaDataBuilder {
    * @param track whether to track put() attempt IDs.
    */
   public static void setTrackPutAttempts(boolean track) {
-    trackPutAttempts = track;
+    TRACK_PUT_ATTEMPTS = track;
   }
 
   /**
@@ -146,7 +146,7 @@ public class KafkaDataBuilder {
     List<Field> subFields = new ArrayList<>(
         Arrays.asList(topicField, partitionField, offsetField, insertTimeField));
 
-    if (trackPutAttempts) {
+    if (TRACK_PUT_ATTEMPTS) {
       subFields.add(com.google.cloud.bigquery.Field.newBuilder(
               KAFKA_DATA_PUT_ATTEMPT_ID_FIELD_NAME, LegacySQLTypeName.STRING)
           .setMode(com.google.cloud.bigquery.Field.Mode.NULLABLE).build());
@@ -183,7 +183,7 @@ public class KafkaDataBuilder {
 
   /**
    * Construct a map of Kafka Data record. Backward-compatible overload; does not include
-   * {@code putAttemptId} even when {@code trackPutAttempts} is enabled.
+   * {@code putAttemptId} even when {@code TRACK_PUT_ATTEMPTS} is enabled.
    *
    * @param kafkaConnectRecord Kafka sink record to build kafka data from.
    * @return HashMap which contains the values of kafka topic, partition, offset, and insertTime.
@@ -195,7 +195,7 @@ public class KafkaDataBuilder {
   /**
    * Construct a map of Kafka Data record, optionally including a put-attempt identifier.
    *
-   * <p>When {@code trackPutAttempts} is enabled and {@code putAttemptId} is non-null, the map
+   * <p>When {@code TRACK_PUT_ATTEMPTS} is enabled and {@code putAttemptId} is non-null, the map
    * includes a {@code putAttemptId} entry so that rows constructed during different
    * {@code put()} invocations can be distinguished downstream.
    *
@@ -212,7 +212,7 @@ public class KafkaDataBuilder {
     kafkaData.put(KAFKA_DATA_PARTITION_FIELD_NAME, maybeGetOriginalKafkaPartition(kafkaConnectRecord));
     kafkaData.put(KAFKA_DATA_OFFSET_FIELD_NAME, maybeGetOriginalKafkaOffset(kafkaConnectRecord));
     kafkaData.put(KAFKA_DATA_INSERT_TIME_FIELD_NAME, System.currentTimeMillis() / 1000.0);
-    if (trackPutAttempts && putAttemptId != null) {
+    if (TRACK_PUT_ATTEMPTS && putAttemptId != null) {
       kafkaData.put(KAFKA_DATA_PUT_ATTEMPT_ID_FIELD_NAME, putAttemptId);
     }
     return kafkaData;
@@ -246,7 +246,7 @@ public class KafkaDataBuilder {
     kafkaData.put(KAFKA_DATA_PARTITION_FIELD_NAME, maybeGetOriginalKafkaPartition(kafkaConnectRecord));
     kafkaData.put(KAFKA_DATA_OFFSET_FIELD_NAME, maybeGetOriginalKafkaOffset(kafkaConnectRecord));
     kafkaData.put(KAFKA_DATA_INSERT_TIME_FIELD_NAME, System.currentTimeMillis() * 1000);
-    if (trackPutAttempts && putAttemptId != null) {
+    if (TRACK_PUT_ATTEMPTS && putAttemptId != null) {
       kafkaData.put(KAFKA_DATA_PUT_ATTEMPT_ID_FIELD_NAME, putAttemptId);
     }
     return kafkaData;

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverter.java
@@ -54,6 +54,10 @@ public class SinkRecordConverter {
   private final boolean useMessageTimeDatePartitioning;
   private final boolean usePartitionDecorator;
 
+  /** Set by {@link com.wepay.kafka.connect.bigquery.BigQuerySinkTask#put} at the start of each
+   * put() invocation when {@code trackPutAttempts} is enabled. Null otherwise. */
+  private volatile String currentPutAttemptId = null;
+
 
   public SinkRecordConverter(BigQuerySinkTaskConfig config,
                              MergeBatches mergeBatches, MergeQueries mergeQueries) {
@@ -67,6 +71,18 @@ public class SinkRecordConverter {
         config.getBoolean(config.BIGQUERY_MESSAGE_TIME_PARTITIONING_CONFIG);
     this.usePartitionDecorator =
         config.getBoolean(config.BIGQUERY_PARTITION_DECORATOR_CONFIG);
+  }
+
+  /**
+   * Called by {@link com.wepay.kafka.connect.bigquery.BigQuerySinkTask#put} once per put()
+   * invocation, before any rows are constructed. The ID is embedded in each row's kafka metadata
+   * struct when {@code trackPutAttempts} is enabled, allowing downstream consumers to distinguish
+   * rows produced by different put() attempts.
+   *
+   * @param id UUID string for the current put() invocation, or {@code null} to clear.
+   */
+  public void setCurrentPutAttemptId(String id) {
+    this.currentPutAttemptId = id;
   }
 
   public InsertAllRequest.RowToInsert getRecordRow(SinkRecord record, TableId table) {
@@ -85,7 +101,7 @@ public class SinkRecordConverter {
 
     if (convertedValue != null) {
       config.getKafkaDataFieldName().ifPresent(
-          fieldName -> convertedValue.put(fieldName, KafkaDataBuilder.buildKafkaDataRecord(record))
+          fieldName -> convertedValue.put(fieldName, KafkaDataBuilder.buildKafkaDataRecord(record, currentPutAttemptId))
       );
     }
 
@@ -126,8 +142,8 @@ public class SinkRecordConverter {
 
     config.getKafkaDataFieldName().ifPresent(fieldName -> {
       Map<String, Object> kafkaDataField = config.getBoolean(config.USE_STORAGE_WRITE_API_CONFIG)
-          ? KafkaDataBuilder.buildKafkaDataRecordStorageApi(record)
-          : KafkaDataBuilder.buildKafkaDataRecord(record);
+          ? KafkaDataBuilder.buildKafkaDataRecordStorageApi(record, currentPutAttemptId)
+          : KafkaDataBuilder.buildKafkaDataRecord(record, currentPutAttemptId);
       result.put(fieldName, kafkaDataField);
     });
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverter.java
@@ -79,7 +79,7 @@ public class SinkRecordConverter {
    * struct when {@code trackPutAttempts} is enabled, allowing downstream consumers to distinguish
    * rows produced by different put() attempts.
    *
-   * @param id UUID string for the current put() invocation, or {@code null} to clear.
+   * @param id ULID string for the current put() invocation, or {@code null} to clear.
    */
   public void setCurrentPutAttemptId(String id) {
     this.currentPutAttemptId = id;

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataConverterTest.java
@@ -24,7 +24,9 @@
 package com.wepay.kafka.connect.bigquery.convert;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.cloud.bigquery.Field;
@@ -64,6 +66,8 @@ public class KafkaDataConverterTest {
     expectedKafkaDataFields.put(kafkaDataTopicName, kafkaDataTopicValue);
     expectedKafkaDataFields.put(kafkaDataPartitionName, kafkaDataPartitionValue);
     expectedKafkaDataFields.put(kafkaDataOffsetName, kafkaDataOffsetValue);
+    // Reset static flag so tests do not interfere with each other
+    KafkaDataBuilder.setTrackPutAttempts(false);
   }
 
   @Test
@@ -181,5 +185,104 @@ public class KafkaDataConverterTest {
         .build();
     Field actualBigQuerySchema = KafkaDataBuilder.buildKafkaDataField(kafkaDataFieldName);
     assertEquals(expectedBigQuerySchema, actualBigQuerySchema);
+  }
+
+  // ---- trackPutAttempts tests ----
+
+  @Test
+  public void testBuildKafkaDataRecord_flagEnabled_includesPutAttemptId() {
+    SinkRecord record = new SinkRecord(kafkaDataTopicValue, kafkaDataPartitionValue, null, null, null, null, kafkaDataOffsetValue);
+    KafkaDataBuilder.setTrackPutAttempts(true);
+
+    Map<String, Object> result = KafkaDataBuilder.buildKafkaDataRecord(record, "attempt-abc");
+
+    assertTrue(result.containsKey(KafkaDataBuilder.KAFKA_DATA_PUT_ATTEMPT_ID_FIELD_NAME));
+    assertEquals("attempt-abc", result.get(KafkaDataBuilder.KAFKA_DATA_PUT_ATTEMPT_ID_FIELD_NAME));
+    assertInstanceOf(Double.class, result.get(kafkaDataInsertTimeName));
+  }
+
+  @Test
+  public void testBuildKafkaDataRecord_flagDisabled_excludesPutAttemptId() {
+    SinkRecord record = new SinkRecord(kafkaDataTopicValue, kafkaDataPartitionValue, null, null, null, null, kafkaDataOffsetValue);
+    // flag already false from setup()
+
+    Map<String, Object> result = KafkaDataBuilder.buildKafkaDataRecord(record, "attempt-abc");
+
+    assertFalse(result.containsKey(KafkaDataBuilder.KAFKA_DATA_PUT_ATTEMPT_ID_FIELD_NAME));
+  }
+
+  @Test
+  public void testBuildKafkaDataRecord_flagEnabled_nullAttemptId_excludesPutAttemptId() {
+    SinkRecord record = new SinkRecord(kafkaDataTopicValue, kafkaDataPartitionValue, null, null, null, null, kafkaDataOffsetValue);
+    KafkaDataBuilder.setTrackPutAttempts(true);
+
+    Map<String, Object> result = KafkaDataBuilder.buildKafkaDataRecord(record, null);
+
+    assertFalse(result.containsKey(KafkaDataBuilder.KAFKA_DATA_PUT_ATTEMPT_ID_FIELD_NAME));
+  }
+
+  @Test
+  public void testBuildKafkaDataRecord_twoAttemptsProduceDifferentIds() {
+    SinkRecord record = new SinkRecord(kafkaDataTopicValue, kafkaDataPartitionValue, null, null, null, null, kafkaDataOffsetValue);
+    KafkaDataBuilder.setTrackPutAttempts(true);
+
+    Map<String, Object> row1 = KafkaDataBuilder.buildKafkaDataRecord(record, "attempt-1");
+    Map<String, Object> row2 = KafkaDataBuilder.buildKafkaDataRecord(record, "attempt-2");
+
+    assertNotEquals(
+        row1.get(KafkaDataBuilder.KAFKA_DATA_PUT_ATTEMPT_ID_FIELD_NAME),
+        row2.get(KafkaDataBuilder.KAFKA_DATA_PUT_ATTEMPT_ID_FIELD_NAME)
+    );
+  }
+
+  @Test
+  public void testBuildKafkaDataField_flagEnabled_includesPutAttemptIdSubfield() {
+    KafkaDataBuilder.setTrackPutAttempts(true);
+
+    Field recordField = KafkaDataBuilder.buildKafkaDataField(kafkaDataFieldName);
+
+    boolean found = recordField.getSubFields().stream()
+        .anyMatch(f -> KafkaDataBuilder.KAFKA_DATA_PUT_ATTEMPT_ID_FIELD_NAME.equals(f.getName())
+            && LegacySQLTypeName.STRING.equals(f.getType())
+            && Field.Mode.NULLABLE.equals(f.getMode()));
+    assertTrue(found, "putAttemptId STRING NULLABLE subfield should be present when flag is enabled");
+  }
+
+  @Test
+  public void testBuildKafkaDataField_flagDisabled_excludesPutAttemptIdSubfield() {
+    // flag already false from setup()
+
+    Field recordField = KafkaDataBuilder.buildKafkaDataField(kafkaDataFieldName);
+
+    boolean found = recordField.getSubFields().stream()
+        .anyMatch(f -> KafkaDataBuilder.KAFKA_DATA_PUT_ATTEMPT_ID_FIELD_NAME.equals(f.getName()));
+    assertFalse(found, "putAttemptId subfield should not be present when flag is disabled");
+  }
+
+  @Test
+  public void testBuildKafkaDataRecordStorageApi_flagEnabled_includesPutAttemptId() {
+    SinkRecord record = new SinkRecord(kafkaDataTopicValue, kafkaDataPartitionValue, null, null, null, null, kafkaDataOffsetValue);
+    KafkaDataBuilder.setTrackPutAttempts(true);
+
+    Map<String, Object> result = KafkaDataBuilder.buildKafkaDataRecordStorageApi(record, "attempt-xyz");
+
+    assertTrue(result.containsKey(KafkaDataBuilder.KAFKA_DATA_PUT_ATTEMPT_ID_FIELD_NAME));
+    assertEquals("attempt-xyz", result.get(KafkaDataBuilder.KAFKA_DATA_PUT_ATTEMPT_ID_FIELD_NAME));
+    assertInstanceOf(Long.class, result.get(kafkaDataInsertTimeName));
+    assertTrue((Long) result.get(kafkaDataInsertTimeName) > 0);
+  }
+
+  @Test
+  public void testBuildKafkaDataRecord_noArgOverload_backwardCompatible() {
+    SinkRecord record = new SinkRecord(kafkaDataTopicValue, kafkaDataPartitionValue, null, null, null, null, kafkaDataOffsetValue);
+    // flag is false from setup()
+
+    Map<String, Object> result = KafkaDataBuilder.buildKafkaDataRecord(record);
+
+    assertFalse(result.containsKey(KafkaDataBuilder.KAFKA_DATA_PUT_ATTEMPT_ID_FIELD_NAME));
+    assertTrue(result.containsKey(kafkaDataTopicName));
+    assertTrue(result.containsKey(kafkaDataPartitionName));
+    assertTrue(result.containsKey(kafkaDataOffsetName));
+    assertTrue(result.containsKey(kafkaDataInsertTimeName));
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
         <kafka.scala.version>2.12</kafka.scala.version>
         <slf4j.version>1.7.26</slf4j.version>
         <caffeine.version>2.8.6</caffeine.version>
+        <de.huxhorn.sulky.ulid.version>8.3.0</de.huxhorn.sulky.ulid.version>
 
         <junit.version>5.10.2</junit.version>
         <mockito.version>5.20.0</mockito.version>
@@ -346,6 +347,11 @@
                 <groupId>com.google.re2j</groupId>
                 <artifactId>re2j</artifactId>
                 <version>${com.google.re2j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.huxhorn.sulky</groupId>
+                <artifactId>de.huxhorn.sulky.ulid</artifactId>
+                <version>${de.huxhorn.sulky.ulid.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Ticket no:  103807

# Problem
During BigQuery sink operations, internal writer retries result in duplicate records sharing the exact same `__kafka.insertTime`. This prevents reliable downstream deduplication, which relies on accurate insertion timestamps to differentiate between initial write attempts and subsequent retries.

The `__kafka.insertTime` field is populated during row construction through [KafkaDataBuilder.buildKafkaDataRecord(),](https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/blob/main/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataBuilder.java#L159) which uses the current system wall-clock time. This happens while [BigQuerySinkTask.put()](https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/blob/main/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java#L283) processes the batch and converts `SinkRecord` objects into BigQuery row payloads. At that moment, the timestamp is materialized into the `RowToInsert` object.

Once those rows are constructed and passed to the writer threads, the row payload is already fixed. If a writer thread encounters a retryable error and retries the BigQuery insert within the same `put()` execution, it reuses the same already-built row payload. Because the row is retried without invoking `buildKafkaDataRecord()` again, the `__kafka.insertTime` remains the original one from the first row build.

# Solution

Introduces an optional sink-level feature flag, `trackPutAttempts` (boolean, default false). When enabled alongside `kafkaDataFieldName`, a new `putAttemptId` field (`STRING`, `NULLABLE`) is added to the Kafka metadata struct in every BigQuery row. At the start of each `put()` invocation, the sink task generates a `UUID.randomUUID()` and stores it on the `SinkRecordConverter`. All rows constructed during that `put()` call embed the same UUID. A subsequent Connect-level retry of the same records calls `put()` again, which generates a new UUID, so the retried rows are distinguishable from the original rows regardless of how close together in time the two attempts occurred.


# New parameters

## `trackPutAttempts(boolean)`

When true and `kafkaDataFieldName` is set, embeds a `putAttemptId` UUID (`STRING`, `NULLABLE`) in the Kafka metadata struct of each row. Each `put()` invocation generates a new UUID, making rows from different put attempts distinguishable for downstream deduplication. Has no effect if `kafkaDataFieldName`.

**Important:** Enabling this on an existing table that already has a `kafkaDataFieldName` column adds a new `NULLABLE` subfield to that column's `RECORD` schema. This requires `allowNewBigQueryFields=true` to be set.

---

# How it works

1. `BigQuerySinkConfig` constructor calls `KafkaDataBuilder.setTrackPutAttempts(true)` when the flag is enabled — consistent with the existing `setUseOriginalValues()` pattern.
2. `BigQuerySinkTask.put()` calls `recordConverter.setCurrentPutAttemptId(UUID.randomUUID().toString())` before `writeSinkRecords()`. This ID is fixed for the lifetime of one `put()` call and replaced on the next.
3. `SinkRecordConverter` stores the current attempt ID and passes it to `KafkaDataBuilder.buildKafkaDataRecord(record, putAttemptId)` and `buildKafkaDataRecordStorageApi(record, putAttemptId)` at row construction time.
4. `KafkaDataBuilder` embeds `putAttemptId` in the row map and, when building the BQ schema via `buildKafkaDataField()`, conditionally adds `putAttemptId` as a `STRING NULLABLE` subfield of the kafka metadata `RECORD`.

---

# Backward compatibility

* Flag defaults to `false` — zero behavior change for all existing deployments.
* The existing `buildKafkaDataRecord(SinkRecord)` and `buildKafkaDataRecordStorageApi(SinkRecord)` no-arg methods are preserved as backward-compatible wrappers delegating to the new `(SinkRecord, String)` overloads with `null`.
* `SinkRecordConverter.currentPutAttemptId` defaults to `null`; when the flag is off, `null` is always passed and the builder omits `putAttemptId` from both the row map and the BQ schema.

---
# Tests

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.676 s -- in com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiWriterTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.049 s -- in com.wepay.kafka.connect.bigquery.write.storage.BigQueryBuilderTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.013 s -- in com.wepay.kafka.connect.bigquery.write.storage.BigQueryWriteSettingsBuilderTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.045 s -- in com.wepay.kafka.connect.bigquery.write.storage.GcsBuilderTest
[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.175 s -- in com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiBatchApplicationStreamTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s -- in com.wepay.kafka.connect.bigquery.write.storage.StorageApiBatchModeHandlerTest
[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.049 s -- in com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiDefaultStreamTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.211 s -- in com.wepay.kafka.connect.bigquery.write.row.BigQueryWriterTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 s -- in com.wepay.kafka.connect.bigquery.write.row.GcsToBqWriterTest$JsonSerializationTests
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.044 s -- in com.wepay.kafka.connect.bigquery.write.row.GcsToBqWriterTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.048 s -- in com.wepay.kafka.connect.bigquery.write.batch.GcsBatchTableWriterTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.182 s -- in com.wepay.kafka.connect.bigquery.GcpClientBuilderProjectTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.045 s -- in com.wepay.kafka.connect.bigquery.config.GcsBucketValidatorTest
[INFO] Tests run: 33, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.029 s -- in com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfigTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s -- in com.wepay.kafka.connect.bigquery.config.PartitioningModeValidatorTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s -- in com.wepay.kafka.connect.bigquery.config.MultiPropertyValidatorTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.020 s -- in com.wepay.kafka.connect.bigquery.config.CredentialsValidatorTest
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s -- in com.wepay.kafka.connect.bigquery.config.StorageWriteApiValidatorTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s -- in com.wepay.kafka.connect.bigquery.config.PartitioningTypeValidatorTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s -- in com.wepay.kafka.connect.bigquery.utils.PartitionedTableIdTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s -- in com.wepay.kafka.connect.bigquery.utils.FieldNameSanitizerTest
[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.057 s -- in com.wepay.kafka.connect.bigquery.RecordTableResolverTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s -- in com.wepay.kafka.connect.bigquery.ErrantRecordHandlerTest
[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.183 s -- in com.wepay.kafka.connect.bigquery.BigQuerySinkTaskTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.169 s -- in com.wepay.kafka.connect.bigquery.BigQueryStorageApiBatchSinkTaskTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s -- in com.wepay.kafka.connect.bigquery.BigQuerySinkConnectorTest
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.073 s -- in com.wepay.kafka.connect.bigquery.MergeQueriesTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.109 s -- in com.wepay.kafka.connect.bigquery.BigQueryStorageApiSinkTaskTest
[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 s -- in com.wepay.kafka.connect.bigquery.exception.BigQueryStorageWriteApiErrorResponsesTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s -- in com.wepay.kafka.connect.bigquery.exception.BigQueryErrorResponsesTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s -- in com.wepay.kafka.connect.bigquery.exception.BigQueryStorageWriteApiConnectExceptionTest
[INFO] Tests run: 39, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.065 s -- in com.wepay.kafka.connect.bigquery.SchemaManagerTest
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.095 s -- in com.wepay.kafka.connect.bigquery.GcsToBqLoadRunnableTest
[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s -- in com.wepay.kafka.connect.bigquery.convert.KafkaDataConverterTest
[INFO] Tests run: 42, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.093 s -- in com.wepay.kafka.connect.bigquery.convert.BigQuerySchemaConverterTest
[INFO] Tests run: 38, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.025 s -- in com.wepay.kafka.connect.bigquery.convert.BigQueryRecordConverterTest
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s -- in com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConvertersTest
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s -- in com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConvertersTest
[INFO] Results:
[INFO] 
[INFO] Tests run: 383, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  4.528 s
[INFO] Finished at: 2026-04-23T16:30:26+02:00
[INFO] ------------------------------------------------------------------------

```
