### PR TITLE
fix release processing

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -58,6 +58,15 @@ jobs:
           export version=$(echo ${commit_title} | sed s/^Release\ version\ //g)
           echo "Will use version ${version}"
           echo "version=${version}" >> $GITHUB_ENV
+          
+          if [[ `grep -c "^## " docs/src/site/markdown/RELEASE_NOTES.md` -gt 1 ]]
+          then
+            grep -B 999 -m2 "^## " docs/src/site/markdown/RELEASE_NOTES.md  | head -n -1  | tail -n +5 > /tmp/release_notes.txt
+          else
+            cp docs/src/site/markdown/RELEASE_NOTES.md /tmp/release_body.txt
+          fi
+        id: project
+
 
       - name: Set up JDK 8
         uses: actions/setup-java@v4
@@ -88,17 +97,15 @@ jobs:
 
       - name: Create release draft
         id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v2.6.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: "v${{ env.version }}"
-          release_name: "v${{ env.version }}"
-          commitish: ${{ github.event.inputs.commit_hash }}
-          body: |
-            *Fill in*
+          #tag_name: "v${{ env.version }}"
+          target_commitish: ${{ github.event.inputs.commit_hash }}
           draft: true
           prerelease: false
+          body_path: /tmp/release_body.txt
 
       - name: Upload tar
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -61,7 +61,7 @@ jobs:
           
           if [[ `grep -c "^## " docs/src/site/markdown/RELEASE_NOTES.md` -gt 1 ]]
           then
-            grep -B 999 -m2 "^## " docs/src/site/markdown/RELEASE_NOTES.md  | head -n -1  | tail -n +5 > /tmp/release_notes.txt
+            grep -B 999 -m2 "^## " docs/src/site/markdown/RELEASE_NOTES.md  | head -n -1  | tail -n +5 > /tmp/release_body.txt
           else
             cp docs/src/site/markdown/RELEASE_NOTES.md /tmp/release_body.txt
           fi

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Copyright 2022 Aiven Oy and
+# Copyright 2026 Copyright 2022 Aiven Oy and
 # bigquery-connector-for-apache-kafka project contributors
 #
 # This software contains code derived from the Confluent BigQuery
@@ -59,16 +59,16 @@ jobs:
           echo "Will use version ${version}"
           echo "version=${version}" >> $GITHUB_ENV
           
-          if [[ `grep -c "^## " docs/src/site/markdown/RELEASE_NOTES.md` -gt 1 ]]
+          if [[ `grep -c "^## " CHANGE_LOG.md` -gt 1 ]]
           then
-            grep -B 999 -m2 "^## " docs/src/site/markdown/RELEASE_NOTES.md  | head -n -1  | tail -n +5 > /tmp/release_body.txt
+            grep -B 999 -m2 "^## " CHANGE_LOG.md  | head -n -1  | tail -n +5 > /tmp/release_body.txt
           else
-            cp docs/src/site/markdown/RELEASE_NOTES.md /tmp/release_body.txt
+            cp CHANGE_LOG.md /tmp/release_body.txt
           fi
         id: project
 
 
-      - name: Set up JDK 8
+      - name: Set up JDK
         uses: actions/setup-java@v4
         with:
           distribution: 'adopt'

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7.0.1
         with:
           ref: ${{ github.event.inputs.commit_hash }}
 
@@ -69,9 +69,9 @@ jobs:
 
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.7.0
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 17
           cache: maven
 

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2026 Copyright 2022 Aiven Oy and
+# Copyright 2022-2026 Aiven Oy and
 # bigquery-connector-for-apache-kafka project contributors
 #
 # This software contains code derived from the Confluent BigQuery
@@ -101,7 +101,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          #tag_name: "v${{ env.version }}"
           target_commitish: ${{ github.event.inputs.commit_hash }}
           draft: true
           prerelease: false

--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -81,13 +81,19 @@ jobs:
         run: |
           git config --local user.name "GitHub Action"
           git config --local user.email "action@github.com"
-          mvn -e -B -V -ntp versions:set versions:update-child-modules versions:set-property -Dproperty=latestRelease -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.release_version }} 
+          mvn -e -B -V -ntp versions:set versions:update-child-modules versions:set-property -Dproperty=latestRelease -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.release_version }}
           mvn -e -B -V -ntp enforcer:enforce -Denforcer.rules=requireReleaseDeps
+          mvn -e -B -V -ntp -f docs versions:update-parent -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.release_version }}  
+          mvn -e -B -V -ntp -f docs enforcer:enforce -Denforcer.rules=requireReleaseDeps
+          mvn -e -B -V -ntp -f tools versions:update-parent -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.release_version }} 
+          mvn -e -B -V -ntp -f tools enforcer:enforce -Denforcer.rules=requireReleaseDeps
           git add pom.xml **/pom.xml
           git commit -m "Release version ${{ github.event.inputs.release_version }}"
           git tag -a "v${{ steps.project.outputs.version }}" -m "Release version ${{ steps.project.outputs.version }}"
-    
-          mvn -e -B -V -ntp versions:set versions:update-child-modules -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.snapshot_version }}
+
+          mvn -e -B -V -ntp versions:set versions:update-child-modules -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.snapshot_version }} install
+          mvn -e -B -V -ntp -f docs versions:update-parent -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.snapshot_version }} -DallowSnapshots=true
+          mvn -e -B -V -ntp -f tools versions:update-parent -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.release_version }} -DallowSnapshots=true 
           git add pom.xml **/pom.xml
           git commit -m "Bump version to ${{ github.event.inputs.snapshot_version }}"
 

--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -81,6 +81,15 @@ jobs:
         run: |
           git config --local user.name "GitHub Action"
           git config --local user.email "action@github.com"
