### PR TITLE
Add support for Avro time logical types

### DIFF
--- a/docs/src/site/markdown/avroLogicalTypesMigration.md
+++ b/docs/src/site/markdown/avroLogicalTypesMigration.md
@@ -1,0 +1,137 @@
+# Avro Temporal Logical Types Migration Guide
+
+## Background
+
+Starting from this version, the connector correctly maps Avro temporal logical
+types to their corresponding BigQuery column types instead of falling through
+to plain `INTEGER`.
+
+This change requires a compatible version of the Confluent Schema Registry Avro
+converter that produces named Connect schemas for these types (see
+[confluentinc/schema-registry#4341](https://github.com/confluentinc/schema-registry/pull/4341)).
+Both components must be upgraded together.
+
+### Affected Avro logical types
+
+| Avro logical type        | Previous BigQuery type | New BigQuery type |
+|--------------------------|------------------------|-------------------|
+| `timestamp-micros`       | `INTEGER`              | `TIMESTAMP`       |
+| `timestamp-nanos`        | `INTEGER`              | `TIMESTAMP`       |
+| `time-micros`            | `INTEGER`              | `TIME`            |
+| `local-timestamp-millis` | `INTEGER`              | `DATETIME`        |
+| `local-timestamp-micros` | `INTEGER`              | `DATETIME`        |
+| `local-timestamp-nanos`  | `INTEGER`              | `DATETIME`        |
+
+## Who is affected
+
+You are affected if **all** of the following are true:
+
+- Your Avro schemas use any of the logical types listed above
+- You have existing BigQuery tables where these fields were previously written
+  as `INTEGER`
+- You are upgrading both the Avro converter and this connector simultaneously
+
+If your tables were created after upgrading, or these field types were not
+present in your schemas, no action is needed.
+
+## Migration path
+
+BigQuery does not support changing a column's type in place. The recommended
+approach is to rename the old `INTEGER` column out of the way, recreate it with
+the correct type, and backfill — so the connector keeps writing to the same
+field name with no configuration changes required.
+
+Repeat the following steps for each affected column in your table.
+
+### Step 1 — Rename the old column
+
+```sql
+ALTER TABLE `my_dataset.my_table`
+RENAME COLUMN <column> TO <column>_legacy;
+```
+
+### Step 2 — Add a new column with the correct type
+
+Use the backfill expressions and target types from the table below:
+
+| Avro logical type        | New BigQuery type | Backfill expression                              |
+|--------------------------|-------------------|--------------------------------------------------|
+| `timestamp-micros`       | `TIMESTAMP`       | `TIMESTAMP_MICROS(<column>_legacy)`              |
+| `timestamp-nanos`        | `TIMESTAMP`       | `TIMESTAMP_MICROS(<column>_legacy / 1000)`       |
+| `time-micros`            | `TIME`            | `TIME_ADD(TIME '00:00:00', INTERVAL <column>_legacy MICROSECOND)` |
+| `local-timestamp-millis` | `DATETIME`        | `DATETIME(TIMESTAMP_MILLIS(<column>_legacy))`    |
+| `local-timestamp-micros` | `DATETIME`        | `DATETIME(TIMESTAMP_MICROS(<column>_legacy))`    |
+| `local-timestamp-nanos`  | `DATETIME`        | `DATETIME(TIMESTAMP_MICROS(<column>_legacy / 1000))` |
+
+```sql
+ALTER TABLE `my_dataset.my_table`
+ADD COLUMN <column> <NEW_TYPE>;
+```
+
+### Step 3 — Backfill
+
+```sql
+UPDATE `my_dataset.my_table`
+SET <column> = <backfill expression>
+WHERE TRUE;
+```
+
+For example, for a `timestamp-micros` column named `ts_micros`:
+
+```sql
+ALTER TABLE `my_dataset.my_table` RENAME COLUMN ts_micros TO ts_micros_legacy;
+ALTER TABLE `my_dataset.my_table` ADD COLUMN ts_micros TIMESTAMP;
+UPDATE `my_dataset.my_table` SET ts_micros = TIMESTAMP_MICROS(ts_micros_legacy) WHERE TRUE;
+```
+
+### Step 4 — Upgrade
+
+Upgrade the Avro converter and the connector. The connector will resume writing
+to the original column names automatically — no topic routing or schema changes
+needed.
+
+### Step 5 — Drop the legacy columns
+
+Once you have verified the migrated data, drop the temporary columns:
+
+```sql
+ALTER TABLE `my_dataset.my_table` DROP COLUMN <column>_legacy;
+```
+
+## Rollback
+
+If you need to roll back after upgrading, you must reverse the table changes
+as well as downgrade the software — the old connector cannot write raw
+`INTEGER` values into `TIMESTAMP`, `DATETIME`, or `TIME` columns.
+
+### Step 1 — Downgrade the connector and Avro converter
+
+Restore the previous versions of both components before making any table
+changes, so no new records land in the wrong column type.
+
+### Step 2 — Restore the original INTEGER columns
+
+For each migrated column, rename the new typed column out of the way and
+restore the legacy `INTEGER` column to its original name:
+
+```sql
+ALTER TABLE `my_dataset.my_table` RENAME COLUMN <column> TO <column>_migrated;
+ALTER TABLE `my_dataset.my_table` RENAME COLUMN <column>_legacy TO <column>;
+```
+
+For example, for `ts_micros`:
+
+```sql
+ALTER TABLE `my_dataset.my_table` RENAME COLUMN ts_micros TO ts_micros_migrated;
+ALTER TABLE `my_dataset.my_table` RENAME COLUMN ts_micros_legacy TO ts_micros;
+```
+
+The connector will resume writing raw `INTEGER` values to the restored columns.
+
+### Step 3 — Clean up
+
+Once you have confirmed the rollback is stable, drop the migrated columns:
+
+```sql
+ALTER TABLE `my_dataset.my_table` DROP COLUMN <column>_migrated;
+```

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -37,6 +37,7 @@ import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
 import com.wepay.kafka.connect.bigquery.convert.SchemaConverter;
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.AvroLogicalConverters;
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters;
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConverters;
 import com.wepay.kafka.connect.bigquery.exception.BigQueryStorageWriteApiConnectException;
@@ -436,6 +437,7 @@ public class BigQuerySinkTask extends SinkTask {
   private static void populateLogicalConverterRegistry(BigQuerySinkTaskConfig config) {
     DebeziumLogicalConverters.initialize(config);
     KafkaLogicalConverters.initialize(config);
+    AvroLogicalConverters.initialize();
   }
 
   @Override

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -437,7 +437,9 @@ public class BigQuerySinkTask extends SinkTask {
   private static void populateLogicalConverterRegistry(BigQuerySinkTaskConfig config) {
     DebeziumLogicalConverters.initialize(config);
     KafkaLogicalConverters.initialize(config);
-    AvroLogicalConverters.initialize();
+    if (config.getShouldUseAvroTemporalLogicalTypes()) {
+      AvroLogicalConverters.initialize();
+    }
   }
 
   @Override

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -185,6 +185,16 @@ public class BigQuerySinkConfig extends AbstractConfig {
 
   public static final String CONVERT_DEBEZIUM_TIMESTAMP_TO_INTEGER_CONFIG = "convertDebeziumTimestampToInteger";
 
+  /**
+   * Controls whether Avro temporal logical types introduced after Avro 1.12.1 (timestamp-micros,
+   * timestamp-nanos, time-micros, local-timestamp-millis, local-timestamp-micros, local-timestamp-nanos)
+   * are converted to their corresponding BigQuery types (TIMESTAMP, TIME, DATETIME) rather than
+   * being left as plain INTEGER. Disabled by default to preserve existing table schemas; enabling
+   * this for a topic whose BigQuery table already has these fields as INTEGER will require a manual
+   * schema migration, since BigQuery does not support in-place column type changes.
+   */
+  public static final String USE_AVRO_TEMPORAL_LOGICAL_TYPES_CONFIG = "useAvroTemporalLogicalTypes";
+
   public static final String DECIMAL_HANDLING_MODE_CONFIG = "decimalHandlingMode";
   public static final ConfigDef.Type DECIMAL_HANDLING_MODE_TYPE = ConfigDef.Type.STRING;
   public static final String DECIMAL_HANDLING_MODE_DEFAULT = DecimalHandlingMode.FLOAT.name();
@@ -615,6 +625,10 @@ public class BigQuerySinkConfig extends AbstractConfig {
   private static final ConfigDef.Type CONVERT_DEBEZIUM_TIMESTAMP_TO_INTEGER_TYPE = ConfigDef.Type.BOOLEAN;
   private static final Boolean CONVERT_DEBEZIUM_TIMESTAMP_TO_INTEGER_DEFAULT = false;
   private static final ConfigDef.Importance CONVERT_DEBEZIUM_TIMESTAMP_TO_INTEGER_IMPORTANCE =
+      ConfigDef.Importance.MEDIUM;
+  private static final ConfigDef.Type USE_AVRO_TEMPORAL_LOGICAL_TYPES_TYPE = ConfigDef.Type.BOOLEAN;
+  private static final Boolean USE_AVRO_TEMPORAL_LOGICAL_TYPES_DEFAULT = false;
+  private static final ConfigDef.Importance USE_AVRO_TEMPORAL_LOGICAL_TYPES_IMPORTANCE =
       ConfigDef.Importance.MEDIUM;
   private static final ConfigDef.Type TIME_PARTITIONING_TYPE_TYPE = ConfigDef.Type.STRING;
   private static final ConfigDef.Importance TIME_PARTITIONING_TYPE_IMPORTANCE = ConfigDef.Importance.LOW;
@@ -1086,6 +1100,11 @@ public class BigQuerySinkConfig extends AbstractConfig {
                     CONVERT_DEBEZIUM_TIMESTAMP_TO_INTEGER_TYPE,
                     CONVERT_DEBEZIUM_TIMESTAMP_TO_INTEGER_DEFAULT,
                     CONVERT_DEBEZIUM_TIMESTAMP_TO_INTEGER_IMPORTANCE
+            ).defineInternal(
+                    USE_AVRO_TEMPORAL_LOGICAL_TYPES_CONFIG,
+                    USE_AVRO_TEMPORAL_LOGICAL_TYPES_TYPE,
+                    USE_AVRO_TEMPORAL_LOGICAL_TYPES_DEFAULT,
+                    USE_AVRO_TEMPORAL_LOGICAL_TYPES_IMPORTANCE
             ).define(
                     ExtendedConfigKey.builder(CONVERT_DEBEZIUM_DECIMAL_CONFIG)
                             .type(ConfigDef.Type.BOOLEAN)
@@ -1195,6 +1214,10 @@ public class BigQuerySinkConfig extends AbstractConfig {
 
   public boolean getShouldConvertDebeziumTimestampToInteger() {
     return getBoolean(CONVERT_DEBEZIUM_TIMESTAMP_TO_INTEGER_CONFIG);
+  }
+
+  public boolean getShouldUseAvroTemporalLogicalTypes() {
+    return getBoolean(USE_AVRO_TEMPORAL_LOGICAL_TYPES_CONFIG);
   }
 
   /**

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/AvroLogicalConverters.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/AvroLogicalConverters.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2024 Copyright 2022 Aiven Oy and
+ * bigquery-connector-for-apache-kafka project contributors
+ *
+ * This software contains code derived from the Confluent BigQuery
+ * Kafka Connector, Copyright Confluent, Inc, which in turn
+ * contains code derived from the WePay BigQuery Kafka Connector,
+ * Copyright WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wepay.kafka.connect.bigquery.convert.logicaltype;
+
+import com.google.cloud.bigquery.LegacySQLTypeName;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import org.apache.kafka.connect.data.Schema;
+
+/**
+ * Class containing converters for Avro logical time types that are passed through as named
+ * INT64 schemas by the Confluent schema registry AvroData converter.
+ */
+public class AvroLogicalConverters {
+
+  static final String AVRO_LOGICAL_TIMESTAMP_MICROS = "timestamp-micros";
+  static final String AVRO_LOGICAL_TIMESTAMP_NANOS = "timestamp-nanos";
+  static final String AVRO_LOGICAL_LOCAL_TIMESTAMP_MILLIS = "local-timestamp-millis";
+  static final String AVRO_LOGICAL_LOCAL_TIMESTAMP_MICROS = "local-timestamp-micros";
+  static final String AVRO_LOGICAL_LOCAL_TIMESTAMP_NANOS = "local-timestamp-nanos";
+  static final String AVRO_LOGICAL_TIME_MICROS = "time-micros";
+
+  private static final int MICROS_IN_MILLI = 1000;
+  private static final long MICROS_IN_SEC = 1_000_000L;
+  private static final long NANOS_IN_MICRO = 1000L;
+
+  public static void initialize() {
+    LogicalConverterRegistry.registerIfAbsent(AVRO_LOGICAL_TIMESTAMP_MICROS, new TimestampMicrosConverter());
+    LogicalConverterRegistry.registerIfAbsent(AVRO_LOGICAL_TIMESTAMP_NANOS, new TimestampNanosConverter());
+    LogicalConverterRegistry.registerIfAbsent(AVRO_LOGICAL_LOCAL_TIMESTAMP_MILLIS, new LocalTimestampMillisConverter());
+    LogicalConverterRegistry.registerIfAbsent(AVRO_LOGICAL_LOCAL_TIMESTAMP_MICROS, new LocalTimestampMicrosConverter());
+    LogicalConverterRegistry.registerIfAbsent(AVRO_LOGICAL_LOCAL_TIMESTAMP_NANOS, new LocalTimestampNanosConverter());
+    LogicalConverterRegistry.registerIfAbsent(AVRO_LOGICAL_TIME_MICROS, new TimeMicrosConverter());
+  }
+
+  public static void remove() {
+    LogicalConverterRegistry.unregister(AVRO_LOGICAL_TIMESTAMP_MICROS);
+    LogicalConverterRegistry.unregister(AVRO_LOGICAL_TIMESTAMP_NANOS);
+    LogicalConverterRegistry.unregister(AVRO_LOGICAL_LOCAL_TIMESTAMP_MILLIS);
+    LogicalConverterRegistry.unregister(AVRO_LOGICAL_LOCAL_TIMESTAMP_MICROS);
+    LogicalConverterRegistry.unregister(AVRO_LOGICAL_LOCAL_TIMESTAMP_NANOS);
+    LogicalConverterRegistry.unregister(AVRO_LOGICAL_TIME_MICROS);
+  }
+
+  private AvroLogicalConverters() {
+    // do not instantiate.
+  }
+
+  /**
+   * Converts Avro timestamp-micros (INT64, microseconds since epoch) to BigQuery TIMESTAMP.
+   */
+  public static class TimestampMicrosConverter extends LogicalTypeConverter {
+    public TimestampMicrosConverter() {
+      super(AVRO_LOGICAL_TIMESTAMP_MICROS, Schema.Type.INT64, LegacySQLTypeName.TIMESTAMP);
+    }
+
+    @Override
+    public String convert(Object kafkaConnectObject) {
+      long microTimestamp = (Long) kafkaConnectObject;
+      return formatMicrosAsTimestamp(microTimestamp);
+    }
+  }
+
+  /**
+   * Converts Avro timestamp-nanos (INT64, nanoseconds since epoch) to BigQuery TIMESTAMP.
+   * Nanosecond precision is truncated to microseconds since BigQuery TIMESTAMP supports up to micros.
+   */
+  public static class TimestampNanosConverter extends LogicalTypeConverter {
+    public TimestampNanosConverter() {
+      super(AVRO_LOGICAL_TIMESTAMP_NANOS, Schema.Type.INT64, LegacySQLTypeName.TIMESTAMP);
+    }
+
+    @Override
+    public String convert(Object kafkaConnectObject) {
+      long nanoTimestamp = (Long) kafkaConnectObject;
+      long microTimestamp = nanoTimestamp / NANOS_IN_MICRO;
+      return formatMicrosAsTimestamp(microTimestamp);
+    }
+  }
+
+  /**
+   * Converts Avro local-timestamp-millis (INT64, milliseconds since epoch, no timezone) to BigQuery DATETIME.
+   */
+  public static class LocalTimestampMillisConverter extends LogicalTypeConverter {
+    public LocalTimestampMillisConverter() {
+      super(AVRO_LOGICAL_LOCAL_TIMESTAMP_MILLIS, Schema.Type.INT64, LegacySQLTypeName.DATETIME);
+    }
+
+    @Override
+    public String convert(Object kafkaConnectObject) {
+      long milliTimestamp = (Long) kafkaConnectObject;
+      Date date = new Date(milliTimestamp);
+      SimpleDateFormat bqDatetimeFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+      bqDatetimeFormat.setTimeZone(LogicalTypeConverter.utcTimeZone);
+      return bqDatetimeFormat.format(date);
+    }
+  }
+
+  /**
+   * Converts Avro local-timestamp-micros (INT64, microseconds since epoch, no timezone) to BigQuery DATETIME.
+   */
+  public static class LocalTimestampMicrosConverter extends LogicalTypeConverter {
+    public LocalTimestampMicrosConverter() {
+      super(AVRO_LOGICAL_LOCAL_TIMESTAMP_MICROS, Schema.Type.INT64, LegacySQLTypeName.DATETIME);
+    }
+
+    @Override
+    public String convert(Object kafkaConnectObject) {
+      long microTimestamp = (Long) kafkaConnectObject;
+      return formatMicrosAsDatetime(microTimestamp);
+    }
+  }
+
+  /**
+   * Converts Avro local-timestamp-nanos (INT64, nanoseconds since epoch, no timezone) to BigQuery DATETIME.
+   * Nanosecond precision is truncated to microseconds since BigQuery DATETIME supports up to micros.
+   */
+  public static class LocalTimestampNanosConverter extends LogicalTypeConverter {
+    public LocalTimestampNanosConverter() {
+      super(AVRO_LOGICAL_LOCAL_TIMESTAMP_NANOS, Schema.Type.INT64, LegacySQLTypeName.DATETIME);
+    }
+
+    @Override
+    public String convert(Object kafkaConnectObject) {
+      long nanoTimestamp = (Long) kafkaConnectObject;
+      long microTimestamp = nanoTimestamp / NANOS_IN_MICRO;
+      return formatMicrosAsDatetime(microTimestamp);
+    }
+  }
+
+  /**
+   * Converts Avro time-micros (INT64, microseconds since midnight) to BigQuery TIME.
+   */
+  public static class TimeMicrosConverter extends LogicalTypeConverter {
+    public TimeMicrosConverter() {
+      super(AVRO_LOGICAL_TIME_MICROS, Schema.Type.INT64, LegacySQLTypeName.TIME);
+    }
+
+    @Override
+    public String convert(Object kafkaConnectObject) {
+      long microTimestamp = (Long) kafkaConnectObject;
+      long milliTimestamp = microTimestamp / MICROS_IN_MILLI;
+      Date date = new Date(milliTimestamp);
+
+      SimpleDateFormat bqTimeSecondsFormat = new SimpleDateFormat("HH:mm:ss");
+      bqTimeSecondsFormat.setTimeZone(LogicalTypeConverter.utcTimeZone);
+      String formattedSecondsTime = bqTimeSecondsFormat.format(date);
+
+      long microRemainder = microTimestamp % MICROS_IN_SEC;
+      return formattedSecondsTime + "." + String.format("%06d", microRemainder);
+    }
+  }
+
+  private static String formatMicrosAsTimestamp(long microTimestamp) {
+    long milliTimestamp = microTimestamp / MICROS_IN_MILLI;
+    Date date = new Date(milliTimestamp);
+
+    SimpleDateFormat bqTimestampSecondsFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    bqTimestampSecondsFormat.setTimeZone(LogicalTypeConverter.utcTimeZone);
+    String formattedSeconds = bqTimestampSecondsFormat.format(date);
+
+    long microRemainder = microTimestamp % MICROS_IN_SEC;
+    return formattedSeconds + "." + String.format("%06d", microRemainder);
+  }
+
+  private static String formatMicrosAsDatetime(long microTimestamp) {
+    long milliTimestamp = microTimestamp / MICROS_IN_MILLI;
+    Date date = new Date(milliTimestamp);
+
+    SimpleDateFormat bqDatetimeSecondsFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    bqDatetimeSecondsFormat.setTimeZone(LogicalTypeConverter.utcTimeZone);
+    String formattedSeconds = bqDatetimeSecondsFormat.format(date);
+
+    long microRemainder = microTimestamp % MICROS_IN_SEC;
+    return formattedSeconds + "." + String.format("%06d", microRemainder);
+  }
+}

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTaskTest.java
@@ -48,8 +48,10 @@ import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.AvroLogicalConverters;
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.DebeziumLogicalConverters;
 import com.wepay.kafka.connect.bigquery.convert.logicaltype.KafkaLogicalConverters;
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.LogicalConverterRegistry;
 import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 import com.wepay.kafka.connect.bigquery.utils.MockTime;
 import com.wepay.kafka.connect.bigquery.utils.Time;
@@ -244,6 +246,50 @@ public class BigQuerySinkTaskTest {
   @AfterEach
   public void cleanUp() {
     MergeBatches.resetStreamingBufferAvailabilityWait();
+    AvroLogicalConverters.remove();
+  }
+
+  @Test
+  public void testAvroLogicalTypesNotRegisteredByDefault() {
+    Map<String, String> properties = propertiesFactory.getProperties();
+    properties.put(BigQuerySinkConfig.TOPICS_CONFIG, "test-topic");
+    properties.put(BigQuerySinkConfig.DEFAULT_DATASET_CONFIG, "scratch");
+
+    BigQuerySinkTask testTask = createTestTask(
+        mock(BigQuery.class),
+        mock(SchemaRetriever.class),
+        mock(Storage.class),
+        mock(SchemaManager.class),
+        mockedStorageWriteApiDefaultStream,
+        mockedBatchHandler,
+        time
+    );
+
+    testTask.start(properties);
+
+    assertFalse(LogicalConverterRegistry.isRegisteredLogicalType("timestamp-micros"));
+  }
+
+  @Test
+  public void testAvroLogicalTypesRegisteredWhenEnabled() {
+    Map<String, String> properties = propertiesFactory.getProperties();
+    properties.put(BigQuerySinkConfig.TOPICS_CONFIG, "test-topic");
+    properties.put(BigQuerySinkConfig.DEFAULT_DATASET_CONFIG, "scratch");
+    properties.put(BigQuerySinkConfig.USE_AVRO_TEMPORAL_LOGICAL_TYPES_CONFIG, "true");
+
+    BigQuerySinkTask testTask = createTestTask(
+        mock(BigQuery.class),
+        mock(SchemaRetriever.class),
+        mock(Storage.class),
+        mock(SchemaManager.class),
+        mockedStorageWriteApiDefaultStream,
+        mockedBatchHandler,
+        time
+    );
+
+    testTask.start(properties);
+
+    assertTrue(LogicalConverterRegistry.isRegisteredLogicalType("timestamp-micros"));
   }
 
   @Test

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfigTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfigTest.java
@@ -384,5 +384,17 @@ public class BigQuerySinkConfigTest {
     assertEquals(BigQuerySinkConfig.DecimalHandlingMode.RECORD, config.getVariableScaleDecimalHandlingMode());
     assertEquals(BigQuerySinkConfig.DecimalHandlingMode.FLOAT, config.getDecimalHandlingMode());
     assertFalse(config.getShouldConvertDebeziumTimestampToInteger());
+    assertFalse(config.getShouldUseAvroTemporalLogicalTypes());
+  }
+
+  @Test
+  void testUseAvroLogicalTypesConfig() {
+    Map<String, String> configProperties = propertiesFactory.getProperties();
+    BigQuerySinkConfig config = new BigQuerySinkConfig(configProperties);
+    assertFalse(config.getShouldUseAvroTemporalLogicalTypes());
+
+    configProperties.put(BigQuerySinkConfig.USE_AVRO_TEMPORAL_LOGICAL_TYPES_CONFIG, "true");
+    config = new BigQuerySinkConfig(configProperties);
+    assertTrue(config.getShouldUseAvroTemporalLogicalTypes());
   }
 }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/AvroLogicalConvertersTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/convert/logicaltype/AvroLogicalConvertersTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2024 Copyright 2022 Aiven Oy and
+ * bigquery-connector-for-apache-kafka project contributors
+ *
+ * This software contains code derived from the Confluent BigQuery
+ * Kafka Connector, Copyright Confluent, Inc, which in turn
+ * contains code derived from the WePay BigQuery Kafka Connector,
+ * Copyright WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wepay.kafka.connect.bigquery.convert.logicaltype;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.google.cloud.bigquery.LegacySQLTypeName;
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.AvroLogicalConverters.LocalTimestampMicrosConverter;
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.AvroLogicalConverters.LocalTimestampMillisConverter;
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.AvroLogicalConverters.LocalTimestampNanosConverter;
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.AvroLogicalConverters.TimeMicrosConverter;
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.AvroLogicalConverters.TimestampMicrosConverter;
+import com.wepay.kafka.connect.bigquery.convert.logicaltype.AvroLogicalConverters.TimestampNanosConverter;
+import org.apache.kafka.connect.data.Schema;
+import org.junit.jupiter.api.Test;
+
+public class AvroLogicalConvertersTest {
+
+  // 2017-03-01 22:20:38.808123 UTC
+  private static final long TIMESTAMP_MICROS = 1488406838_808_123L;
+  // same moment in nanos
+  private static final long TIMESTAMP_NANOS = TIMESTAMP_MICROS * 1000L;
+
+  // 22:20:38.808123 (time of day, microseconds since midnight)
+  private static final long TIME_MICROS = (22 * 3600L + 20 * 60L + 38) * 1_000_000L + 808_123L;
+
+  @Test
+  public void testTimestampMicrosConverterSchemaType() {
+    TimestampMicrosConverter converter = new TimestampMicrosConverter();
+    assertEquals(LegacySQLTypeName.TIMESTAMP, converter.getBqSchemaType());
+    converter.checkEncodingType(Schema.Type.INT64);
+    assertThrows(Exception.class, () -> converter.checkEncodingType(Schema.Type.INT32));
+  }
+
+  @Test
+  public void testTimestampMicrosConversion() {
+    TimestampMicrosConverter converter = new TimestampMicrosConverter();
+    assertEquals("2017-03-01 22:20:38.808123", converter.convert(TIMESTAMP_MICROS));
+  }
+
+  @Test
+  public void testTimestampMicrosConversionEpoch() {
+    TimestampMicrosConverter converter = new TimestampMicrosConverter();
+    assertEquals("1970-01-01 00:00:00.000000", converter.convert(0L));
+  }
+
+  @Test
+  public void testTimestampNanosConverterSchemaType() {
+    TimestampNanosConverter converter = new TimestampNanosConverter();
+    assertEquals(LegacySQLTypeName.TIMESTAMP, converter.getBqSchemaType());
+    converter.checkEncodingType(Schema.Type.INT64);
+  }
+
+  @Test
+  public void testTimestampNanosConversion() {
+    TimestampNanosConverter converter = new TimestampNanosConverter();
+    // nanos truncated to micros precision
+    assertEquals("2017-03-01 22:20:38.808123", converter.convert(TIMESTAMP_NANOS));
+  }
+
+  @Test
+  public void testTimestampNanosConversionTruncation() {
+    TimestampNanosConverter converter = new TimestampNanosConverter();
+    // sub-microsecond nanos are truncated, not rounded
+    long nanosWithSubMicro = TIMESTAMP_MICROS * 1000L + 999L;
+    assertEquals("2017-03-01 22:20:38.808123", converter.convert(nanosWithSubMicro));
+  }
+
+  @Test
+  public void testLocalTimestampMillisConverterSchemaType() {
+    LocalTimestampMillisConverter converter = new LocalTimestampMillisConverter();
+    assertEquals(LegacySQLTypeName.DATETIME, converter.getBqSchemaType());
+    converter.checkEncodingType(Schema.Type.INT64);
+  }
+
+  @Test
+  public void testLocalTimestampMillisConversion() {
+    LocalTimestampMillisConverter converter = new LocalTimestampMillisConverter();
+    long millis = TIMESTAMP_MICROS / 1000L;
+    assertEquals("2017-03-01 22:20:38.808", converter.convert(millis));
+  }
+
+  @Test
+  public void testLocalTimestampMicrosConverterSchemaType() {
+    LocalTimestampMicrosConverter converter = new LocalTimestampMicrosConverter();
+    assertEquals(LegacySQLTypeName.DATETIME, converter.getBqSchemaType());
+    converter.checkEncodingType(Schema.Type.INT64);
+  }
+
+  @Test
+  public void testLocalTimestampMicrosConversion() {
+    LocalTimestampMicrosConverter converter = new LocalTimestampMicrosConverter();
+    assertEquals("2017-03-01 22:20:38.808123", converter.convert(TIMESTAMP_MICROS));
+  }
+
+  @Test
+  public void testLocalTimestampNanosConverterSchemaType() {
+    LocalTimestampNanosConverter converter = new LocalTimestampNanosConverter();
+    assertEquals(LegacySQLTypeName.DATETIME, converter.getBqSchemaType());
+    converter.checkEncodingType(Schema.Type.INT64);
+  }
+
+  @Test
+  public void testLocalTimestampNanosConversion() {
+    LocalTimestampNanosConverter converter = new LocalTimestampNanosConverter();
+    assertEquals("2017-03-01 22:20:38.808123", converter.convert(TIMESTAMP_NANOS));
+  }
+
+  @Test
+  public void testTimeMicrosConverterSchemaType() {
+    TimeMicrosConverter converter = new TimeMicrosConverter();
+    assertEquals(LegacySQLTypeName.TIME, converter.getBqSchemaType());
+    converter.checkEncodingType(Schema.Type.INT64);
+    assertThrows(Exception.class, () -> converter.checkEncodingType(Schema.Type.INT32));
+  }
+
+  @Test
+  public void testTimeMicrosConversion() {
+    TimeMicrosConverter converter = new TimeMicrosConverter();
+    assertEquals("22:20:38.808123", converter.convert(TIME_MICROS));
+  }
+
+  @Test
+  public void testTimeMicrosConversionMidnight() {
+    TimeMicrosConverter converter = new TimeMicrosConverter();
+    assertEquals("00:00:00.000000", converter.convert(0L));
+  }
+}

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/AvroLogicalTypesIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/AvroLogicalTypesIT.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2024 Copyright 2022 Aiven Oy and
+ * bigquery-connector-for-apache-kafka project contributors
+ *
+ * This software contains code derived from the Confluent BigQuery
+ * Kafka Connector, Copyright Confluent, Inc, which in turn
+ * contains code derived from the WePay BigQuery Kafka Connector,
+ * Copyright WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wepay.kafka.connect.bigquery.integration;
+
+import static io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.LegacySQLTypeName;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.Table;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
+import com.wepay.kafka.connect.bigquery.integration.utils.SchemaRegistryTestUtils;
+import com.wepay.kafka.connect.bigquery.integration.utils.TableClearer;
+import com.wepay.kafka.connect.bigquery.retrieve.IdentitySchemaRetriever;
+import io.confluent.connect.avro.AvroConverter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.runtime.ConnectorConfig;
+import org.apache.kafka.connect.runtime.SinkConnectorConfig;
+import org.apache.kafka.connect.storage.Converter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test that verifies Avro logical time types (timestamp-micros, timestamp-nanos,
+ * time-micros, local-timestamp-*) are written to BigQuery with the correct column types and values,
+ * rather than falling through to plain INTEGER.
+ *
+ * <p>These types are passed through by the Confluent schema registry AvroData converter as named
+ * INT64 Connect schemas, and are handled by {@link
+ * com.wepay.kafka.connect.bigquery.convert.logicaltype.AvroLogicalConverters}.
+ */
+@Tag("integration")
+public class AvroLogicalTypesIT extends BaseConnectorIT {
+
+  private static final String CONNECTOR_NAME = "bigquery-avro-logical-types-connector";
+  private static final int TASKS_MAX = 1;
+
+  // 2017-03-01 22:20:38.808123 UTC
+  private static final long TIMESTAMP_MICROS = 1_488_406_838_808_123L;
+  private static final long TIMESTAMP_NANOS = TIMESTAMP_MICROS * 1_000L;
+  // 2017-03-01 22:20:38.808 UTC in milliseconds
+  private static final long TIMESTAMP_MILLIS = TIMESTAMP_MICROS / 1_000L;
+  // 22:20:38.808123 as microseconds since midnight
+  private static final long TIME_MICROS = (22 * 3_600L + 20 * 60L + 38) * 1_000_000L + 808_123L;
+
+  private BigQuery bigQuery;
+  private SchemaRegistryTestUtils schemaRegistry;
+  private Converter keyConverter;
+  private Converter valueConverter;
+
+  private org.apache.kafka.connect.data.Schema keySchema;
+  private org.apache.kafka.connect.data.Schema valueSchema;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    startConnect();
+    bigQuery = newBigQuery();
+
+    schemaRegistry = new SchemaRegistryTestUtils(connect.kafka().bootstrapServers());
+    schemaRegistry.start();
+
+    keySchema = SchemaBuilder.struct()
+        .field("id", org.apache.kafka.connect.data.Schema.INT64_SCHEMA)
+        .build();
+
+    valueSchema = SchemaBuilder.struct()
+        .field("ts_micros", SchemaBuilder.int64().name("timestamp-micros").optional().build())
+        .field("ts_nanos", SchemaBuilder.int64().name("timestamp-nanos").optional().build())
+        .field("local_ts_millis", SchemaBuilder.int64().name("local-timestamp-millis").optional().build())
+        .field("local_ts_micros", SchemaBuilder.int64().name("local-timestamp-micros").optional().build())
+        .field("local_ts_nanos", SchemaBuilder.int64().name("local-timestamp-nanos").optional().build())
+        .field("time_micros", SchemaBuilder.int64().name("time-micros").optional().build())
+        .build();
+
+    keyConverter = new AvroConverter();
+    keyConverter.configure(
+        Collections.singletonMap(SCHEMA_REGISTRY_URL_CONFIG, schemaRegistry.schemaRegistryUrl()),
+        true
+    );
+
+    valueConverter = new AvroConverter();
+    valueConverter.configure(
+        Collections.singletonMap(SCHEMA_REGISTRY_URL_CONFIG, schemaRegistry.schemaRegistryUrl()),
+        false
+    );
+  }
+
+  @AfterEach
+  public void cleanup() throws Exception {
+    connect.deleteConnector(CONNECTOR_NAME);
+    if (schemaRegistry != null) {
+      schemaRegistry.stop();
+    }
+    stopConnect();
+  }
+
+  @Test
+  public void testAvroLogicalTypesLandWithCorrectBigQueryTypes() throws Exception {
+    final String topic = suffixedTableOrTopic("avro-logical-types");
+    final String table = sanitizedTable(topic);
+
+    connect.kafka().createTopic(topic, TASKS_MAX);
+    TableClearer.clearTables(bigQuery, dataset(), table);
+
+    connect.configureConnector(CONNECTOR_NAME, connectorProps(topic));
+    waitForConnectorToStart(CONNECTOR_NAME, TASKS_MAX);
+
+    produceRecord(topic, 1L);
+
+    waitForCommittedRecords(
+        CONNECTOR_NAME, Collections.singleton(topic), 1, TASKS_MAX, COMMIT_MAX_DURATION_MS);
+
+    // Verify BigQuery column types — the core assertion:
+    // before this change these would all be INTEGER (plain INT64 fallback)
+    Schema bqSchema = getBigQuerySchema(table);
+    assertFieldType(bqSchema, "ts_micros", LegacySQLTypeName.TIMESTAMP);
+    assertFieldType(bqSchema, "ts_nanos", LegacySQLTypeName.TIMESTAMP);
+    assertFieldType(bqSchema, "local_ts_millis", LegacySQLTypeName.DATETIME);
+    assertFieldType(bqSchema, "local_ts_micros", LegacySQLTypeName.DATETIME);
+    assertFieldType(bqSchema, "local_ts_nanos", LegacySQLTypeName.DATETIME);
+    assertFieldType(bqSchema, "time_micros", LegacySQLTypeName.TIME);
+
+    // Verify actual values
+    List<List<Object>> rows = readAllRows(bigQuery, table, "ts_micros");
+    assertEquals(1, rows.size());
+    List<Object> row = rows.get(0);
+
+    // TIMESTAMP fields: getTimestampValue() returns epoch microseconds
+    assertEquals(TIMESTAMP_MICROS, row.get(0), "ts_micros");
+    assertEquals(TIMESTAMP_MICROS, row.get(1), "ts_nanos (truncated to micros)");
+
+    // DATETIME fields: getTimestampValue() returns epoch microseconds interpreted as UTC
+    assertEquals(TIMESTAMP_MILLIS * 1_000L, row.get(2), "local_ts_millis");
+    assertEquals(TIMESTAMP_MICROS, row.get(3), "local_ts_micros");
+    assertEquals(TIMESTAMP_MICROS, row.get(4), "local_ts_nanos (truncated to micros)");
+
+    // TIME field: getStringValue() returns formatted string
+    assertEquals("22:20:38.808123", row.get(5), "time_micros");
+  }
+
+  private void produceRecord(String topic, long id) {
+    Struct key = new Struct(keySchema).put("id", id);
+    Struct value = new Struct(valueSchema)
+        .put("ts_micros", TIMESTAMP_MICROS)
+        .put("ts_nanos", TIMESTAMP_NANOS)
+        .put("local_ts_millis", TIMESTAMP_MILLIS)
+        .put("local_ts_micros", TIMESTAMP_MICROS)
+        .put("local_ts_nanos", TIMESTAMP_NANOS)
+        .put("time_micros", TIME_MICROS);
+
+    List<List<SchemaAndValue>> records = new ArrayList<>();
+    List<SchemaAndValue> record = new ArrayList<>();
+    record.add(new SchemaAndValue(keySchema, key));
+    record.add(new SchemaAndValue(valueSchema, value));
+    records.add(record);
+
+    schemaRegistry.produceRecordsWithKey(keyConverter, valueConverter, records, topic);
+  }
+
+  private Schema getBigQuerySchema(String tableName) {
+    Table table = bigQuery.getTable(dataset(), tableName);
+    assertNotNull(table, "BigQuery table '" + tableName + "' was not created");
+    return table.getDefinition().getSchema();
+  }
+
+  private void assertFieldType(Schema schema, String fieldName, LegacySQLTypeName expectedType) {
+    Field field = schema.getFields().get(fieldName);
+    assertNotNull(field, "Expected field '" + fieldName + "' not found in BigQuery schema");
+    assertEquals(
+        expectedType,
+        field.getType(),
+        "Field '" + fieldName + "' should be " + expectedType + " but was " + field.getType()
+    );
+  }
+
+  private java.util.Map<String, String> connectorProps(String topic) {
+    java.util.Map<String, String> props = baseConnectorProps(TASKS_MAX);
+    props.put(SinkConnectorConfig.TOPICS_CONFIG, topic);
+    props.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
+    props.put(BigQuerySinkConfig.TABLE_CREATE_CONFIG, "true");
+    props.put(BigQuerySinkConfig.SCHEMA_RETRIEVER_CONFIG, IdentitySchemaRetriever.class.getName());
+    props.put(KEY_CONVERTER_CLASS_CONFIG, AvroConverter.class.getName());
+    props.put(KEY_CONVERTER_CLASS_CONFIG + "." + SCHEMA_REGISTRY_URL_CONFIG,
+        schemaRegistry.schemaRegistryUrl());
+    props.put(VALUE_CONVERTER_CLASS_CONFIG, AvroConverter.class.getName());
+    props.put(ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG + "." + SCHEMA_REGISTRY_URL_CONFIG,
+        schemaRegistry.schemaRegistryUrl());
+    return props;
+  }
+}


### PR DESCRIPTION
<p>Adds converters for Avro time logical types that the Confluent schema registry <code>AvroData</code> converter passes through as named INT64 schemas. Previously these types fell through to plain <code>INTEGER</code> in BigQuery.</p>
<p><strong>New converters in <code>AvroLogicalConverters</code>:</strong></p>

Avro logical type | BigQuery type
-- | --
timestamp-micros | TIMESTAMP
timestamp-nanos | TIMESTAMP (truncated to µs)
time-micros | TIME
local-timestamp-millis | DATETIME
local-timestamp-micros | DATETIME
local-timestamp-nanos | DATETIME (truncated to µs)