### PR TITLE
Update putAttemptId for uniqueness across internal Bigquery write retries and GCS Batch Idempotent Load Jobs

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -227,12 +227,16 @@ public class BigQuerySinkTask extends SinkTask {
         if (!tableWriterBuilders.containsKey(table)) {
           TableWriterBuilder tableWriterBuilder;
           if (useStorageApi) {
-            tableWriterBuilder = new StorageWriteApiWriter.Builder(
+            StorageWriteApiWriter.Builder storageWriterBuilder = new StorageWriteApiWriter.Builder(
                 storageApiWriter,
                 table,
                 recordConverter,
                 batchHandler
             );
+            if (trackPutAttempts) {
+              storageWriterBuilder.withUlidSupplier(() -> ULID_GENERATOR.nextULID());
+            }
+            tableWriterBuilder = storageWriterBuilder;
           } else if (config.getList(BigQuerySinkConfig.ENABLE_BATCH_CONFIG).contains(record.topic())) {
             String topic = record.topic();
             long offset = record.kafkaOffset();
@@ -254,6 +258,9 @@ public class BigQuerySinkTask extends SinkTask {
             if (upsertDelete) {
               simpleTableWriterBuilder.onFinish(rows ->
                   mergeBatches.onRowWrites(table.getBaseTableId(), rows));
+            }
+            if (trackPutAttempts) {
+              simpleTableWriterBuilder.withUlidSupplier(() -> ULID_GENERATOR.nextULID());
             }
             tableWriterBuilder = simpleTableWriterBuilder;
           }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GcsToBqLoadRunnable.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GcsToBqLoadRunnable.java
@@ -28,6 +28,7 @@ import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.FormatOptions;
 import com.google.cloud.bigquery.Job;
+import com.google.cloud.bigquery.JobId;
 import com.google.cloud.bigquery.JobInfo;
 import com.google.cloud.bigquery.JobStatus;
 import com.google.cloud.bigquery.LoadJobConfiguration;
@@ -40,6 +41,9 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.re2j.Matcher;
 import com.google.re2j.Pattern;
 import com.wepay.kafka.connect.bigquery.write.row.GcsToBqWriter;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -81,6 +85,13 @@ public class GcsToBqLoadRunnable implements Runnable {
    * The set of blob Ids that the system can delete.
    */
   private final Set<BlobId> deletableBlobIds;
+  /**
+   * Tracks how many times each blob batch has been submitted as a load job (keyed by sorted
+   * blob names). Incremented when a job is confirmed to have genuinely failed, so that the next
+   * submission uses a different deterministic job ID and BigQuery creates a new load job rather
+   * than returning 409 for the already-known-failed one.
+   */
+  private final Map<String, Integer> blobBatchAttempts;
 
   /**
    * Create a {@link GcsToBqLoadRunnable} with the given bigquery, bucket, and ms wait interval.
@@ -94,6 +105,7 @@ public class GcsToBqLoadRunnable implements Runnable {
     this.activeJobs = new HashMap<>();
     this.claimedBlobIds = new HashSet<>();
     this.deletableBlobIds = new HashSet<>();
+    this.blobBatchAttempts = new HashMap<>();
   }
 
   /**
@@ -107,11 +119,17 @@ public class GcsToBqLoadRunnable implements Runnable {
    */
   @VisibleForTesting
   GcsToBqLoadRunnable(BigQuery bigQuery, Bucket bucket, Map<Job, List<BlobId>> activeJobs, Set<BlobId> claimedBlobIds, Set<BlobId> deletableBlobIds) {
+    this(bigQuery, bucket, activeJobs, claimedBlobIds, deletableBlobIds, new HashMap<>());
+  }
+
+  @VisibleForTesting
+  GcsToBqLoadRunnable(BigQuery bigQuery, Bucket bucket, Map<Job, List<BlobId>> activeJobs, Set<BlobId> claimedBlobIds, Set<BlobId> deletableBlobIds, Map<String, Integer> blobBatchAttempts) {
     this.bigQuery = bigQuery;
     this.bucket = bucket;
     this.activeJobs = activeJobs;
     this.claimedBlobIds = claimedBlobIds;
     this.deletableBlobIds = deletableBlobIds;
+    this.blobBatchAttempts = blobBatchAttempts;
   }
 
   /**
@@ -215,7 +233,8 @@ public class GcsToBqLoadRunnable implements Runnable {
     return newJobs;
   }
 
-  private Job triggerBigQueryLoadJob(TableId table, List<Blob> blobs) {
+  @VisibleForTesting
+  Job triggerBigQueryLoadJob(TableId table, List<Blob> blobs) {
     List<String> uris = blobs.stream()
         .map(b -> String.format(SOURCE_URI_FORMAT,
             bucket.getName(),
@@ -228,14 +247,59 @@ public class GcsToBqLoadRunnable implements Runnable {
             .setCreateDisposition(JobInfo.CreateDisposition.CREATE_IF_NEEDED)
             .setWriteDisposition(JobInfo.WriteDisposition.WRITE_APPEND)
             .build();
-    // create and return the job.
-    Job job = bigQuery.create(JobInfo.of(loadJobConfiguration));
-    // update active jobs and claimed blobs.
     List<BlobId> blobIds = blobs.stream().map(Blob::getBlobId).collect(Collectors.toList());
+    String batchKey = blobBatchKey(blobIds);
+    int attempt = blobBatchAttempts.getOrDefault(batchKey, 0);
+    String jobId = stableJobId(blobIds, attempt);
+    // Submit with a deterministic job ID so that re-submission of the same blob batch after a
+    // task restart or a transient status-check failure returns 409 instead of running the load
+    // a second time. On 409 we retrieve the existing job and monitor it as usual.
+    Job job;
+    try {
+      job = bigQuery.create(
+          JobInfo.newBuilder(loadJobConfiguration)
+              .setJobId(JobId.of(jobId))
+              .build()
+      );
+    } catch (BigQueryException e) {
+      if (e.getCode() == 409) {
+        job = bigQuery.getJob(JobId.of(jobId));
+        logger.info("Load job {} already exists; will monitor its existing status.", jobId);
+      } else {
+        throw e;
+      }
+    }
+    // update active jobs and claimed blobs.
     activeJobs.put(job, blobIds);
     claimedBlobIds.addAll(blobIds);
     logger.info("Triggered load job for table {} with {} blobs.", table, blobs.size());
     return job;
+  }
+
+  private String blobBatchKey(List<BlobId> blobIds) {
+    return blobIds.stream()
+        .map(BlobId::getName)
+        .sorted()
+        .collect(Collectors.joining(","));
+  }
+
+  private String stableJobId(List<BlobId> blobIds, int attempt) {
+    String input = blobBatchKey(blobIds) + ":attempt=" + attempt;
+    return "kcbq-" + sha256Hex(input);
+  }
+
+  private static String sha256Hex(String input) {
+    try {
+      MessageDigest md = MessageDigest.getInstance("SHA-256");
+      byte[] digest = md.digest(input.getBytes(StandardCharsets.UTF_8));
+      StringBuilder sb = new StringBuilder(digest.length * 2);
+      for (byte b : digest) {
+        sb.append(String.format("%02x", b & 0xff));
+      }
+      return sb.toString();
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   /**
@@ -269,7 +333,9 @@ public class GcsToBqLoadRunnable implements Runnable {
             processSuccessfulJob(job, jobEntry.getValue());
             successCount++;
           } else {
-            processFailedJob(job, jobEntry.getValue());
+            // Genuinely failed: increment the attempt counter so the next submission uses a
+            // different job ID instead of hitting 409 for this already-failed job.
+            processFailedJob(job, jobEntry.getValue(), true);
             failureCount++;
           }
           jobIterator.remove();
@@ -278,7 +344,10 @@ public class GcsToBqLoadRunnable implements Runnable {
       } catch (BigQueryException ex) {
         // log a message.
         logger.warn("GCS to BQ load job failed", ex);
-        processFailedJob(job, jobEntry.getValue());
+        // Transient error — we don't know if the job actually succeeded. Don't increment the
+        // attempt counter: the next submission will use the same job ID, hit 409 if the job
+        // already exists, and retrieve its real status without running a second load.
+        processFailedJob(job, jobEntry.getValue(), false);
         failureCount++;
         jobIterator.remove();
         logger.trace("Job is removed from iterator: {}", job.getJobId());
@@ -296,7 +365,7 @@ public class GcsToBqLoadRunnable implements Runnable {
     logger.trace("Completed blobs marked as deletable: {}", blobIdsToDelete);
   }
 
-  private void processFailedJob(final Job job, final List<BlobId> blobsNotCompleted) {
+  private void processFailedJob(final Job job, final List<BlobId> blobsNotCompleted, boolean incrementAttemptCounter) {
     logger.warn("Job {} failed with {}", job.getJobId(), job.getStatus().getError());
     if (job.getStatus().getExecutionErrors().isEmpty()) {
       logger.warn("No additional errors associated with job {}", job.getJobId());
@@ -304,6 +373,9 @@ public class GcsToBqLoadRunnable implements Runnable {
       logger.warn("Additional errors associated with job {}: {}", job.getJobId(), job.getStatus().getExecutionErrors());
     }
     logger.warn("Blobs in job {}: {}", job.getJobId(), blobsNotCompleted);
+    if (incrementAttemptCounter) {
+      blobBatchAttempts.merge(blobBatchKey(blobsNotCompleted), 1, Integer::sum);
+    }
     // unclaim blobs
     blobsNotCompleted.forEach(claimedBlobIds::remove);
     logger.trace("Failed blobs reset as processable");

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GcsToBqLoadRunnable.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/GcsToBqLoadRunnable.java
@@ -363,6 +363,7 @@ public class GcsToBqLoadRunnable implements Runnable {
     logger.trace("Completed blobs have been removed from claimed set: {}", blobIdsToDelete);
     deletableBlobIds.addAll(blobIdsToDelete);
     logger.trace("Completed blobs marked as deletable: {}", blobIdsToDelete);
+    blobBatchAttempts.remove(blobBatchKey(blobIdsToDelete));
   }
 
   private void processFailedJob(final Job job, final List<BlobId> blobsNotCompleted, boolean incrementAttemptCounter) {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverter.java
@@ -86,14 +86,28 @@ public class SinkRecordConverter {
   }
 
   public InsertAllRequest.RowToInsert getRecordRow(SinkRecord record, TableId table) {
+    return getRecordRow(record, table, currentPutAttemptId);
+  }
+
+  /**
+   * Converts a record to a BigQuery row using an explicitly supplied write-attempt ID instead of
+   * the shared {@code currentPutAttemptId} field. Use this overload from executor threads (e.g.,
+   * inside {@code BigQueryWriter.writeRows()}) to avoid the race condition that arises when
+   * multiple {@code TableWriter} threads concurrently read and write the shared volatile field.
+   *
+   * @param record         the Kafka record to convert
+   * @param table          the target BigQuery table
+   * @param writeAttemptId the write-attempt ID to embed, or {@code null} if tracking is disabled
+   */
+  public InsertAllRequest.RowToInsert getRecordRow(SinkRecord record, TableId table, String writeAttemptId) {
     Map<String, Object> convertedRecord = config.isUpsertDeleteEnabled()
-        ? getUpsertDeleteRow(record, table)
-        : getRegularRow(record);
+        ? getUpsertDeleteRow(record, table, writeAttemptId)
+        : getRegularRow(record, writeAttemptId);
 
     return InsertAllRequest.RowToInsert.of(getRowId(record), convertedRecord);
   }
 
-  private Map<String, Object> getUpsertDeleteRow(SinkRecord record, TableId table) {
+  private Map<String, Object> getUpsertDeleteRow(SinkRecord record, TableId table, String writeAttemptId) {
     // Unconditionally allow tombstone records if delete is enabled.
     Map<String, Object> convertedValue = config.getBoolean(config.DELETE_ENABLED_CONFIG) && record.value() == null
         ? null
@@ -101,7 +115,7 @@ public class SinkRecordConverter {
 
     if (convertedValue != null) {
       config.getKafkaDataFieldName().ifPresent(
-          fieldName -> convertedValue.put(fieldName, KafkaDataBuilder.buildKafkaDataRecord(record, currentPutAttemptId))
+          fieldName -> convertedValue.put(fieldName, KafkaDataBuilder.buildKafkaDataRecord(record, writeAttemptId))
       );
     }
 
@@ -138,12 +152,16 @@ public class SinkRecordConverter {
   }
 
   public Map<String, Object> getRegularRow(SinkRecord record) {
+    return getRegularRow(record, currentPutAttemptId);
+  }
+
+  public Map<String, Object> getRegularRow(SinkRecord record, String writeAttemptId) {
     Map<String, Object> result = recordConverter.convertRecord(record, KafkaSchemaRecordType.VALUE);
 
     config.getKafkaDataFieldName().ifPresent(fieldName -> {
       Map<String, Object> kafkaDataField = config.getBoolean(config.USE_STORAGE_WRITE_API_CONFIG)
-          ? KafkaDataBuilder.buildKafkaDataRecordStorageApi(record, currentPutAttemptId)
-          : KafkaDataBuilder.buildKafkaDataRecord(record, currentPutAttemptId);
+          ? KafkaDataBuilder.buildKafkaDataRecordStorageApi(record, writeAttemptId)
+          : KafkaDataBuilder.buildKafkaDataRecord(record, writeAttemptId);
       result.put(fieldName, kafkaDataField);
     });
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
@@ -41,6 +41,7 @@ import java.util.Objects;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,22 +57,32 @@ public class TableWriter implements Runnable {
   private final PartitionedTableId table;
   private final SortedMap<SinkRecord, RowToInsert> rows;
   private final Consumer<Collection<RowToInsert>> onFinish;
+  private final SinkRecordConverter recordConverter;
+  private final Supplier<String> ulidSupplier;
 
   /**
-   * @param writer   the {@link BigQueryWriter} to use.
-   * @param table    the BigQuery table to write to.
-   * @param rows     the rows to write.
-   * @param onFinish a callback to invoke after all rows have been written successfully, which is
-   *                 called with all the rows written by the writer
+   * @param writer          the {@link BigQueryWriter} to use.
+   * @param table           the BigQuery table to write to.
+   * @param rows            the rows to write.
+   * @param onFinish        a callback to invoke after all rows have been written successfully,
+   *                        which is called with all the rows written by the writer
+   * @param recordConverter when non-null, passed to {@link BigQueryWriter#writeRows} so that rows
+   *                        are re-converted on each internal retry with a fresh {@code putAttemptId}
+   * @param ulidSupplier    generates a fresh ULID for each retry; ignored when
+   *                        {@code recordConverter} is null
    */
   public TableWriter(BigQueryWriter writer,
                      PartitionedTableId table,
                      SortedMap<SinkRecord, RowToInsert> rows,
-                     Consumer<Collection<RowToInsert>> onFinish) {
+                     Consumer<Collection<RowToInsert>> onFinish,
+                     SinkRecordConverter recordConverter,
+                     Supplier<String> ulidSupplier) {
     this.writer = writer;
     this.table = table;
     this.rows = rows;
     this.onFinish = onFinish;
+    this.recordConverter = recordConverter;
+    this.ulidSupplier = ulidSupplier;
   }
 
   private static int getNewBatchSize(int currentBatchSize, Throwable err) {
@@ -133,7 +144,7 @@ public class TableWriter implements Runnable {
           for (Map.Entry<SinkRecord, RowToInsert> record : currentBatchList) {
             currentBatch.put(record.getKey(), record.getValue());
           }
-          writer.writeRows(table, currentBatch);
+          writer.writeRows(table, currentBatch, recordConverter, ulidSupplier);
           currentIndex += currentBatchSize;
           successCount++;
         } catch (BigQueryException err) {
@@ -174,6 +185,7 @@ public class TableWriter implements Runnable {
     private SortedMap<SinkRecord, RowToInsert> rows;
     private SinkRecordConverter recordConverter;
     private Consumer<Collection<RowToInsert>> onFinish;
+    private Supplier<String> ulidSupplier = null;
 
     /**
      * @param writer          the BigQueryWriter to use
@@ -210,10 +222,15 @@ public class TableWriter implements Runnable {
       this.onFinish = Objects.requireNonNull(onFinish, "Finish callback cannot be null");
     }
 
+    public Builder withUlidSupplier(Supplier<String> ulidSupplier) {
+      this.ulidSupplier = ulidSupplier;
+      return this;
+    }
+
     @Override
     public TableWriter build() {
       return new TableWriter(writer, table, rows, onFinish != null ? onFinish : n -> {
-      });
+      }, recordConverter, ulidSupplier);
     }
   }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriter.java
@@ -31,6 +31,7 @@ import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 import com.wepay.kafka.connect.bigquery.exception.BigQueryErrorResponses;
 import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
+import com.wepay.kafka.connect.bigquery.utils.SinkRecordConverter;
 import com.wepay.kafka.connect.bigquery.utils.Time;
 import java.util.Collection;
 import java.util.List;
@@ -40,6 +41,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.function.Supplier;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -136,6 +138,26 @@ public abstract class BigQueryWriter {
   public void writeRows(PartitionedTableId table,
                         SortedMap<SinkRecord, InsertAllRequest.RowToInsert> rows)
       throws BigQueryConnectException, BigQueryException, InterruptedException {
+    writeRows(table, rows, null, null);
+  }
+
+  /**
+   * @param table           The BigQuery table to write the rows to.
+   * @param rows            The rows to write.
+   * @param recordConverter When non-null, used to re-convert rows before every
+   *                        {@link #performWriteRequest} call (including the first), so that
+   *                        each actual BigQuery API call carries a distinct write-attempt ID
+   *                        rather than reusing the put-level ID stamped during row conversion.
+   *                        Pass {@code null} when {@code trackPutAttempts} is disabled.
+   * @param ulidSupplier    Generates a fresh ULID for each write attempt. Must be non-null
+   *                        when {@code recordConverter} is non-null; ignored otherwise.
+   * @throws InterruptedException if interrupted.
+   */
+  public void writeRows(PartitionedTableId table,
+                        SortedMap<SinkRecord, InsertAllRequest.RowToInsert> rows,
+                        SinkRecordConverter recordConverter,
+                        Supplier<String> ulidSupplier)
+      throws BigQueryConnectException, BigQueryException, InterruptedException {
     logger.debug("writing {} row{} to table {}", rows.size(), rows.size() != 1 ? "s" : "", table);
 
     Exception mostRecentException = null;
@@ -145,6 +167,17 @@ public abstract class BigQueryWriter {
     do {
       if (retryCount > 0) {
         waitRandomTime();
+      }
+      if (recordConverter != null && ulidSupplier != null) {
+        // Regenerate a fresh write-attempt ID before every performWriteRequest() call,
+        // including the first. Pass it directly to getRecordRow() to avoid writing to
+        // the shared volatile currentPutAttemptId field from this executor thread.
+        String newId = ulidSupplier.get();
+        SortedMap<SinkRecord, InsertAllRequest.RowToInsert> rebuilt = new TreeMap<>(rows.comparator());
+        for (SinkRecord record : rows.keySet()) {
+          rebuilt.put(record, recordConverter.getRecordRow(record, table.getBaseTableId(), newId));
+        }
+        rows = rebuilt;
       }
       try {
         failedRowsMap = performWriteRequest(table, rows);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBase.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBase.java
@@ -39,6 +39,7 @@ import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import com.wepay.kafka.connect.bigquery.exception.BigQueryStorageWriteApiConnectException;
 import com.wepay.kafka.connect.bigquery.exception.BigQueryStorageWriteApiErrorResponses;
 import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
+import com.wepay.kafka.connect.bigquery.utils.SinkRecordConverter;
 import com.wepay.kafka.connect.bigquery.utils.TableNameUtils;
 import com.wepay.kafka.connect.bigquery.utils.Time;
 import com.wepay.kafka.connect.bigquery.write.RecordBatches;
@@ -49,9 +50,11 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.json.JSONArray;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.threeten.bp.Duration;
@@ -192,6 +195,24 @@ public abstract class StorageWriteApiBase {
    * @param streamName The stream to use to write table to table.
    */
   public void initializeAndWriteRecords(PartitionedTableId table, List<ConvertedRecord> rows, String streamName) {
+    initializeAndWriteRecords(table, rows, streamName, null, null);
+  }
+
+  /**
+   * Handles required initialization steps and goes to append records to table. When
+   * {@code recordConverter} and {@code ulidSupplier} are both non-null (i.e. when
+   * {@code trackPutAttempts=true}), a fresh ULID is generated and the batch is re-converted
+   * immediately before every {@code appendRows()} call so that each gRPC write carries a
+   * unique write-attempt ID.
+   *
+   * @param table            The table to write data to
+   * @param rows             List of pre- and post-conversion records.
+   * @param streamName       The stream to use to write data to the table.
+   * @param recordConverter  Converter used to rebuild rows with a fresh ULID; may be {@code null}.
+   * @param ulidSupplier     Supplier of write-attempt ULIDs; may be {@code null}.
+   */
+  public void initializeAndWriteRecords(PartitionedTableId table, List<ConvertedRecord> rows, String streamName,
+                                        SinkRecordConverter recordConverter, Supplier<String> ulidSupplier) {
     TableName tableName = TableNameUtils.tableName(table.getFullTableId());
     StorageWriteApiRetryHandler retryHandler = new StorageWriteApiRetryHandler(table.getBaseTableId(), getSinkRecords(rows), retry, retryWait, time);
     logger.debug("Sending {} records to write Api Application stream {}", rows.size(), streamName);
@@ -202,7 +223,7 @@ public abstract class StorageWriteApiBase {
 
       while (!batch.isEmpty()) {
         try {
-          writeBatch(writer, batch, retryHandler, tableName);
+          writeBatch(writer, batch, retryHandler, tableName, recordConverter, ulidSupplier);
           batch = Collections.emptyList(); // Can't do batch.clear(); it'll mess with the batch tracking logic in RecordBatches
         } catch (RetryException e) {
           retryHandler.maybeRetry("write to table " + tableName);
@@ -245,8 +266,19 @@ public abstract class StorageWriteApiBase {
       StreamWriter writer,
       List<ConvertedRecord> batch,
       StorageWriteApiRetryHandler retryHandler,
-      TableName tableName
+      TableName tableName,
+      SinkRecordConverter recordConverter,
+      Supplier<String> ulidSupplier
   ) throws BatchTooLargeException, MalformedRowsException, RetryException {
+    if (recordConverter != null && ulidSupplier != null) {
+      String newId = ulidSupplier.get();
+      List<ConvertedRecord> rebuilt = new ArrayList<>();
+      for (ConvertedRecord item : batch) {
+        Map<String, Object> convertedMap = recordConverter.getRegularRow(item.original(), newId);
+        rebuilt.add(new ConvertedRecord(item.original(), getJsonFromMap(convertedMap)));
+      }
+      batch = rebuilt;
+    }
     try {
       JSONArray jsonRecords = getJsonRecords(batch);
       logger.trace("Sending records to Storage API writer for batch load");
@@ -488,6 +520,36 @@ public abstract class StorageWriteApiBase {
       logger.warn("DLQ is not configured!");
       throw new BigQueryStorageWriteApiConnectException(tableName, errorMap);
     }
+  }
+
+  /**
+   * Converts a nested {@code Map<String, Object>} (as produced by
+   * {@link SinkRecordConverter#getRegularRow}) into a {@link JSONObject} suitable for the
+   * Storage Write API. Map values that are themselves {@code Map} instances are recursively
+   * converted; {@code List} values are converted to {@link org.json.JSONArray}.
+   *
+   * <p>Package-private so that {@link StorageWriteApiWriter.Builder} can call it when
+   * building the initial {@link ConvertedRecord} objects at {@code addRow()} time.
+   */
+  static JSONObject getJsonFromMap(Map<String, Object> map) {
+    JSONObject jsonObject = new JSONObject();
+    map.forEach((key, value) -> {
+      if (value instanceof Map<?, ?>) {
+        value = getJsonFromMap((Map<String, Object>) value);
+      } else if (value instanceof List<?>) {
+        org.json.JSONArray items = new org.json.JSONArray();
+        ((List<?>) value).forEach(v -> {
+          if (v instanceof Map<?, ?>) {
+            items.put(getJsonFromMap((Map<String, Object>) v));
+          } else {
+            items.put(v);
+          }
+        });
+        value = items;
+      }
+      jsonObject.put(key, value);
+    });
+    return jsonObject;
   }
 
   private JSONArray getJsonRecords(List<ConvertedRecord> rows) {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiWriter.java
@@ -32,8 +32,8 @@ import com.wepay.kafka.connect.bigquery.write.batch.TableWriterBuilder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import org.apache.kafka.connect.sink.SinkRecord;
-import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,6 +48,8 @@ public class StorageWriteApiWriter implements Runnable {
   private final PartitionedTableId table;
   private final List<ConvertedRecord> records;
   private final String streamName;
+  private final SinkRecordConverter recordConverter;
+  private final Supplier<String> ulidSupplier;
   Logger logger = LoggerFactory.getLogger(StorageWriteApiWriter.class);
 
   /**
@@ -72,10 +74,17 @@ public class StorageWriteApiWriter implements Runnable {
    * @param streamName   The stream to use while writing data
    */
   public StorageWriteApiWriter(PartitionedTableId table, StorageWriteApiBase streamWriter, List<ConvertedRecord> records, String streamName) {
+    this(table, streamWriter, records, streamName, null, null);
+  }
+
+  StorageWriteApiWriter(PartitionedTableId table, StorageWriteApiBase streamWriter, List<ConvertedRecord> records,
+                        String streamName, SinkRecordConverter recordConverter, Supplier<String> ulidSupplier) {
     this.streamWriter = streamWriter;
     this.records = records;
     this.table = table;
     this.streamName = streamName;
+    this.recordConverter = recordConverter;
+    this.ulidSupplier = ulidSupplier;
   }
 
   @Override
@@ -85,7 +94,11 @@ public class StorageWriteApiWriter implements Runnable {
       return;
     }
     logger.debug("Putting {} records into {} stream", records.size(), streamName);
-    streamWriter.initializeAndWriteRecords(table, records, streamName);
+    if (recordConverter != null && ulidSupplier != null) {
+      streamWriter.initializeAndWriteRecords(table, records, streamName, recordConverter, ulidSupplier);
+    } else {
+      streamWriter.initializeAndWriteRecords(table, records, streamName);
+    }
   }
 
   public static class Builder implements TableWriterBuilder {
@@ -94,6 +107,7 @@ public class StorageWriteApiWriter implements Runnable {
     private final PartitionedTableId table;
     private final StorageWriteApiBase streamWriter;
     private final StorageApiBatchModeHandler batchModeHandler;
+    private Supplier<String> ulidSupplier = null;
 
     /**
      * @deprecated Use {@link #Builder(StorageWriteApiBase, PartitionedTableId, SinkRecordConverter, StorageApiBatchModeHandler)} instead.
@@ -117,6 +131,20 @@ public class StorageWriteApiWriter implements Runnable {
     }
 
     /**
+     * Enables write-attempt ID regeneration before every {@code appendRows()} call. When set,
+     * the writer generates a fresh ULID from this supplier immediately before each gRPC write
+     * (including the first attempt) and re-converts every row in the batch so that each actual
+     * BigQuery API call carries a unique write-attempt ID.
+     *
+     * @param ulidSupplier supplier of ULID strings; must be thread-safe
+     * @return this builder
+     */
+    public Builder withUlidSupplier(Supplier<String> ulidSupplier) {
+      this.ulidSupplier = ulidSupplier;
+      return this;
+    }
+
+    /**
      * Captures actual record and corresponding JSONObject converted record
      *
      * @param sinkRecord The actual records
@@ -134,7 +162,7 @@ public class StorageWriteApiWriter implements Runnable {
      */
     private JSONObject convertRecord(SinkRecord record) {
       Map<String, Object> convertedRecord = recordConverter.getRegularRow(record);
-      return getJsonFromMap(convertedRecord);
+      return StorageWriteApiBase.getJsonFromMap(convertedRecord);
     }
 
     /**
@@ -147,28 +175,7 @@ public class StorageWriteApiWriter implements Runnable {
         TableName tableName = TableNameUtils.tableName(table.getBaseTableId());
         streamName = batchModeHandler.updateOffsetsOnStream(tableName.toString(), records);
       }
-      return new StorageWriteApiWriter(table, streamWriter, records, streamName);
-    }
-
-    private JSONObject getJsonFromMap(Map<String, Object> map) {
-      JSONObject jsonObject = new JSONObject();
-      map.forEach((key, value) -> {
-        if (value instanceof Map<?, ?>) {
-          value = getJsonFromMap((Map<String, Object>) value);
-        } else if (value instanceof List<?>) {
-          JSONArray items = new JSONArray();
-          ((List<?>) value).forEach(v -> {
-            if (v instanceof Map<?, ?>) {
-              items.put(getJsonFromMap((Map<String, Object>) v));
-            } else {
-              items.put(v);
-            }
-          });
-          value = items;
-        }
-        jsonObject.put(key, value);
-      });
-      return jsonObject;
+      return new StorageWriteApiWriter(table, streamWriter, records, streamName, recordConverter, ulidSupplier);
     }
   }
 }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/GcsToBqLoadRunnableTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/GcsToBqLoadRunnableTest.java
@@ -273,6 +273,110 @@ public class GcsToBqLoadRunnableTest {
     assertEquals(captured.get(0).getJobId().getJob(), captured.get(1).getJobId().getJob());
   }
 
+  @Test
+  void testSuccessfulJobAfterPriorFailure_removesBlobBatchAttemptsEntry() {
+    BigQuery bigQuery = mock(BigQuery.class);
+    Bucket bucket = mock(Bucket.class);
+    when(bucket.getName()).thenReturn("test-bucket");
+
+    Map<Job, List<BlobId>> activeJobs = new HashMap<>();
+    Set<BlobId> claimedBlobIds = new HashSet<>();
+    Set<BlobId> deletableBlobIds = new HashSet<>();
+    Map<String, Integer> blobBatchAttempts = new HashMap<>();
+
+    GcsToBqLoadRunnable runnable = new GcsToBqLoadRunnable(
+        bigQuery, bucket, activeJobs, claimedBlobIds, deletableBlobIds, blobBatchAttempts);
+
+    TableId tableId = TableId.of("dataset", "table");
+    Blob blob = mock(Blob.class);
+    BlobId blobId = BlobId.of("test-bucket", "blob1");
+    when(blob.getBlobId()).thenReturn(blobId);
+    when(blob.getName()).thenReturn("blob1");
+
+    // First submission (attempt 0): bigQuery.create returns a job that will then fail.
+    Job firstJob = mock(Job.class);
+    when(firstJob.getJobId()).thenReturn(JobId.of("first-job"));
+    Job secondJob = mock(Job.class);
+    when(secondJob.getJobId()).thenReturn(JobId.of("second-job"));
+    when(bigQuery.create(any(JobInfo.class))).thenReturn(firstJob).thenReturn(secondJob);
+
+    runnable.triggerBigQueryLoadJob(tableId, Collections.singletonList(blob));
+
+    // checkJobs sees attempt 0 as DONE + error → counter goes to 1.
+    Job failedJobResult = mock(Job.class);
+    when(failedJobResult.getJobId()).thenReturn(JobId.of("first-job"));
+    JobStatus failedStatus = mock(JobStatus.class);
+    when(failedJobResult.getStatus()).thenReturn(failedStatus);
+    when(failedStatus.getState()).thenReturn(JobStatus.State.DONE);
+    when(failedStatus.getError()).thenReturn(new BigQueryError("reason", "location", "message", "debug"));
+    when(failedStatus.getExecutionErrors()).thenReturn(Collections.emptyList());
+    when(bigQuery.getJob(any(JobId.class))).thenReturn(failedJobResult);
+
+    runnable.checkJobs();
+    assertEquals(1, blobBatchAttempts.values().stream().mapToInt(Integer::intValue).sum());
+
+    // Second submission (attempt 1).
+    runnable.triggerBigQueryLoadJob(tableId, Collections.singletonList(blob));
+
+    // checkJobs sees attempt 1 as DONE + no error → successful → entry should be removed.
+    Job successJobResult = mock(Job.class);
+    when(successJobResult.getJobId()).thenReturn(JobId.of("second-job"));
+    JobStatus successStatus = mock(JobStatus.class);
+    when(successJobResult.getStatus()).thenReturn(successStatus);
+    when(successStatus.getState()).thenReturn(JobStatus.State.DONE);
+    when(successStatus.getError()).thenReturn(null);
+    when(bigQuery.getJob(any(JobId.class))).thenReturn(successJobResult);
+
+    runnable.checkJobs();
+
+    assertTrue(blobBatchAttempts.isEmpty(),
+        "blobBatchAttempts should be cleared after the batch succeeds");
+    assertTrue(deletableBlobIds.contains(blobId));
+  }
+
+  @Test
+  void testSuccessfulJobForNeverFailedBatch_leavesMapEmpty() {
+    BigQuery bigQuery = mock(BigQuery.class);
+    Bucket bucket = mock(Bucket.class);
+    when(bucket.getName()).thenReturn("test-bucket");
+
+    Map<Job, List<BlobId>> activeJobs = new HashMap<>();
+    Set<BlobId> claimedBlobIds = new HashSet<>();
+    Set<BlobId> deletableBlobIds = new HashSet<>();
+    Map<String, Integer> blobBatchAttempts = new HashMap<>();
+
+    GcsToBqLoadRunnable runnable = new GcsToBqLoadRunnable(
+        bigQuery, bucket, activeJobs, claimedBlobIds, deletableBlobIds, blobBatchAttempts);
+
+    TableId tableId = TableId.of("dataset", "table");
+    Blob blob = mock(Blob.class);
+    BlobId blobId = BlobId.of("test-bucket", "blob1");
+    when(blob.getBlobId()).thenReturn(blobId);
+    when(blob.getName()).thenReturn("blob1");
+
+    Job job = mock(Job.class);
+    when(job.getJobId()).thenReturn(JobId.of("only-job"));
+    when(bigQuery.create(any(JobInfo.class))).thenReturn(job);
+
+    runnable.triggerBigQueryLoadJob(tableId, Collections.singletonList(blob));
+
+    // checkJobs sees a successful DONE+no error result on first attempt.
+    Job successJobResult = mock(Job.class);
+    when(successJobResult.getJobId()).thenReturn(JobId.of("only-job"));
+    JobStatus successStatus = mock(JobStatus.class);
+    when(successJobResult.getStatus()).thenReturn(successStatus);
+    when(successStatus.getState()).thenReturn(JobStatus.State.DONE);
+    when(successStatus.getError()).thenReturn(null);
+    when(bigQuery.getJob(any(JobId.class))).thenReturn(successJobResult);
+
+    runnable.checkJobs();
+
+    // Map was empty going in and Map#remove on a missing key is a no-op.
+    assertTrue(blobBatchAttempts.isEmpty(),
+        "blobBatchAttempts must remain empty when the batch never failed");
+    assertTrue(deletableBlobIds.contains(blobId));
+  }
+
   static List<Arguments> checkJobsData() {
     List<Arguments> args = new ArrayList<>();
 

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/GcsToBqLoadRunnableTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/GcsToBqLoadRunnableTest.java
@@ -24,7 +24,10 @@
 package com.wepay.kafka.connect.bigquery;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -33,6 +36,7 @@ import com.google.cloud.bigquery.BigQueryError;
 import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.Job;
 import com.google.cloud.bigquery.JobId;
+import com.google.cloud.bigquery.JobInfo;
 import com.google.cloud.bigquery.JobStatus;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.storage.Blob;
@@ -51,6 +55,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 public class GcsToBqLoadRunnableTest {
@@ -138,6 +143,134 @@ public class GcsToBqLoadRunnableTest {
     assertEquals(activeCount, activeJobs.size(), "Wrong active count" );
     assertEquals(claimedCount, claimedBlobIds.size(), "Wrong claimed count");
     assertEquals(deletableCount, deletableBlobIds.size(), "Wrong deletable count");
+  }
+
+  // --- Tests for deterministic job ID and 409 handling ---
+
+  @Test
+  void testTriggerLoadJob_409ConflictOnCreate_retrievesExistingJob() {
+    BigQuery bigQuery = mock(BigQuery.class);
+    Bucket bucket = mock(Bucket.class);
+    when(bucket.getName()).thenReturn("test-bucket");
+
+    Map<Job, List<BlobId>> activeJobs = new HashMap<>();
+    Set<BlobId> claimedBlobIds = new HashSet<>();
+    Map<String, Integer> blobBatchAttempts = new HashMap<>();
+
+    GcsToBqLoadRunnable runnable = new GcsToBqLoadRunnable(
+        bigQuery, bucket, activeJobs, claimedBlobIds, new HashSet<>(), blobBatchAttempts);
+
+    TableId tableId = TableId.of("dataset", "table");
+    Blob blob = mock(Blob.class);
+    BlobId blobId = BlobId.of("test-bucket", "blob1");
+    when(blob.getBlobId()).thenReturn(blobId);
+    when(blob.getName()).thenReturn("blob1");
+
+    Job existingJob = mock(Job.class);
+    when(existingJob.getJobId()).thenReturn(JobId.of("existing-job"));
+    when(bigQuery.create(any(JobInfo.class))).thenThrow(new BigQueryException(409, "Already Exists"));
+    when(bigQuery.getJob(any(JobId.class))).thenReturn(existingJob);
+
+    runnable.triggerBigQueryLoadJob(tableId, Collections.singletonList(blob));
+
+    assertTrue(activeJobs.containsKey(existingJob));
+    assertTrue(claimedBlobIds.contains(blobId));
+  }
+
+  @Test
+  void testGenuineJobFailure_incrementsAttemptCounter_nextTriggerUsesNewJobId() {
+    BigQuery bigQuery = mock(BigQuery.class);
+    Bucket bucket = mock(Bucket.class);
+    when(bucket.getName()).thenReturn("test-bucket");
+
+    Map<Job, List<BlobId>> activeJobs = new HashMap<>();
+    Set<BlobId> claimedBlobIds = new HashSet<>();
+    Map<String, Integer> blobBatchAttempts = new HashMap<>();
+
+    GcsToBqLoadRunnable runnable = new GcsToBqLoadRunnable(
+        bigQuery, bucket, activeJobs, claimedBlobIds, new HashSet<>(), blobBatchAttempts);
+
+    TableId tableId = TableId.of("dataset", "table");
+    Blob blob = mock(Blob.class);
+    BlobId blobId = BlobId.of("test-bucket", "blob1");
+    when(blob.getBlobId()).thenReturn(blobId);
+    when(blob.getName()).thenReturn("blob1");
+
+    ArgumentCaptor<JobInfo> captor = ArgumentCaptor.forClass(JobInfo.class);
+    Job firstJob = mock(Job.class);
+    when(firstJob.getJobId()).thenReturn(JobId.of("first-job"));
+    when(bigQuery.create(captor.capture())).thenReturn(firstJob).thenReturn(mock(Job.class));
+
+    runnable.triggerBigQueryLoadJob(tableId, Collections.singletonList(blob));
+
+    // checkJobs: job DONE with a real error → genuine failure → increment attempt counter
+    Job failedJobResult = mock(Job.class);
+    when(failedJobResult.getJobId()).thenReturn(JobId.of("first-job"));
+    JobStatus failedStatus = mock(JobStatus.class);
+    when(failedJobResult.getStatus()).thenReturn(failedStatus);
+    when(failedStatus.getState()).thenReturn(JobStatus.State.DONE);
+    when(failedStatus.getError()).thenReturn(new BigQueryError("reason", "location", "message", "debug"));
+    when(failedStatus.getExecutionErrors()).thenReturn(Collections.emptyList());
+    when(bigQuery.getJob(any(JobId.class))).thenReturn(failedJobResult);
+
+    runnable.checkJobs();
+
+    assertEquals(1, blobBatchAttempts.values().stream().mapToInt(Integer::intValue).sum());
+
+    runnable.triggerBigQueryLoadJob(tableId, Collections.singletonList(blob));
+
+    List<JobInfo> captured = captor.getAllValues();
+    assertEquals(2, captured.size());
+    assertNotEquals(captured.get(0).getJobId().getJob(), captured.get(1).getJobId().getJob());
+  }
+
+  @Test
+  void testTransientCheckJobsException_doesNotIncrementAttemptCounter_sameJobIdUsedOnNextTrigger() {
+    BigQuery bigQuery = mock(BigQuery.class);
+    Bucket bucket = mock(Bucket.class);
+    when(bucket.getName()).thenReturn("test-bucket");
+
+    Map<Job, List<BlobId>> activeJobs = new HashMap<>();
+    Set<BlobId> claimedBlobIds = new HashSet<>();
+    Map<String, Integer> blobBatchAttempts = new HashMap<>();
+
+    GcsToBqLoadRunnable runnable = new GcsToBqLoadRunnable(
+        bigQuery, bucket, activeJobs, claimedBlobIds, new HashSet<>(), blobBatchAttempts);
+
+    TableId tableId = TableId.of("dataset", "table");
+    Blob blob = mock(Blob.class);
+    BlobId blobId = BlobId.of("test-bucket", "blob1");
+    when(blob.getBlobId()).thenReturn(blobId);
+    when(blob.getName()).thenReturn("blob1");
+
+    ArgumentCaptor<JobInfo> captor = ArgumentCaptor.forClass(JobInfo.class);
+    Job firstJob = mock(Job.class);
+    when(firstJob.getJobId()).thenReturn(JobId.of("first-job"));
+    when(bigQuery.create(captor.capture())).thenReturn(firstJob).thenReturn(mock(Job.class));
+
+    runnable.triggerBigQueryLoadJob(tableId, Collections.singletonList(blob));
+
+    // checkJobs: transient BigQueryException while inspecting job status → processFailedJob(..., false)
+    Job transientJob = mock(Job.class);
+    when(transientJob.getJobId()).thenReturn(JobId.of("first-job"));
+    JobStatus transientStatus = mock(JobStatus.class);
+    when(transientJob.getStatus()).thenReturn(transientStatus);
+    when(transientStatus.getState()).thenThrow(BigQueryException.class);
+    when(transientStatus.getError()).thenReturn(null);
+    when(transientStatus.getExecutionErrors()).thenReturn(Collections.emptyList());
+    when(bigQuery.getJob(any(JobId.class))).thenReturn(transientJob);
+
+    runnable.checkJobs();
+
+    // Transient error must NOT increment the attempt counter so the next submission
+    // uses the same job ID and hits 409 if the original job already succeeded.
+    assertTrue(blobBatchAttempts.isEmpty());
+
+    runnable.triggerBigQueryLoadJob(tableId, Collections.singletonList(blob));
+
+    List<JobInfo> captured = captor.getAllValues();
+    assertEquals(2, captured.size());
+    assertEquals(captured.get(0).getJobId().getJob(), captured.get(1).getJobId().getJob());
   }
 
   static List<Arguments> checkJobsData() {

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriterTest.java
@@ -24,6 +24,7 @@
 package com.wepay.kafka.connect.bigquery.write.row;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -320,6 +321,158 @@ public class BigQueryWriterTest {
     Exception expectedEx = assertThrows(BigQueryConnectException.class,
         () -> testTask.flush(Collections.emptyMap()));
     assertTrue(expectedEx.getCause().getMessage().contains("test_topic"));
+  }
+
+  @Test
+  public void testPutAttemptIdRefreshedOnInternalRetry() {
+    final String topic = "test_topic";
+    final String dataset = "scratch";
+    final Map<String, String> properties = makeProperties("3", "2000", topic, dataset);
+    properties.put(BigQuerySinkConfig.TRACK_PUT_ATTEMPTS_CONFIG, "true");
+    properties.put(BigQuerySinkConfig.KAFKA_DATA_FIELD_NAME_CONFIG, "_kafka_data");
+
+    BigQuery bigQuery = mock(BigQuery.class);
+    Table mockTable = mock(Table.class);
+    when(bigQuery.getTable(any(TableId.class))).thenReturn(mockTable);
+
+    InsertAllResponse successResponse = mock(InsertAllResponse.class);
+    when(successResponse.hasErrors()).thenReturn(false);
+    when(successResponse.getInsertErrors()).thenReturn(Collections.emptyMap());
+
+    // First call: backend error triggers internal retry inside BigQueryWriter.writeRows()
+    BigQueryException backendError = new BigQueryException(500, "Internal server error");
+    when(bigQuery.insertAll(any(InsertAllRequest.class)))
+        .thenThrow(backendError)
+        .thenReturn(successResponse);
+
+    SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
+    SchemaRetriever schemaRetriever = mock(SchemaRetriever.class);
+    SchemaManager schemaManager = mock(SchemaManager.class);
+    Storage storage = mock(Storage.class);
+
+    BigQuerySinkTask testTask = BigQuerySinkTaskTest.createTestTask(
+        bigQuery, schemaRetriever, storage, schemaManager,
+        mockedStorageWriteApiDefaultStream, mockedBatchHandler, time);
+    testTask.initialize(sinkTaskContext);
+    testTask.start(properties);
+    testTask.put(Collections.singletonList(spoofSinkRecord(topic, 0, 0, "some_field", "some_value")));
+    testTask.flush(Collections.emptyMap());
+
+    ArgumentCaptor<InsertAllRequest> requestCaptor = ArgumentCaptor.forClass(InsertAllRequest.class);
+    verify(bigQuery, times(2)).insertAll(requestCaptor.capture());
+
+    // Extract putAttemptId from each request's row
+    String putAttemptIdFirst = extractPutAttemptId(requestCaptor.getAllValues().get(0));
+    String putAttemptIdRetry = extractPutAttemptId(requestCaptor.getAllValues().get(1));
+
+    assertTrue(putAttemptIdFirst != null && !putAttemptIdFirst.isEmpty(),
+        "First attempt should have a putAttemptId");
+    assertTrue(putAttemptIdRetry != null && !putAttemptIdRetry.isEmpty(),
+        "Retry attempt should have a putAttemptId");
+    assertNotEquals(putAttemptIdFirst, putAttemptIdRetry,
+        "Internal retry must produce a different putAttemptId than the first attempt");
+  }
+
+  @Test
+  public void testPutAttemptIdNotSetWhenTrackingDisabled() {
+    final String topic = "test_topic";
+    final String dataset = "scratch";
+    final Map<String, String> properties = makeProperties("3", "2000", topic, dataset);
+    // trackPutAttempts defaults to false; set kafkaDataFieldName so the struct is included
+    properties.put(BigQuerySinkConfig.KAFKA_DATA_FIELD_NAME_CONFIG, "_kafka_data");
+
+    BigQuery bigQuery = mock(BigQuery.class);
+    Table mockTable = mock(Table.class);
+    when(bigQuery.getTable(any(TableId.class))).thenReturn(mockTable);
+
+    InsertAllResponse successResponse = mock(InsertAllResponse.class);
+    when(successResponse.hasErrors()).thenReturn(false);
+    when(successResponse.getInsertErrors()).thenReturn(Collections.emptyMap());
+
+    BigQueryException backendError = new BigQueryException(500, "Internal server error");
+    when(bigQuery.insertAll(any(InsertAllRequest.class)))
+        .thenThrow(backendError)
+        .thenReturn(successResponse);
+
+    SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
+    SchemaRetriever schemaRetriever = mock(SchemaRetriever.class);
+    SchemaManager schemaManager = mock(SchemaManager.class);
+    Storage storage = mock(Storage.class);
+
+    BigQuerySinkTask testTask = BigQuerySinkTaskTest.createTestTask(
+        bigQuery, schemaRetriever, storage, schemaManager,
+        mockedStorageWriteApiDefaultStream, mockedBatchHandler, time);
+    testTask.initialize(sinkTaskContext);
+    testTask.start(properties);
+    testTask.put(Collections.singletonList(spoofSinkRecord(topic, 0, 0, "some_field", "some_value")));
+    testTask.flush(Collections.emptyMap());
+
+    ArgumentCaptor<InsertAllRequest> requestCaptor = ArgumentCaptor.forClass(InsertAllRequest.class);
+    verify(bigQuery, times(2)).insertAll(requestCaptor.capture());
+
+    // With tracking disabled, putAttemptId should not appear in the row content
+    String putAttemptIdFirst = extractPutAttemptId(requestCaptor.getAllValues().get(0));
+    String putAttemptIdRetry = extractPutAttemptId(requestCaptor.getAllValues().get(1));
+
+    assertTrue(putAttemptIdFirst == null,
+        "putAttemptId should be absent when trackPutAttempts=false");
+    assertTrue(putAttemptIdRetry == null,
+        "putAttemptId should be absent when trackPutAttempts=false on retry");
+  }
+
+  @Test
+  public void testWriteAttemptIdPresentOnFirstAttempt() {
+    // Even with no retry, writeRows() now generates a fresh write-attempt ID before the
+    // first performWriteRequest() call, so the ID in BigQuery differs from the put-level ID.
+    final String topic = "test_topic";
+    final String dataset = "scratch";
+    final Map<String, String> properties = makeProperties("3", "2000", topic, dataset);
+    properties.put(BigQuerySinkConfig.TRACK_PUT_ATTEMPTS_CONFIG, "true");
+    properties.put(BigQuerySinkConfig.KAFKA_DATA_FIELD_NAME_CONFIG, "_kafka_data");
+
+    BigQuery bigQuery = mock(BigQuery.class);
+    Table mockTable = mock(Table.class);
+    when(bigQuery.getTable(any(TableId.class))).thenReturn(mockTable);
+
+    InsertAllResponse successResponse = mock(InsertAllResponse.class);
+    when(successResponse.hasErrors()).thenReturn(false);
+    when(successResponse.getInsertErrors()).thenReturn(Collections.emptyMap());
+
+    when(bigQuery.insertAll(any(InsertAllRequest.class))).thenReturn(successResponse);
+
+    SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
+    SchemaRetriever schemaRetriever = mock(SchemaRetriever.class);
+    SchemaManager schemaManager = mock(SchemaManager.class);
+    Storage storage = mock(Storage.class);
+
+    BigQuerySinkTask testTask = BigQuerySinkTaskTest.createTestTask(
+        bigQuery, schemaRetriever, storage, schemaManager,
+        mockedStorageWriteApiDefaultStream, mockedBatchHandler, time);
+    testTask.initialize(sinkTaskContext);
+    testTask.start(properties);
+    testTask.put(Collections.singletonList(spoofSinkRecord(topic, 0, 0, "some_field", "some_value")));
+    testTask.flush(Collections.emptyMap());
+
+    ArgumentCaptor<InsertAllRequest> requestCaptor = ArgumentCaptor.forClass(InsertAllRequest.class);
+    verify(bigQuery, times(1)).insertAll(requestCaptor.capture());
+
+    String writeAttemptId = extractPutAttemptId(requestCaptor.getValue());
+    assertTrue(writeAttemptId != null && !writeAttemptId.isEmpty(),
+        "First (and only) write attempt should carry a write-attempt ID");
+  }
+
+  @SuppressWarnings("unchecked")
+  private String extractPutAttemptId(InsertAllRequest request) {
+    if (request.getRows().isEmpty()) {
+      return null;
+    }
+    Map<String, Object> content = request.getRows().get(0).getContent();
+    Object kafkaData = content.get("_kafka_data");
+    if (!(kafkaData instanceof Map)) {
+      return null;
+    }
+    Object id = ((Map<String, Object>) kafkaData).get("putAttemptId");
+    return id != null ? id.toString() : null;
   }
 
   /**

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiWriterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiWriterTest.java
@@ -25,31 +25,46 @@ package com.wepay.kafka.connect.bigquery.write.storage;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.api.core.ApiFuture;
 import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.storage.v1.AppendRowsResponse;
+import com.google.cloud.bigquery.storage.v1.JsonStreamWriter;
 import com.google.cloud.bigquery.storage.v1.TableName;
+import com.google.cloud.bigquery.storage.v1.TableSchema;
 import com.google.protobuf.ByteString;
+import com.wepay.kafka.connect.bigquery.ErrantRecordHandler;
+import com.wepay.kafka.connect.bigquery.SchemaManager;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
 import com.wepay.kafka.connect.bigquery.convert.BigQueryRecordConverter;
+import com.wepay.kafka.connect.bigquery.convert.KafkaDataBuilder;
 import com.wepay.kafka.connect.bigquery.convert.RecordConverter;
+import com.wepay.kafka.connect.bigquery.utils.MockTime;
 import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
 import com.wepay.kafka.connect.bigquery.utils.SinkRecordConverter;
 import com.wepay.kafka.connect.bigquery.utils.TableNameUtils;
 import com.wepay.kafka.connect.bigquery.write.batch.TableWriterBuilder;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -160,6 +175,175 @@ public class StorageWriteApiWriterTest {
     String tableNameUsedInUpdate = tableNameCaptor.getValue();
     assertFalse(tableNameUsedInUpdate.contains("$"), "Partition decorator ($...) should not be used");
     assertEquals(expectedTableName.toString(), tableNameUsedInUpdate, "Base table name should be used for stream construction");
+  }
+
+  @Test
+  public void testWriteAttemptIdRefreshedOnStorageApiInternalRetry() throws Exception {
+    KafkaDataBuilder.setTrackPutAttempts(true);
+    try {
+      BigQuerySinkTaskConfig mockedConfig = buildTrackedConfig();
+      SinkRecordConverter sinkRecordConverter = new SinkRecordConverter(mockedConfig, null, null);
+
+      StorageWriteApiDefaultStream stream = mock(StorageWriteApiDefaultStream.class, CALLS_REAL_METHODS);
+      JsonStreamWriter jsonWriter = mock(JsonStreamWriter.class);
+      stream.tableToStream = new ConcurrentHashMap<>();
+      stream.schemaManager = mock(SchemaManager.class);
+      stream.errantRecordHandler = mock(ErrantRecordHandler.class);
+      stream.time = new MockTime();
+      doReturn(jsonWriter).when(stream).getDefaultStream(any(), any());
+      doReturn(true).when(stream).canAttemptSchemaUpdate();
+
+      AppendRowsResponse schemaUpdateResponse = AppendRowsResponse.newBuilder()
+          .setUpdatedSchema(TableSchema.newBuilder().build())
+          .build();
+      AppendRowsResponse successResponse = AppendRowsResponse.newBuilder()
+          .setAppendResult(AppendRowsResponse.AppendResult.newBuilder().getDefaultInstanceForType())
+          .build();
+      ApiFuture<AppendRowsResponse> future1 = mock(ApiFuture.class);
+      when(future1.get()).thenReturn(schemaUpdateResponse);
+      ApiFuture<AppendRowsResponse> future2 = mock(ApiFuture.class);
+      when(future2.get()).thenReturn(successResponse);
+      when(jsonWriter.append(any(JSONArray.class))).thenReturn(future1).thenReturn(future2);
+
+      AtomicInteger counter = new AtomicInteger(0);
+      Supplier<String> ulidSupplier = () -> "ULID-" + counter.incrementAndGet();
+
+      PartitionedTableId table = new PartitionedTableId.Builder(
+          TableId.of("test-project", "scratch", "dummy_table")).build();
+      StorageApiBatchModeHandler batchModeHandler = mock(StorageApiBatchModeHandler.class);
+      StorageWriteApiWriter.Builder builder = new StorageWriteApiWriter.Builder(
+          stream, table, sinkRecordConverter, batchModeHandler);
+      builder.withUlidSupplier(ulidSupplier);
+      builder.addRow(createRecord("abc", 100), null);
+      builder.build().run();
+
+      ArgumentCaptor<JSONArray> captor = ArgumentCaptor.forClass(JSONArray.class);
+      verify(jsonWriter, times(2)).append(captor.capture());
+
+      String idFirst = extractPutAttemptId(captor.getAllValues().get(0));
+      String idRetry = extractPutAttemptId(captor.getAllValues().get(1));
+
+      assertNotNull(idFirst, "First attempt should have a putAttemptId");
+      assertNotNull(idRetry, "Retry attempt should have a putAttemptId");
+      assertNotEquals(idFirst, idRetry,
+          "Internal retry must produce a different putAttemptId than the first attempt");
+    } finally {
+      KafkaDataBuilder.setTrackPutAttempts(false);
+    }
+  }
+
+  @Test
+  public void testWriteAttemptIdNotSetWhenTrackingDisabledStorageApi() throws Exception {
+    KafkaDataBuilder.setTrackPutAttempts(false);
+
+    BigQuerySinkTaskConfig mockedConfig = buildTrackedConfig();
+    SinkRecordConverter sinkRecordConverter = new SinkRecordConverter(mockedConfig, null, null);
+
+    StorageWriteApiDefaultStream stream = mock(StorageWriteApiDefaultStream.class, CALLS_REAL_METHODS);
+    JsonStreamWriter jsonWriter = mock(JsonStreamWriter.class);
+    stream.tableToStream = new ConcurrentHashMap<>();
+    stream.schemaManager = mock(SchemaManager.class);
+    stream.errantRecordHandler = mock(ErrantRecordHandler.class);
+    stream.time = new MockTime();
+    doReturn(jsonWriter).when(stream).getDefaultStream(any(), any());
+    doReturn(true).when(stream).canAttemptSchemaUpdate();
+
+    AppendRowsResponse schemaUpdateResponse = AppendRowsResponse.newBuilder()
+        .setUpdatedSchema(TableSchema.newBuilder().build())
+        .build();
+    AppendRowsResponse successResponse = AppendRowsResponse.newBuilder()
+        .setAppendResult(AppendRowsResponse.AppendResult.newBuilder().getDefaultInstanceForType())
+        .build();
+    ApiFuture<AppendRowsResponse> future1 = mock(ApiFuture.class);
+    when(future1.get()).thenReturn(schemaUpdateResponse);
+    ApiFuture<AppendRowsResponse> future2 = mock(ApiFuture.class);
+    when(future2.get()).thenReturn(successResponse);
+    when(jsonWriter.append(any(JSONArray.class))).thenReturn(future1).thenReturn(future2);
+
+    // No withUlidSupplier() call — tracking disabled
+    PartitionedTableId table = new PartitionedTableId.Builder(
+        TableId.of("test-project", "scratch", "dummy_table")).build();
+    StorageApiBatchModeHandler batchModeHandler = mock(StorageApiBatchModeHandler.class);
+    StorageWriteApiWriter.Builder builder = new StorageWriteApiWriter.Builder(
+        stream, table, sinkRecordConverter, batchModeHandler);
+    builder.addRow(createRecord("abc", 100), null);
+    builder.build().run();
+
+    ArgumentCaptor<JSONArray> captor = ArgumentCaptor.forClass(JSONArray.class);
+    verify(jsonWriter, times(2)).append(captor.capture());
+
+    String idFirst = extractPutAttemptId(captor.getAllValues().get(0));
+    String idRetry = extractPutAttemptId(captor.getAllValues().get(1));
+
+    assertNull(idFirst, "putAttemptId should be absent when trackPutAttempts=false");
+    assertNull(idRetry, "putAttemptId should be absent when trackPutAttempts=false on retry");
+  }
+
+  @Test
+  public void testWriteAttemptIdPresentOnFirstAttemptStorageApi() throws Exception {
+    KafkaDataBuilder.setTrackPutAttempts(true);
+    try {
+      BigQuerySinkTaskConfig mockedConfig = buildTrackedConfig();
+      SinkRecordConverter sinkRecordConverter = new SinkRecordConverter(mockedConfig, null, null);
+
+      StorageWriteApiDefaultStream stream = mock(StorageWriteApiDefaultStream.class, CALLS_REAL_METHODS);
+      JsonStreamWriter jsonWriter = mock(JsonStreamWriter.class);
+      stream.tableToStream = new ConcurrentHashMap<>();
+      stream.schemaManager = mock(SchemaManager.class);
+      stream.errantRecordHandler = mock(ErrantRecordHandler.class);
+      stream.time = new MockTime();
+      doReturn(jsonWriter).when(stream).getDefaultStream(any(), any());
+
+      AppendRowsResponse successResponse = AppendRowsResponse.newBuilder()
+          .setAppendResult(AppendRowsResponse.AppendResult.newBuilder().getDefaultInstanceForType())
+          .build();
+      ApiFuture<AppendRowsResponse> future = mock(ApiFuture.class);
+      when(future.get()).thenReturn(successResponse);
+      when(jsonWriter.append(any(JSONArray.class))).thenReturn(future);
+
+      AtomicInteger counter = new AtomicInteger(0);
+      Supplier<String> ulidSupplier = () -> "ULID-" + counter.incrementAndGet();
+
+      PartitionedTableId table = new PartitionedTableId.Builder(
+          TableId.of("test-project", "scratch", "dummy_table")).build();
+      StorageApiBatchModeHandler batchModeHandler = mock(StorageApiBatchModeHandler.class);
+      StorageWriteApiWriter.Builder builder = new StorageWriteApiWriter.Builder(
+          stream, table, sinkRecordConverter, batchModeHandler);
+      builder.withUlidSupplier(ulidSupplier);
+      builder.addRow(createRecord("abc", 100), null);
+      builder.build().run();
+
+      ArgumentCaptor<JSONArray> captor = ArgumentCaptor.forClass(JSONArray.class);
+      verify(jsonWriter, times(1)).append(captor.capture());
+
+      String writeAttemptId = extractPutAttemptId(captor.getValue());
+      assertNotNull(writeAttemptId, "First (and only) write attempt should carry a write-attempt ID");
+    } finally {
+      KafkaDataBuilder.setTrackPutAttempts(false);
+    }
+  }
+
+  private BigQuerySinkTaskConfig buildTrackedConfig() {
+    BigQuerySinkTaskConfig mockedConfig = Mockito.mock(BigQuerySinkTaskConfig.class);
+    when(mockedConfig.getBoolean(BigQuerySinkConfig.USE_STORAGE_WRITE_API_CONFIG)).thenReturn(true);
+    when(mockedConfig.getKafkaDataFieldName()).thenReturn(Optional.of("_kafka_data"));
+    when(mockedConfig.getKafkaKeyFieldName()).thenReturn(Optional.empty());
+    when(mockedConfig.getBoolean(BigQuerySinkConfig.SANITIZE_FIELD_NAME_CONFIG)).thenReturn(false);
+    RecordConverter<Map<String, Object>> rc = new BigQueryRecordConverter(false, false);
+    when(mockedConfig.getRecordConverter()).thenReturn(rc);
+    return mockedConfig;
+  }
+
+  private String extractPutAttemptId(JSONArray records) {
+    if (records.length() == 0) {
+      return null;
+    }
+    JSONObject row = records.getJSONObject(0);
+    if (!row.has("_kafka_data")) {
+      return null;
+    }
+    JSONObject kafkaData = row.getJSONObject("_kafka_data");
+    return kafkaData.optString("putAttemptId", null);
   }
 
   private SinkRecord createRecord(String topic, long offset) {


### PR DESCRIPTION
## 1. Problem (ID: #104629)

The `trackPutAttempts` feature embeds a `putAttemptId` ULID in the `_kafka_data`
metadata struct of every BigQuery row, intended to make rows from different write attempts
distinguishable for downstream deduplication.

However, the ULID was generated once per `put()` invocation and stamped into immutable
`RowToInsert` / `JSONObject` payloads at row-construction time (`addRow()`). When the
connector's internal retry loop resent the same rows to BigQuery, due to a backend 5xx,
quota exceeded, rate limit, or IO error, it reused the same already-built payloads.
Every retry attempt therefore carried the same `putAttemptId` as the original attempt,
making internal-retry duplicates indistinguishable.

The ULID being frozen at `addRow()` time affects all three write paths:

- **Streaming insert path** (`BigQueryWriter`): `performWriteRequest()` retried with the
  same `RowToInsert` map. A 5xx or transient error can arrive after BigQuery has already
  committed the rows, so the retry writes them again with the same ULID.
- **Storage Write API path** (`StorageWriteApiBase`): `appendRows()` retried with the same
  `ConvertedRecord` list. Same at-least-once risk: BigQuery may have committed the rows
  before the gRPC error is observed by the client.
- **GCS batch path** (`GcsBatchTableWriter` + `GcsToBqLoadRunnable`): also frozen at
  `addRow()` time. Connect-level `put()` retries produce two blobs with different ULIDs
  (one per `put()` call) distinguishable. However, two additional scenarios cause the
  same blob to be loaded twice, producing rows with the same ULID:
  - **Task restart with un-deleted blobs**: `GcsToBqLoadRunnable`'s in-memory claim sets
    (`claimedBlobIds`, `activeJobs`, `deletableBlobIds`) are lost on restart. The already-
    loaded blob is picked up again and a second load job appends the same rows.
  - **Transient status-check error**: `checkJobs()` catches a `BigQueryException` while
    reading job status, assumes failure, and unclaims the blob. The blob is re-submitted
    even though the original job may have already committed.

Connect-level retries (Kafka Connect calls `put()` again) were already distinguishable
because each `put()` call set a new `currentPutAttemptId`.

---

## 2. Solution

Two complementary mechanisms are introduced, one per category of problem:

**a-) ULID regeneration before every BigQuery API call** (streaming insert and Storage API paths)

Regenerate a fresh ULID immediately before every actual BigQuery API call, both on the
first attempt and on every internal retry. The original `SinkRecord` keys, preserved
throughout the retry loops, are used as the source for re-conversion. This makes
`putAttemptId` a write-attempt ID (one per API call) rather than a put-attempt ID
(one per `put()` invocation).

**b-)  Deterministic BigQuery job IDs** (GCS batch path)

Make each GCS-to-BigQuery load job idempotent by assigning it a deterministic, content-
derived job ID rather than letting BigQuery assign a random one. The same batch of blobs
always maps to the same job ID (keyed by sorted blob names + attempt counter, hashed with
SHA-256). A re-submission of the same batch after a restart or transient error receives
HTTP 409 (Conflict) from BigQuery; the connector then retrieves the existing job and
inspects its real status , without launching a second load.

---

## 3. Changes

### 3.1 `SinkRecordConverter` - explicit-ID overloads

Added public overloads `getRecordRow(record, table, writeAttemptId)` and
`getRegularRow(record, writeAttemptId)` that accept the ULID as an explicit parameter
instead of reading the shared `volatile currentPutAttemptId` field.

This eliminates the race condition that would arise if executor threads called
`setCurrentPutAttemptId()` concurrently. The shared field is now only written on the Kafka
Connect framework thread (in `put()`) and read on the same thread (in `addRow()`). Executor
threads use the explicit-parameter overloads exclusively.

```java
// New: used by writeRows() and writeBatch() on executor threads
public RowToInsert getRecordRow(SinkRecord record, TableId table, String writeAttemptId)
public Map<String, Object> getRegularRow(SinkRecord record, String writeAttemptId)
```

---

### 3.2 `BigQueryWriter` -  4-arg `writeRows()` overload

The original `writeRows(table, rows)` now delegates to a new
`writeRows(table, rows, recordConverter, ulidSupplier)`. When both are non-null (i.e. when
`trackPutAttempts=true`), the re-conversion block runs before every `performWriteRequest()`
call, including the first:

```java
// Runs before every performWriteRequest(), including the first attempt
if (recordConverter != null && ulidSupplier != null) {
    String newId = ulidSupplier.get();                          // fresh ULID
    SortedMap<SinkRecord, RowToInsert> rebuilt = new TreeMap<>(rows.comparator());
    for (SinkRecord record : rows.keySet()) {
        rebuilt.put(record, recordConverter.getRecordRow(record, table.getBaseTableId(), newId));
    }
    rows = rebuilt;
}
performWriteRequest(table, rows);
```

The block is placed alongside `waitRandomTime()`, outside the `try/catch (BigQueryException)`
guard, so conversion errors propagate cleanly without being swallowed by the retry handler.

The original 2-arg signature is preserved unchanged for all existing callers.

---

### 3.3 `TableWriter` - threads `recordConverter` and `ulidSupplier` through

Two new nullable fields (`recordConverter`, `ulidSupplier`) added to `TableWriter` and its
`Builder`. The builder gains a fluent `withUlidSupplier(Supplier<String>)` setter. `run()`
passes both to the 4-arg `writeRows()`:

```java
writer.writeRows(table, currentBatch, recordConverter, ulidSupplier);
```

When `ulidSupplier` is null (tracking disabled), the call falls through to the original
2-arg path, zero overhead, zero behaviour change.

---

### 3.4 `StorageWriteApiBase` -  re-conversion in `writeBatch()`

The 3-arg `initializeAndWriteRecords()` now delegates to a new 5-arg overload that carries
`recordConverter` and `ulidSupplier` into `writeBatch()`. At the top of `writeBatch()`,
before `appendRows()` is called, the re-conversion block runs:

```java
if (recordConverter != null && ulidSupplier != null) {
    String newId = ulidSupplier.get();                          // fresh ULID
    List<ConvertedRecord> rebuilt = new ArrayList<>();
    for (ConvertedRecord item : batch) {
        Map<String, Object> map = recordConverter.getRegularRow(item.original(), newId);
        rebuilt.add(new ConvertedRecord(item.original(), getJsonFromMap(map)));
    }
    batch = rebuilt;    // local parameter reassignment - caller's variable is NOT modified
}
writer.appendRows(getJsonRecords(batch));
```

`batch` is a method parameter, so reassigning it inside `writeBatch()` does not affect the
outer retry loop's variable. On every retry the outer loop passes the original
`ConvertedRecord` list back in, and a new ULID is generated.

`getJsonFromMap()` is moved from `StorageWriteApiWriter.Builder` (where it was a private
method) to `StorageWriteApiBase` as a package-private static method, so both `writeBatch()`
and `Builder.convertRecord()` can call it from the same package.

---

### 3.5 `StorageWriteApiWriter` - threads `recordConverter` and `ulidSupplier` through

Two new fields and a package-private 6-arg constructor. `run()` calls the 5-arg
`initializeAndWriteRecords()` when tracking is enabled, falling back to the 3-arg form
otherwise (preserving backward compatibility for existing tests that mock on the 3-arg
signature). Builder gains `withUlidSupplier()`. `convertRecord()` now calls
`StorageWriteApiBase.getJsonFromMap()` instead of the deleted private copy.

---

### 3.6 `BigQuerySinkTask.writeSinkRecords()` - wires the supplier when tracking is enabled

```java
// Streaming insert path
if (trackPutAttempts) {
    simpleTableWriterBuilder.withUlidSupplier(() -> ULID_GENERATOR.nextULID());
}

// Storage Write API path
if (trackPutAttempts) {
    storageWriterBuilder.withUlidSupplier(() -> ULID_GENERATOR.nextULID());
}
```

When `trackPutAttempts=false` (the default), `withUlidSupplier()` is never called, the
guard in `writeRows()` / `writeBatch()` evaluates to false on every call, and no overhead
is added.

---

### 3.7 `GcsToBqLoadRunnable` - deterministic job IDs and idempotent re-submission

Three structural changes make GCS-to-BigQuery load jobs idempotent:

**New field: `blobBatchAttempts`**

```java
private final Map<String, Integer> blobBatchAttempts;
```

Tracks how many times each blob batch has been confirmed to genuinely fail (not merely
mis-classified due to a transient error). Keyed by the sorted, comma-joined blob names of
the batch.

**New helpers: `blobBatchKey()` and `stableJobId()`**

```java
private String blobBatchKey(List<BlobId> blobIds) {
    return blobIds.stream().map(BlobId::getName).sorted().collect(Collectors.joining(","));
}

private String stableJobId(List<BlobId> blobIds, int attempt) {
    String input = blobBatchKey(blobIds) + ":attempt=" + attempt;
    return "kcbq-" + sha256Hex(input);   // SHA-256 via java.security.MessageDigest
}
```

Blob names are sorted to eliminate ordering non-determinism. The attempt counter is
appended so that a confirmed-failed batch gets a genuinely new job ID on retry (rather
than a 409 for the known-bad job). SHA-256 hex is 64 characters; with the `kcbq-` prefix
the total is 69 characters - within BigQuery's 1024-character job ID limit.

**Updated `triggerBigQueryLoadJob()` - deterministic ID, 409 handling**

```java
String jobId = stableJobId(blobIds, blobBatchAttempts.getOrDefault(batchKey, 0));
Job job;
try {
    job = bigQuery.create(
        JobInfo.newBuilder(loadJobConfiguration).setJobId(JobId.of(jobId)).build());
} catch (BigQueryException e) {
    if (e.getCode() == 409) {
        job = bigQuery.getJob(JobId.of(jobId));
        logger.info("Load job {} already exists; will monitor its existing status.", jobId);
    } else {
        throw e;
    }
}
activeJobs.put(job, blobIds);
claimedBlobIds.addAll(blobIds);
```

On first submission the job is created normally. On re-submission of the same batch (task
restart or transient error), BigQuery returns 409 and the existing job is retrieved and
monitored by the normal `checkJobs()` path - without a second load.

**Updated `processFailedJob()` — distinguishes genuine failure from transient error**

```java
private void processFailedJob(Job job, List<BlobId> blobsNotCompleted,
                               boolean incrementAttemptCounter) {
    ...
    if (incrementAttemptCounter) {
        blobBatchAttempts.merge(blobBatchKey(blobsNotCompleted), 1, Integer::sum);
    }
    blobsNotCompleted.forEach(claimedBlobIds::remove);
}
```

Called with `true` when `getError() != null` (genuine BigQuery failure): the attempt
counter increments so the next submission uses a different hash and creates a real new job.

Called with `false` when a `BigQueryException` is caught inside the status-check try block
(transient error — outcome unknown): the counter stays unchanged so the next submission
reuses the same job ID, hits 409 if the job already succeeded, and retrieves its real
status without running a second load.

---

## 4. What Reaches BigQuery - Before and After

### 4.1 Streaming insert path

```
BEFORE
  put() call 1
    addRow() → RowToInsert[ULID-PUT-1]  ← frozen
    writeRows():
      attempt 0 → performWriteRequest() → BigQuery gets ULID-PUT-1
      [500 error → internal retry]
      retry 1   → performWriteRequest() → BigQuery gets ULID-PUT-1  ← SAME

AFTER
  put() call 1
    addRow() → RowToInsert[ULID-PUT-1]  ← discarded by re-conversion
    writeRows():
      attempt 0 → newId = ULID-W1 → rebuild → performWriteRequest() → BigQuery gets ULID-W1
      [500 error → internal retry]
      retry 1   → newId = ULID-W2 → rebuild → performWriteRequest() → BigQuery gets ULID-W2

  put() call 2 (Connect-level retry)
    writeRows():
      attempt 0 → newId = ULID-W3 → rebuild → performWriteRequest() → BigQuery gets ULID-W3
```

ULID-W1 ≠ ULID-W2 (internal retry distinguishable). ULID-W1/W2 ≠ ULID-W3 (Connect retry
distinguishable).

### 4.2 Storage Write API path

```
BEFORE
  put() call 1
    addRow() → ConvertedRecord[JSONObject{ULID-PUT-1}]  ← frozen
    writeBatch() attempt 0 → appendRows() → BigQuery gets ULID-PUT-1
    [gRPC error]
    writeBatch() retry 1   → appendRows() → BigQuery gets ULID-PUT-1  ← SAME

AFTER
  put() call 1
    addRow() → ConvertedRecord[original=SinkRecord, converted=JSONObject{ULID-PUT-1}]
    writeBatch() attempt 0:
      newId = ULID-W1 → rebuild from item.original() → appendRows() → BigQuery gets ULID-W1
    [gRPC error; outer batch variable unchanged]
    writeBatch() retry 1:
      newId = ULID-W2 → rebuild from item.original() → appendRows() → BigQuery gets ULID-W2
```

ULID-W1 ≠ ULID-W2 (internal retry distinguishable).

### 4.3 GCS batch path

```
BEFORE — Connect-level retry (already worked)
  put() call 1 → ULID-PUT-1 baked into blob_A → load job → BigQuery gets ULID-PUT-1
  put() call 2 → ULID-PUT-2 baked into blob_B → load job → BigQuery gets ULID-PUT-2
  ULID-PUT-1 ≠ ULID-PUT-2 ✓

BEFORE — Task restart or transient checkJobs() error (broken)
  blob_A already loaded; task restarts (or checkJobs() misclassifies the succeeded job)
  blob_A re-submitted → new load job → BigQuery gets ULID-PUT-1 again
  Both copies have ULID-PUT-1 → indistinguishable ✗

AFTER — Task restart or transient checkJobs() error (fixed)
  blob_A already loaded with jobId = "kcbq-<hash-blob_A:attempt=0>"
  blob_A re-submitted → bigQuery.create("kcbq-<hash-blob_A:attempt=0>") → 409
  → bigQuery.getJob("kcbq-<hash-blob_A:attempt=0>") → existing succeeded job
  → processSuccessfulJob() → blob_A marked for deletion; no second load ✓

AFTER — Genuinely failed load job (correct retry)
  Attempt 0 fails: blobBatchAttempts["blob_A"] = 1
  Attempt 1: jobId = "kcbq-<hash-blob_A:attempt=1>" → new BigQuery job → genuine retry ✓
```

---

## 5. Backward Compatibility

- `writeRows(table, rows)` (2-arg): unchanged signature, unchanged behaviour.
- `initializeAndWriteRecords(table, rows, streamName)` (3-arg): unchanged signature,
  unchanged behaviour (delegates with `null, null`).
- `StorageWriteApiWriter(table, streamWriter, records, streamName)` (4-arg public
  constructor): unchanged, delegates to 6-arg with `null, null`.
- `GcsToBqLoadRunnable(bigQuery, bucket, activeJobs, claimedBlobIds, deletableBlobIds)`
  (5-arg `@VisibleForTesting` constructor): unchanged, delegates to new 6-arg form with an
  empty `blobBatchAttempts` map.
- When `trackPutAttempts=false` (the default): `withUlidSupplier()` is never called; the
  guards in `writeRows()` and `writeBatch()` are always false; no re-conversion occurs;
  no `putAttemptId` field is added to rows.
- Existing deployments with no un-deleted blobs in GCS are unaffected by the deterministic
  job ID change. Deployments with leftover blobs from a prior run will have those blobs
  re-submitted with the new deterministic ID; if the original job already succeeded, the
  409 response prevents a second load.

---

## 6. Tests

### 6.1 `BigQueryWriterTest` — 3 new tests (streaming insert path)

| Test | What it verifies |
|---|---|
| `testPutAttemptIdRefreshedOnInternalRetry` | After a 500 backend error triggers an internal retry, the second `insertAll` call carries a different `putAttemptId` than the first |
| `testPutAttemptIdNotSetWhenTrackingDisabled` | When `trackPutAttempts=false`, no `putAttemptId` appears in any row, even after an internal retry |
| `testWriteAttemptIdPresentOnFirstAttempt` | Even on the first (non-retry) write, the `insertAll` call carries a non-null write-attempt ID generated inside `writeRows()`, not inherited from `put()` |

Test Run:
```
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.043 s -- in com.wepay.kafka.connect.bigquery.write.row.BigQueryWriterTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for kafka-connect-bigquery-api 2.14.0-SNAPSHOT:
[INFO] 
[INFO] kafka-connect-bigquery-api ......................... SUCCESS [  1.913 s]
[INFO] kafka-connect-bigquery ............................. SUCCESS [  4.120 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  6.353 s
[INFO] Finished at: 2026-05-29T10:21:15+02:00
[INFO] ------------------------------------------------------------------------
```



### 6.2 `StorageWriteApiWriterTest` — 3 new tests (Storage Write API path)

| Test | What it verifies |
|---|---|
| `testWriteAttemptIdRefreshedOnStorageApiInternalRetry` | After a schema-update response triggers an internal retry, the second `appendRows` call carries a different `putAttemptId` than the first |
| `testWriteAttemptIdNotSetWhenTrackingDisabledStorageApi` | When `withUlidSupplier()` is not called, no `putAttemptId` field appears on any attempt |
| `testWriteAttemptIdPresentOnFirstAttemptStorageApi` | The first (and only) `appendRows` call carries a non-null write-attempt ID |

Test Run:
```
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.844 s -- in com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiWriterTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for kafka-connect-bigquery-api 2.14.0-SNAPSHOT:
[INFO] 
[INFO] kafka-connect-bigquery-api ......................... SUCCESS [  1.655 s]
[INFO] kafka-connect-bigquery ............................. SUCCESS [  3.968 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  5.922 s
[INFO] Finished at: 2026-05-29T10:25:58+02:00
[INFO] ------------------------------------------------------------------------
```



### 6.3 `GcsToBqLoadRunnableTest` — 3 new tests (GCS batch path)

| Test | What it verifies |
|---|---|
| `testTriggerLoadJob_409ConflictOnCreate_retrievesExistingJob` | When `bigQuery.create()` returns 409, the existing job is retrieved and added to `activeJobs`; the blob is claimed without a second load |
| `testGenuineJobFailure_incrementsAttemptCounter_nextTriggerUsesNewJobId` | After `checkJobs()` finds a job with `getError() != null`, `blobBatchAttempts` is incremented and the next `triggerBigQueryLoadJob()` call produces a different job ID |
| `testTransientCheckJobsException_doesNotIncrementAttemptCounter_sameJobIdUsedOnNextTrigger` | After `checkJobs()` catches a transient `BigQueryException`, `blobBatchAttempts` is unchanged and the next trigger uses the identical job ID |


Test Run:
```
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.861 s -- in com.wepay.kafka.connect.bigquery.GcsToBqLoadRunnableTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for kafka-connect-bigquery-api 2.14.0-SNAPSHOT:
[INFO] 
[INFO] kafka-connect-bigquery-api ......................... SUCCESS [  1.471 s]
[INFO] kafka-connect-bigquery ............................. SUCCESS [  3.467 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  5.210 s
[INFO] Finished at: 2026-05-29T10:26:06+02:00
[INFO] ------------------------------------------------------------------------
```

### 6.4 Unit Tests

Test Run:
```
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.788 s -- in com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiWriterTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.059 s -- in com.wepay.kafka.connect.bigquery.write.storage.BigQueryBuilderTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.018 s -- in com.wepay.kafka.connect.bigquery.write.storage.BigQueryWriteSettingsBuilderTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.043 s -- in com.wepay.kafka.connect.bigquery.write.storage.GcsBuilderTest
[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.155 s -- in com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiBatchApplicationStreamTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 s -- in com.wepay.kafka.connect.bigquery.write.storage.StorageApiBatchModeHandlerTest
[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.050 s -- in com.wepay.kafka.connect.bigquery.write.storage.StorageWriteApiDefaultStreamTest
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.254 s -- in com.wepay.kafka.connect.bigquery.write.row.BigQueryWriterTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.010 s -- in com.wepay.kafka.connect.bigquery.write.row.GcsToBqWriterTest$JsonSerializationTests
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.046 s -- in com.wepay.kafka.connect.bigquery.write.row.GcsToBqWriterTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.052 s -- in com.wepay.kafka.connect.bigquery.write.batch.GcsBatchTableWriterTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.251 s -- in com.wepay.kafka.connect.bigquery.GcpClientBuilderProjectTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.035 s -- in com.wepay.kafka.connect.bigquery.config.GcsBucketValidatorTest
[INFO] Tests run: 33, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.032 s -- in com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfigTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s -- in com.wepay.kafka.connect.bigquery.config.PartitioningModeValidatorTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s -- in com.wepay.kafka.connect.bigquery.config.MultiPropertyValidatorTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.020 s -- in com.wepay.kafka.connect.bigquery.config.CredentialsValidatorTest
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s -- in com.wepay.kafka.connect.bigquery.config.StorageWriteApiValidatorTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s -- in com.wepay.kafka.connect.bigquery.config.PartitioningTypeValidatorTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s -- in com.wepay.kafka.connect.bigquery.utils.PartitionedTableIdTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s -- in com.wepay.kafka.connect.bigquery.utils.FieldNameSanitizerTest
[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.063 s -- in com.wepay.kafka.connect.bigquery.RecordTableResolverTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s -- in com.wepay.kafka.connect.bigquery.ErrantRecordHandlerTest
[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.161 s -- in com.wepay.kafka.connect.bigquery.BigQuerySinkTaskTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.178 s -- in com.wepay.kafka.connect.bigquery.BigQueryStorageApiBatchSinkTaskTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s -- in com.wepay.kafka.connect.bigquery.BigQuerySinkConnectorTest
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.090 s -- in com.wepay.kafka.connect.bigquery.MergeQueriesTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.114 s -- in com.wepay.kafka.connect.bigquery.BigQueryStorageApiSinkTaskTest
[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s -- in com.wepay.kafka.connect.bigquery.exception.BigQueryStorageWriteApiErrorResponsesTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s -- in com.wepay.kafka.connect.bigquery.exception.BigQueryErrorResponsesTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s -- in com.wepay.kafka.connect.bigquery.exception.BigQueryStorageWriteApiConnectExceptionTest
[INFO] Tests run: 43, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.089 s -- in com.wepay.kafka.connect.bigquery.SchemaManagerTest
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.113 s -- in com.wepay.kafka.connect.bigquery.GcsToBqLoadRunnableTest
[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 s -- in com.wepay.kafka.connect.bigquery.convert.KafkaDataConverterTest
[INFO] Tests run: 42, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.107 s -- in com.wepay.kafka.connect.bigquery.convert.BigQuerySchemaConverterTest
[INFO] Tests run: 38, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.026 s -- in com.wepay.kafka.connect.bigquery.convert.BigQueryRecordConverterTest
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s -- in com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConvertersTest
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s -- in com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConvertersTest
[INFO] Results:
[INFO] 
[INFO] Tests run: 396, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for kafka-connect-bigquery-api 2.14.0-SNAPSHOT:
[INFO] 
[INFO] kafka-connect-bigquery-api ......................... SUCCESS [  1.752 s]
[INFO] kafka-connect-bigquery ............................. SUCCESS [  5.539 s]
[INFO] ------------------------------------------------------------------------
```