+          #
+          # | options | Description|
+          # |----------|------------|
+          # | -e       | Produce execution error messages|
+          # | -B       | Run in non interactive (batch) mode (disables output colour) |
+          # | -V       | Display version information without stopping the build |
+          # | -ntp     | Do not display transfer progress when downloading or uploading|
+          # | -f       | Force the use of an alternative POM file or directory with pom.xml |
+          #        
           mvn -e -B -V -ntp versions:set versions:update-child-modules versions:set-property -Dproperty=latestRelease -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.release_version }}
           mvn -e -B -V -ntp enforcer:enforce -Denforcer.rules=requireReleaseDeps
           mvn -e -B -V -ntp -f docs versions:update-parent -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.release_version }}  

--- a/.github/workflows/create_release_pr.yml
+++ b/.github/workflows/create_release_pr.yml
@@ -52,7 +52,7 @@ jobs:
           fi
 
       - name: Checkout main
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
         with:
           ref: main
           fetch-depth: 0
@@ -71,9 +71,9 @@ jobs:
         id: project
 
       - name: Set up Java ${{ steps.project.outputs.java_version }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.7.0
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ steps.project.outputs.java_version }}
           cache: maven
 

--- a/.github/workflows/prs_and_commits.yml
+++ b/.github/workflows/prs_and_commits.yml
@@ -47,14 +47,28 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7.0.1
+
       - name: Set up JDK 17
         uses: actions/setup-java@v5.7.0
         with:
           distribution: 'temurin'
           java-version: 17
           cache: maven
+
+      - name: Calc load
+        run: |
+          echo "load=$(uptime | cut -d, -f3 | cut -d: -f2)" >> $GITHUB_OUTPUT;
+          echo "nproc=$(nproc)" >> $GITHUB_OUTPUT;
+          echo "scale=4;${load} / $(nproc)" | bc
+        id: project
+
+
       - name: Build (Maven)
+        env:
+          NPROC: ${{project.nproc}}
+          LOAD: ${{project.load}}
         run:  mvn -ntp -P ci clean install -DskipITs
+
       - name: Upload test results (Maven)
         if: always()
         uses: actions/upload-artifact@v7.0.1

--- a/.github/workflows/prs_and_commits.yml
+++ b/.github/workflows/prs_and_commits.yml
@@ -65,8 +65,8 @@ jobs:
 
       - name: Build (Maven)
         env:
-          NPROC: ${{project.nproc}}
-          LOAD: ${{project.load}}
+          NPROC: ${{ steps.project.outputs.nproc }}
+          LOAD: ${{ steps.project.outputs.load }}
         run:  mvn -ntp -P ci clean install -DskipITs
 
       - name: Upload test results (Maven)

--- a/.github/workflows/prs_and_commits.yml
+++ b/.github/workflows/prs_and_commits.yml
@@ -59,6 +59,7 @@ jobs:
         run: |
           echo $(which uptime)
           echo $(uptime | cut -d, -f3 | cut -d: -f2)
+          echo "load=$(uptime | cut -d, -f3 | cut -d: -f2)"
           echo "load=$(uptime | cut -d, -f3 | cut -d: -f2)" >> $GITHUB_OUTPUT;
           echo "nproc=$(nproc)" >> $GITHUB_OUTPUT;
           echo "scale=4;${load} / $(nproc)" | bc

--- a/.github/workflows/prs_and_commits.yml
+++ b/.github/workflows/prs_and_commits.yml
@@ -59,7 +59,6 @@ jobs:
         run: |
           echo "load=$(uptime | cut -d, -f3 | cut -d: -f2 | xargs)" >> $GITHUB_OUTPUT;
           echo "nproc=$(nproc)" >> $GITHUB_OUTPUT;
-          echo "scale=4;${load} / $(nproc)" | bc
         id: project
 
 

--- a/.github/workflows/prs_and_commits.yml
+++ b/.github/workflows/prs_and_commits.yml
@@ -57,6 +57,8 @@ jobs:
 
       - name: Calc load
         run: |
+          echo $(which uptime)
+          echo $(uptime | cut -d, -f3 | cut -d: -f2)
           echo "load=$(uptime | cut -d, -f3 | cut -d: -f2)" >> $GITHUB_OUTPUT;
           echo "nproc=$(nproc)" >> $GITHUB_OUTPUT;
           echo "scale=4;${load} / $(nproc)" | bc

--- a/.github/workflows/prs_and_commits.yml
+++ b/.github/workflows/prs_and_commits.yml
@@ -57,10 +57,7 @@ jobs:
 
       - name: Calc load
         run: |
-          echo $(which uptime)
-          echo $(uptime | cut -d, -f3 | cut -d: -f2)
-          echo "load=$(uptime | cut -d, -f3 | cut -d: -f2)"
-          echo "load=$(uptime | cut -d, -f3 | cut -d: -f2)" >> $GITHUB_OUTPUT;
+          echo "load=$(uptime | cut -d, -f3 | cut -d: -f2 | xargs)" >> $GITHUB_OUTPUT;
           echo "nproc=$(nproc)" >> $GITHUB_OUTPUT;
           echo "scale=4;${load} / $(nproc)" | bc
         id: project

--- a/.github/workflows/prs_and_commits.yml
+++ b/.github/workflows/prs_and_commits.yml
@@ -77,7 +77,7 @@ jobs:
           KCBQ_TEST_PROJECT:    ${{ secrets.KCBQ_TEST_PROJECT }}
           KCBQ_TEST_DATASET:    ${{ secrets.KCBQ_TEST_DATASET }}
           KCBQ_TEST_BUCKET:     ${{ secrets.KCBQ_TEST_BUCKET }}
-        if: KCBQ_TEST_PROJECT != ''
+        #if:  KCBQ_TEST_PROJECT != ''
         run: |
           echo "$CREDENTIALS_JSON" > /tmp/creds.json
           export KCBQ_TEST_TABLE_SUFFIX=_$(date +%s)_$RANDOM
@@ -85,7 +85,7 @@ jobs:
       - name: Upload integration test results (Maven)
         env:
           KCBQ_TEST_PROJECT: ${{ secrets.KCBQ_TEST_PROJECT }}
-        if: KCBQ_TEST_PROJECT != ''
+        #if: KCBQ_TEST_PROJECT != ''
         uses: actions/upload-artifact@v4
         with:
           path: |

--- a/.github/workflows/prs_and_commits.yml
+++ b/.github/workflows/prs_and_commits.yml
@@ -46,18 +46,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7.0.1
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.7.0
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 17
           cache: maven
       - name: Build (Maven)
         run:  mvn -ntp -P ci clean install -DskipITs
       - name: Upload test results (Maven)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           path: |
             **/target/*-reports/*
@@ -86,7 +86,7 @@ jobs:
         env:
           KCBQ_TEST_PROJECT: ${{ secrets.KCBQ_TEST_PROJECT }}
         #if: KCBQ_TEST_PROJECT != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           path: |
             **/target/*-reports/*

--- a/.github/workflows/prs_and_commits.yml
+++ b/.github/workflows/prs_and_commits.yml
@@ -54,6 +54,19 @@ jobs:
           java-version: 17
           cache: maven
       - name: Build (Maven)
+        run:  mvn -ntp -P ci clean install -DskipITs
+      - name: Upload test results (Maven)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          path: |
+            **/target/*-reports/*
+            **/target/site/*
+            **/target/jacoco.exec
+          name: test-results
+          retention-days: 1
+
+      - name: Execute integration tests (Maven)
         env:
           # Necessary for client builder integration tests that run with
           # default application credentials
@@ -64,17 +77,20 @@ jobs:
           KCBQ_TEST_PROJECT:    ${{ secrets.KCBQ_TEST_PROJECT }}
           KCBQ_TEST_DATASET:    ${{ secrets.KCBQ_TEST_DATASET }}
           KCBQ_TEST_BUCKET:     ${{ secrets.KCBQ_TEST_BUCKET }}
+        if: KCBQ_TEST_PROJECT != ''
         run: |
           echo "$CREDENTIALS_JSON" > /tmp/creds.json
           export KCBQ_TEST_TABLE_SUFFIX=_$(date +%s)_$RANDOM
-          mvn -ntp -P ci clean verify
+          mvn -ntp -P ci verify
       - name: Upload integration test results (Maven)
-        if: always()
+        env:
+          KCBQ_TEST_PROJECT: ${{ secrets.KCBQ_TEST_PROJECT }}
+        if: KCBQ_TEST_PROJECT != ''
         uses: actions/upload-artifact@v4
         with:
           path: |
             **/target/*-reports/*
             **/target/site/*
             **/target/jacoco.exec
-          name: test-results
+          name: integration-test-results
           retention-days: 1

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -3,7 +3,7 @@
 
 All releases can be found at https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/releases
 
-#qgi# v2.14.0
+## v2.14.0
 ### What is changed
 
 - Update putAttemptId for uniqueness across internal Bigquery write retries and GCS Batch Idempotent Load Jobs (#206)

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -18,9 +18,9 @@ https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/compare/v2.13.
 ### What is changed
  
  - Update jackson-core and jetty versions (#192)
- - update release scripting (#191)
+ - Update release scripting (#191)
  - Bump org.apache.kafka:kafka-clients from 3.8.1 to 3.9.2 (#44)
- - Fix license check issue (#39)
+ - Fix: license check issue (#39)
  - Fix: Retry-and-reconcile for concurrent schema update failures in GCS to BQ Load (#188)
  - Add putAttemptId to kafka metadata struct for put()-level retry deduplication (#189)
  

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -1,36 +1,219 @@
-## v2.14.0
+
+# Change Log
+
+All releases can be found at https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/releases
+
+#qgi# v2.14.0
 ### What is changed
- 
- - Update putAttemptId for uniqueness across internal Bigquery write retries and GCS Batch Idempotent Load Jobs (#206)
- 
- 
+
+- Update putAttemptId for uniqueness across internal Bigquery write retries and GCS Batch Idempotent Load Jobs (#206)
+
 ### Co-authored by
- 
- - Claude Warren
- - Veli Can Ünal
- 
- 
+
+- Claude Warren
+- Veli Can Ünal
+
 ### Full Changelog
 
 https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/compare/v2.13.0...v2.14.0
- 
 ## v2.13.0
 ### What is changed
- 
- - Update jackson-core and jetty versions (#192)
- - Update release scripting (#191)
- - Bump org.apache.kafka:kafka-clients from 3.8.1 to 3.9.2 (#44)
- - Fix: license check issue (#39)
- - Fix: Retry-and-reconcile for concurrent schema update failures in GCS to BQ Load (#188)
- - Add putAttemptId to kafka metadata struct for put()-level retry deduplication (#189)
- 
- 
+
+- Update jackson-core and jetty versions (#192)
+- update release scripting (#191)
+- Bump org.apache.kafka:kafka-clients from 3.8.1 to 3.9.2 (#44)
+- Fix license check issue (#39)
+- Fix: Retry-and-reconcile for concurrent schema update failures in GCS to BQ Load (#188)
+- Add putAttemptId to kafka metadata struct for put()-level retry deduplication (#189)
+
+
 ### Co-authored by
- 
- - Claude Warren
- - Veli Can Ünal
- 
- 
+
+- Claude Warren
+- Veli Can Ünal
+
 ### Full Changelog
 https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/compare/v2.12.0...v2.13.0
- 
+
+## v2.12.0
+### What's changed
+- upgraded to google-utils v1.1.0 and system v1.1.0
+
+
+### Co-authored by
+- Claude Warren
+
+### Full Changelog
+https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/compare/v2.11.0...v2.12.0
+
+## v2.11.0
+### What's changed
+- Fix for CVE-2026-23529
+- Updated versions
+    - Java 8 -> 17
+    - confluent 7.6.0 -> 7.9.5
+    - jackson 2.14.2 -> 2.20.1
+    - kafka 3.6.1 -> 3.8.1
+- Introducted
+    - aiven-commons:system:1.0.0
+    - aiven-commons:google-utils:1.0.0
+- updated README
+
+
+### Co-authored by
+- Aindriú Lavelle
+- Audrey Budryte
+- Claude Warren
+
+
+### Full Changelog
+https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/compare/v2.10.3...v2.11.0
+
+
+## v2.10.3
+### What's changed
+- fix: populate LogicalConverterRegistry in Task
+
+### Co-authored by
+- Claude Warren
+
+
+### Full Changelog
+https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/compare/v2.10.2...v2.10.3
+
+## v2.10.2
+### What's changed
+- Fix serializing Infinity/NaN for Floats when convertDoubleSpecialValues is enabled (#162)
+- Fix bug with SchemaManager causing records to be placed on DLQ (#163)
+- Update documentation for DECIMAL_HANDLING_MODE_CONFIG (#156)
+
+### Co-authored by
+- Aindriú Lavelle
+- Claude Warren
+- Erik Gustafsson
+- HieuNT
+- Ryan Skraba
+
+
+### Full Changelog
+https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/compare/v2.10.1...v2.10.2
+
+## v2.10.1
+### What's changed
+- Fix potential silent data loss caused by stale BigQuery load job status not being refreshed (#155)
+- Fix data loss from BigQuery write exception during GCSBatchTableWriter run (#153)
+- Fix documentation error: the comments were attached to the wrong functions (#150)
+- Bump version to 2.11.0-SNAPSHOT
+
+### Co-authored by
+- Claude Warren
+- Gyllsdorff
+- Pammi-Jyothi
+- Ryan Skraba
+
+### Full Changelog
+https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/compare/v2.10.0...v2.10.1
+
+## v2.10.0
+### What's changed
+- Add ability to ignore unknown fields in kafka messages (#88)
+- skip test on kcbq-api build (#142)
+- Enable partition decorator syntax for Storage Write API (#69)
+- Specify Trace ID to enable BigQuery to track traffic originating from this connector. (#141)
+- Add ByteBuffer TypeAdapter to avoid reflection crash on Java 9+ (#140)
+- Add feature to update table schemas for GCStoBQ load jobs (#134)
+- Enable connection pooling on Storage Write API Default Stream (#89)
+- Update contributors list (#138)
+- Add design doc for WriteAPI partition decorator support (#135)
+- Add design doc and best practice doc (#136)
+- Add since tags to some configuration options
+- Update project id of BQ target table when useCredentialsProjectId is enabled (#123)
+- Bump version to 2.10.0-SNAPSHOT
+
+### Co-authored by
+- Aindriú Lavelle
+- Claude Warren
+- hasan-cosan
+- Mariia Podgaietska
+- minsungoh
+- Siddharth Agrawal
+- Veli Can Ünal
+
+### Full Changelog
+https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/compare/v2.9.0...v2.10.0
+
+## v2.9.0
+### What's changed
+- Fix retry login in GcsToBqWriter (#112)
+- Update readme (#115)
+- Create and Deploy the website (#102) (#110)
+- Revert GCS Batch loading deprecation
+- Add "deprecation" and "since" data to configuration options. (#103)
+- Add ability to generate a documentation site. (#102)
+- Enforced a minimum of 10 seconds for merge interval (#107)
+- Add checks for BigQuery ingestion failures (#99)
+- Revert deprecating partition decorator syntax (#68)
+- Fix closing writers race condition (#98)
+- Allow opt-in to use original message metadata (#97)
+- Enable client-side request level retries for Storage Write API (#81)
+
+### Co-authored by
+- Brahmesh
+- Claude Warren
+- Davide Armand
+- hasan-cosan
+- Mariia Podgaietska
+
+### Full Changelog
+https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/compare/v2.8.0...v2.9.0
+
+## v2.8.0
+### What's Changed
+- Updated Kafka.Decimal and Debezium.VariableScaleDecimal processing and adjusted tests (#82)
+- Added methods to LogicalConverterRegistry (#79)
+- Manifest contains valid specification information. #58 (#74)
+- Converted LogicalConverter libraries to true utility classes (#78)
+- Added log warning on lookup retries (#83)
+- Use the project defined in the connector configuration when useCredentialsProjectId is set to true (#75)
+- Retain the original topic, partition and offset in Kafka metadata record (#70)
+
+### New Contributors
+* @SamoylovMD made their first contribution in https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/pull/70
+* @hpmouton made their first contribution in https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/pull/74
+
+### Full Changelog ##
+https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/compare/v2.7.0...v2.8.0
+
+---------
+### Co-authored-by ##
+- Ryan Skraba <ryan.skraba@aiven.io>
+- Maksim Samoilov <maxim.samoilov@team.wrike.com>
+- Mouton <HoutonH@bdv.local>
+- veliuenal <veli.uenal@deliveryhero.com>
+
+## v2.7.0
+
+### What's Changed
+
+* Deprecate GCS batch loading feature (#20)
+* Deprecate partition decorator syntax feature (#21)
+* Bumps org.eclipse.jetty:jetty-server from 9.4.53.v20231009 to 9.4.56.v20240826.
+* Bumps org.eclipse.jetty:jetty-servlets from 9.4.53.v20231009 to 9.4.54.v20240208.
+* Add header provider (#57)
+* Retry getTable process before rasing any failure (#51)
+* Enable bigdecimal conversion for Debezium numeric types (#41)
+* Add optional configuration flag to use project ID from keyfile (#38)
+
+### New Contributors
+* @gharris1727 made their first contribution in https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/pull/28
+* @jeqo made their first contribution in https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/pull/29
+* @veliuenal made their first contribution in https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/pull/38
+
+### Full Changelog
+https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/compare/v2.6.0...v2.7.0
+
+## v2.6.0
+### What's Changed
+- Adds opt-in support for the [Storage Write API](https://cloud.google.com/bigquery/docs/write-api), which can be enabled via the `useStorageWriteApi` property. If enabled, the [default stream](https://cloud.google.com/bigquery/docs/write-api-streaming#at-least-once) will be used, unless the `enableBatchMode` property is set to `true`, in which case, the [pending type stream](https://cloud.google.com/bigquery/docs/write-api-batch#batch_load_data_using_pending_type) will be used instead. **NOTE: This is currently a beta feature and is not recommended for use in production.**
+- Permits multiple topics to be routed to the same table with the `topic2TableMap` property (https://github.com/confluentinc/kafka-connect-bigquery/pull/361)
+- Adds retry logic for "jobInternalError" errors when performing merge queries in upsert/delete mode (https://github.com/confluentinc/kafka-connect-bigquery/pull/363)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Kafka Connect BigQuery Connector
 
+
+[![Build site and deploy](https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/actions/workflows/build_site.yml/badge.svg)](https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/actions/workflows/build_site.yml)
+
 This is an implementation of a sink connector from [Apache Kafka](http://kafka.apache.org) to 
 [Google BigQuery](https://cloud.google.com/bigquery/), built on top 
 of [Apache Kafka Connect](https://kafka.apache.org/documentation.html#connect).

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -179,6 +179,7 @@
                                 <resource>
                                     <directory>${project.parent.basedir}/</directory>
                                     <includes>LICENSE.md</includes>
+                                    <includes>CHANGE_LOG.md</includes>
                                 </resource>
                             </resources>
                         </configuration>

--- a/docs/src/site/markdown/RELEASE_NOTES.md
+++ b/docs/src/site/markdown/RELEASE_NOTES.md
@@ -30,7 +30,7 @@ https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/compare/v2.13.
 ### Co-authored by
  
  - Claude Warren
- - Veli Can &#220;nal
+ - Veli Can Ünal
  
 ### Full Changelog
 https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/compare/v2.12.0...v2.13.0

--- a/docs/src/site/site.xml
+++ b/docs/src/site/site.xml
@@ -44,7 +44,7 @@
             <item name="Code of Conduct" href="CODE_OF_CONDUCT.html"/>
             <item name="Contributing" href="CONTRIBUTING.html"/>
             <item name="License" href="LICENSE.html"/>
-            <item name="Release Notes" href="RELEASE_NOTES.html"/>
+            <item name="Change log" href="CHANGE_LOG.html"/>
             <item name="Security" href="SECURITY.html"/>
         </menu>
 

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BaseConnectorIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BaseConnectorIT.java
@@ -104,6 +104,8 @@ public abstract class BaseConnectorIT {
   protected static final long ONE_SECOND = 1_000L;
 
   protected EmbeddedConnectCluster connect;
+  /** The status message if there are any issues with the connector status check */
+  protected String connectorStatus;
   private Admin kafkaAdminClient;
 
   protected static List<Byte> boxByteArray(byte[] bytes) {
@@ -208,7 +210,7 @@ public abstract class BaseConnectorIT {
             try {
               assertTrue(
                   assertConnectorAndTasksRunning(connector, numTasks).orElse(false),
-                  "Connector or one of its tasks failed during testing");
+                  () -> "Connector or one of its tasks failed during testing: " + connectorStatus);
             } catch (AssertionError e) {
               throw new NoRetryException(e);
             }
@@ -355,7 +357,7 @@ public abstract class BaseConnectorIT {
     waitForCondition(
         () -> assertConnectorAndTasksRunning(name, numTasks).orElse(false),
         CONNECTOR_STARTUP_DURATION_MS,
-        "Connector tasks did not start in time.");
+        "Connector tasks did not start in time: " + connectorStatus);
   }
 
   /**
@@ -363,19 +365,32 @@ public abstract class BaseConnectorIT {
    *
    * @param connectorName the connector
    * @param numTasks the minimum number of tasks
-   * @return an Optional {@code true} if the connector and tasks are in RUNNING state; {@code false}
-   *     if they are not and an empty Optional if there was an Exception thrown.
+   * @return an Optional {@code String} if the connector and tasks are not in RUNNING state; {@code
+   *     empty} if they are an empty Optional if there was an Exception thrown.
    */
   protected Optional<Boolean> assertConnectorAndTasksRunning(String connectorName, int numTasks) {
     try {
       ConnectorStateInfo info = connect.connectorStatus(connectorName);
-      boolean result =
-          info != null
-              && info.tasks().size() >= numTasks
-              && info.connector().state().equals(AbstractStatus.State.RUNNING.toString())
-              && info.tasks().stream()
-                  .allMatch(s -> s.state().equals(AbstractStatus.State.RUNNING.toString()));
-      return Optional.of(result);
+      List<String> msgs = new ArrayList<>();
+      if (info == null) {
+        msgs.add("Could not retrieve connector status.");
+      } else {
+        if (info.tasks().size() < numTasks) {
+          msgs.add(
+              String.format("Too few tasks expected %s got %s.", info.tasks().size(), numTasks));
+        }
+        if (!info.connector().state().equals(AbstractStatus.State.RUNNING.toString())) {
+          msgs.add("Connector state is " + info.connector().state());
+        }
+        info.tasks().stream()
+            .filter(s -> !s.state().equals(AbstractStatus.State.RUNNING.toString()))
+            .forEach(
+                ts ->
+                    msgs.add(
+                        String.format("Task %s is not running: %s.", ts.workerId(), ts.trace())));
+      }
+      connectorStatus = msgs.isEmpty() ? null : String.join(System.lineSeparator(), msgs);
+      return Optional.of(msgs.isEmpty());
     } catch (Exception e) {
       logger.warn("Could not check connector state info.", e);
       return Optional.empty();

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BaseConnectorIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BaseConnectorIT.java
@@ -100,6 +100,8 @@ public abstract class BaseConnectorIT {
   private static final String GCS_BUCKET_ENV_VAR = "KCBQ_TEST_BUCKET";
   private static final String GCS_FOLDER_ENV_VAR = "KCBQ_TEST_FOLDER";
   private static final String TEST_NAMESPACE_ENV_VAR = "KCBQ_TEST_TABLE_SUFFIX";
+  protected static final long ONE_MINUTE = 60_000L;
+  protected static final long ONE_SECOND = 1_000L;
 
   protected EmbeddedConnectCluster connect;
   private Admin kafkaAdminClient;

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BaseConnectorIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BaseConnectorIT.java
@@ -118,6 +118,10 @@ public abstract class BaseConnectorIT {
     return Arrays.asList(result);
   }
 
+  protected BaseConnectorIT() {
+    logger.info("load:{} nproc:{} wait factor: {}", load(), nproc(), waitFactor());
+  }
+
   protected void startConnect() {
     Map<String, String> workerProps = new HashMap<>();
     workerProps.put(
@@ -395,6 +399,7 @@ public abstract class BaseConnectorIT {
       return Optional.of(msgs.isEmpty());
     } catch (Exception e) {
       logger.warn("Could not check connector state info.", e);
+      connectorStatus = null;
       return Optional.empty();
     }
   }
@@ -423,6 +428,18 @@ public abstract class BaseConnectorIT {
 
   private String readEnvVar(String var, String defaultVal) {
     return System.getenv().getOrDefault(var, defaultVal).trim();
+  }
+
+  protected double waitFactor() {
+    return load() / nproc();
+  }
+
+  protected double load() {
+    return Double.parseDouble(readEnvVar("LOAD", "1.0"));
+  }
+
+  protected int nproc() {
+    return Integer.parseInt(readEnvVar("NPROC", "1"));
   }
 
   protected String keyFile() {

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BaseConnectorIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BaseConnectorIT.java
@@ -104,8 +104,10 @@ public abstract class BaseConnectorIT {
   protected static final long ONE_SECOND = 1_000L;
 
   protected EmbeddedConnectCluster connect;
+
   /** The status message if there are any issues with the connector status check */
   protected String connectorStatus;
+
   private Admin kafkaAdminClient;
 
   protected static List<Byte> boxByteArray(byte[] bytes) {

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BigQueryErrorResponsesIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BigQueryErrorResponsesIT.java
@@ -44,7 +44,6 @@ import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableInfo;
 import com.wepay.kafka.connect.bigquery.exception.BigQueryErrorResponses;
 import com.wepay.kafka.connect.bigquery.integration.utils.TableClearer;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -84,7 +83,7 @@ public class BigQueryErrorResponsesIT extends BaseConnectorIT {
                         table, RowToInsert.of(Collections.singletonMap("f1", "v1")))),
             "Should have failed to write to nonexistent table");
 
-    logger.debug("Nonexistent table write error:" + e.getMessage());
+    logger.debug("Nonexistent table write error: {}", e.getMessage());
     assertTrue(BigQueryErrorResponses.isNonExistentTableError(e));
   }
 
@@ -101,7 +100,7 @@ public class BigQueryErrorResponsesIT extends BaseConnectorIT {
     // Make sure that it exists...
     TestUtils.waitForCondition(
         () -> bigQuery.getTable(table) != null,
-        Duration.ofMinutes(1).toMillis(),
+        ONE_MINUTE,
         "Table does not appear to exist one minute after issuing create request");
     logger.info("Created {} successfully", table(table));
 
@@ -123,8 +122,12 @@ public class BigQueryErrorResponsesIT extends BaseConnectorIT {
                 InsertAllRequest.of(table, RowToInsert.of(Collections.singletonMap("f1", "v1"))));
             return false;
           } catch (BigQueryException e) {
-            logger.debug("Deleted table write error: " + e.getMessage());
-            return BigQueryErrorResponses.isNonExistentTableError(e);
+            if (BigQueryErrorResponses.isNonExistentTableError(e)) {
+              logger.debug("Deleted table write error: {}", e.getMessage());
+              return true;
+            }
+            logger.info("Unexpected error: {}", e.getMessage(), e);
+            return false;
           }
         },
         ONE_MINUTE,

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BigQueryErrorResponsesIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BigQueryErrorResponsesIT.java
@@ -44,12 +44,16 @@ import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableInfo;
 import com.wepay.kafka.connect.bigquery.exception.BigQueryErrorResponses;
 import com.wepay.kafka.connect.bigquery.integration.utils.TableClearer;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import org.apache.kafka.test.TestUtils;
@@ -114,6 +118,8 @@ public class BigQueryErrorResponsesIT extends BaseConnectorIT {
         "Table still appears to exist  one minute after issuing delete request");
     logger.info("Deleted {} successfully", table(table));
 
+    final ExceptionTracker exceptionTracker = new ExceptionTracker();
+
     TestUtils.waitForCondition(
         () -> {
           // Try to write to it...
@@ -126,15 +132,17 @@ public class BigQueryErrorResponsesIT extends BaseConnectorIT {
               logger.debug("Deleted table write error: {}", e.getMessage());
               return true;
             }
-            logger.info("Unexpected error: {}", e.getMessage(), e);
+            logger.info("Unexpected error: {}", exceptionTracker.recordException(e).getMessage());
             return false;
           }
         },
         ONE_MINUTE,
-        "Never failed to write to just-deleted table");
+        exceptionTracker.report("Never failed to write to just-deleted table."));
 
     // Recreate it...
     bigQuery.create(TableInfo.newBuilder(table, StandardTableDefinition.of(schema)).build());
+
+    exceptionTracker.reset();
 
     // this one takes time so only check every second.
     TestUtils.waitForCondition(
@@ -145,13 +153,15 @@ public class BigQueryErrorResponsesIT extends BaseConnectorIT {
                 InsertAllRequest.of(table, RowToInsert.of(Collections.singletonMap("f1", "v1"))));
             return true;
           } catch (BigQueryException e) {
-            logger.debug("Recreated table write error: {}", e.getMessage());
+            logger.debug(
+                "Recreated table write error: {}",
+                exceptionTracker.recordException(e).getMessage());
             return false;
           }
         },
         ONE_MINUTE,
         ONE_SECOND,
-        () -> "Never succeeded to write to just-recreated table");
+        () -> exceptionTracker.report("Never succeeded to write to just-recreated table."));
   }
 
   @Test
@@ -319,5 +329,59 @@ public class BigQueryErrorResponsesIT extends BaseConnectorIT {
   private <T> T assertListHasSingleElement(List<T> list) {
     assertEquals(1, list.size());
     return list.get(0);
+  }
+
+  /** Tracks the latest BigQueryException. */
+  private static final class ExceptionTracker {
+    private BigQueryException lastError = null;
+
+    /**
+     * Record the occurrence of the exception.
+     *
+     * @param exception the exception that was thrown.
+     * @return the exception.
+     */
+    public BigQueryException recordException(BigQueryException exception) {
+      lastError = exception;
+      return exception;
+    }
+
+    /**
+     * Produces a report for the exception, if any. Adds the exception stack trace to the base
+     * message if an exception was thrown. Otherwise returns the base message. May be used in lamda
+     * expressions to track exceptions and output detailed reports.
+     *
+     * @param baseMsg the basic message.
+     * @return the report message.
+     */
+    public String report(final String baseMsg) {
+      try (StringWriter sr = new StringWriter();
+          PrintWriter writer = new PrintWriter(sr)) {
+        writer.append(baseMsg);
+        if (lastError != null) {
+          writer.append(" Latest exception: ");
+          lastError.printStackTrace(writer);
+        }
+        writer.flush();
+        return sr.toString();
+      } catch (IOException e) {
+        return baseMsg;
+      }
+    }
+
+    /**
+     * Returns an Optional containing the last exception, if one was thrown, otherwise, an empty
+     * Optional.
+     *
+     * @return an Optional containing the last exception thrown.
+     */
+    public Optional<BigQueryException> getException() {
+      return Optional.ofNullable(lastError);
+    }
+
+    /** Resets the last error so that this tracker can be reused. */
+    public void reset() {
+      lastError = null;
+    }
   }
 }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BigQueryErrorResponsesIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BigQueryErrorResponsesIT.java
@@ -44,6 +44,7 @@ import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableInfo;
 import com.wepay.kafka.connect.bigquery.exception.BigQueryErrorResponses;
 import com.wepay.kafka.connect.bigquery.integration.utils.TableClearer;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -83,7 +84,7 @@ public class BigQueryErrorResponsesIT extends BaseConnectorIT {
                         table, RowToInsert.of(Collections.singletonMap("f1", "v1")))),
             "Should have failed to write to nonexistent table");
 
-    logger.debug("Nonexistent table write error", e);
+    logger.debug("Nonexistent table write error:" + e.getMessage());
     assertTrue(BigQueryErrorResponses.isNonExistentTableError(e));
   }
 
@@ -100,7 +101,7 @@ public class BigQueryErrorResponsesIT extends BaseConnectorIT {
     // Make sure that it exists...
     TestUtils.waitForCondition(
         () -> bigQuery.getTable(table) != null,
-        60_000L,
+        Duration.ofMinutes(1).toMillis(),
         "Table does not appear to exist one minute after issuing create request");
     logger.info("Created {} successfully", table(table));
 
@@ -110,7 +111,7 @@ public class BigQueryErrorResponsesIT extends BaseConnectorIT {
     // Make sure that it's deleted
     TestUtils.waitForCondition(
         () -> bigQuery.getTable(table) == null,
-        60_000L,
+        ONE_MINUTE,
         "Table still appears to exist  one minute after issuing delete request");
     logger.info("Deleted {} successfully", table(table));
 
@@ -122,16 +123,17 @@ public class BigQueryErrorResponsesIT extends BaseConnectorIT {
                 InsertAllRequest.of(table, RowToInsert.of(Collections.singletonMap("f1", "v1"))));
             return false;
           } catch (BigQueryException e) {
-            logger.debug("Deleted table write error", e);
+            logger.debug("Deleted table write error: " + e.getMessage());
             return BigQueryErrorResponses.isNonExistentTableError(e);
           }
         },
-        60_000L,
+        ONE_MINUTE,
         "Never failed to write to just-deleted table");
 
     // Recreate it...
     bigQuery.create(TableInfo.newBuilder(table, StandardTableDefinition.of(schema)).build());
 
+    // this one takes time so only check every second.
     TestUtils.waitForCondition(
         () -> {
           // Try to write to it...
@@ -140,12 +142,13 @@ public class BigQueryErrorResponsesIT extends BaseConnectorIT {
                 InsertAllRequest.of(table, RowToInsert.of(Collections.singletonMap("f1", "v1"))));
             return true;
           } catch (BigQueryException e) {
-            logger.debug("Recreated table write error", e);
+            logger.debug("Recreated table write error: {}", e.getMessage());
             return false;
           }
         },
-        60_000L,
-        "Never succeeded to write to just-recreated table");
+        ONE_MINUTE,
+        ONE_SECOND,
+        () -> "Never succeeded to write to just-recreated table");
   }
 
   @Test

--- a/scripts/release_detail.sh
+++ b/scripts/release_detail.sh
@@ -51,22 +51,21 @@ echo ' ' >> /tmp/proposed_changelog.txt;
 echo '### Full Changelog' >> /tmp/proposed_changelog.txt;
 echo 'https://github.com/Aiven-Open/${repositoryName}/compare/'${startTag}'...v'${endVersion}  >> /tmp/proposed_changelog.txt;
 echo ' ' >> /tmp/proposed_changelog.txt
-touch ${releaseNotes}
-grep -B 999 -m2 "^## " ${releaseNotes}  | tail -n +5 > /tmp/release_notes.txt
+touch CHANGE_LOG.md
+grep -B 999 -m2 "^## " CHANGE_LOG.md  | tail -n +5 > /tmp/release_notes.txt
 echo ' ' > /tmp/changelog.head
-echo '# Release Notes' >> /tmp/changelog.head
+echo '# Change log' >> /tmp/changelog.head
 echo ' ' >> /tmp/changelog.head
 echo 'All releases can be found at https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/releases' >> /tmp/changelog.head
 echo ' ' >> /tmp/changelog.head
 cat /tmp/changelog.head /tmp/proposed_changelog.txt /tmp/release_notes.txt >> /tmp/CHANGE_LOG.md
 
-mv /tmp/CHANGE_LOG.md ${releaseNotes}
+mv /tmp/CHANGE_LOG.md CHANGE_LOG.md
 
-git checkout -b release_notes-${endVersion}
+git checkout -b change_log-${endVersion}
 
-git add ${releaseNotes}
 git add CHANGE_LOG.md
-git commit -m "create Release notes and update changelog for ${startTag} to v${endVersion}"
-git push --set-upstream origin release_notes-${endVersion}
+git commit -m "Update CHANGE_LOG.md for ${startTag} to v${endVersion}"
+git push --set-upstream origin change_log-${endVersion}
 
 

--- a/scripts/release_detail.sh
+++ b/scripts/release_detail.sh
@@ -49,20 +49,24 @@ git log --format=' - %an'  ${commits} | sort -u  >> /tmp/proposed_changelog.txt;
 echo ' ' >> /tmp/proposed_changelog.txt;
 echo ' ' >> /tmp/proposed_changelog.txt;
 echo '### Full Changelog' >> /tmp/proposed_changelog.txt;
-echo 'https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/compare/'${startTag}'...v'${endVersion}  >> /tmp/proposed_changelog.txt;
+echo 'https://github.com/Aiven-Open/${repositoryName}/compare/'${startTag}'...v'${endVersion}  >> /tmp/proposed_changelog.txt;
 echo ' ' >> /tmp/proposed_changelog.txt
-touch CHANGE_LOG.md
-cat /tmp/proposed_changelog.txt CHANGE_LOG.md >> /tmp/CHANGE_LOG.md
-mv /tmp/CHANGE_LOG.md CHANGE_LOG.md
+touch ${releaseNotes}
+grep -B 999 -m2 "^## " ${releaseNotes}  | tail -n +5 > /tmp/release_notes.txt
+echo ' ' > /tmp/changelog.head
+echo '# Release Notes' >> /tmp/changelog.head
+echo ' ' >> /tmp/changelog.head
+echo 'All releases can be found at https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/releases' >> /tmp/changelog.head
+echo ' ' >> /tmp/changelog.head
+cat /tmp/changelog.head /tmp/proposed_changelog.txt /tmp/release_notes.txt >> /tmp/CHANGE_LOG.md
 
-git checkout -b changelog-${endVersion}
+mv /tmp/CHANGE_LOG.md ${releaseNotes}
 
+git checkout -b release_notes-${endVersion}
+
+git add ${releaseNotes}
 git add CHANGE_LOG.md
-git commit -m "Update changelog for ${startTag} to v${endVersion}"
-git push --set-upstream origin changelog-${endVersion}
+git commit -m "create Release notes and update changelog for ${startTag} to v${endVersion}"
+git push --set-upstream origin release_notes-${endVersion}
 
-mvn -P pre-release-check verify
-if [[ $? -eq 1 ]]
-then
-  echo "Fix issues with the build and rerun 'mvn -P pre-release-check verify'"
-fi
+


### PR DESCRIPTION
Automatic adjustment of RELEASE_NOTES during release.
Fix for site version info not being updated.
Cleanup of missing documentation from last release.

Changes:

- fix version updates for `tools` and `docs` modules
- establish CHANGE_LOG as the source of truth for changes.
- extract release info from CHANGE_LOG
- update CHANGE_LOG with complete list from RELEASE_NOTES
- add CHANGE_LOG to site
- remove RELEASE_NOTES from site.
- convert `release_detail.sh` to update CHANGE_LOG
- add build badge to README

closes #202