### PR TITLE
Retry transient 400 jobBackendError in MergeQueries

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/MergeQueries.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/MergeQueries.java
@@ -204,6 +204,8 @@ public class MergeQueries {
             logger.warn("Serialize access error while merging from {} to {}, retry attempt {}", intermediateTable, destinationTable, ++attempt);
           } else if (BigQueryErrorResponses.isJobInternalError(e)) {
             logger.warn("Job internal error while merging from {} to {}, retry attempt {}", intermediateTable, destinationTable, ++attempt);
+          } else if (BigQueryErrorResponses.isJobBackendError(e)) {
+            logger.warn("Job backend error while merging from {} to {}, retry attempt {}", intermediateTable, destinationTable, ++attempt);
           } else {
             throw e;
           }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/BigQueryErrorResponses.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/BigQueryErrorResponses.java
@@ -47,6 +47,7 @@ public class BigQueryErrorResponses {
   private static final String BAD_REQUEST_REASON = "badRequest";
   private static final String INVALID_REASON = "invalid";
   private static final String INVALID_QUERY_REASON = "invalidQuery";
+  private static final String JOB_BACKEND_ERROR = "jobBackendError";
   private static final String JOB_INTERNAL_ERROR = "jobInternalError";
   private static final String NOT_FOUND_REASON = "notFound";
   private static final String QUOTA_EXCEEDED_REASON = "quotaExceeded";
@@ -86,6 +87,11 @@ public class BigQueryErrorResponses {
     return BAD_REQUEST_CODE == exception.getCode()
         && exception.getError() == null
         && exception.getReason() == null;
+  }
+
+  public static boolean isJobBackendError(BigQueryException exception) {
+    return BAD_REQUEST_CODE == exception.getCode()
+        && JOB_BACKEND_ERROR.equals(exception.getReason());
   }
 
   public static boolean isJobInternalError(BigQueryException exception) {

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/MergeQueriesTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/MergeQueriesTest.java
@@ -397,6 +397,36 @@ public class MergeQueriesTest {
   }
 
   @Test
+  public void testBigQueryJobBackendErrorRetry() throws InterruptedException {
+    // Arrange
+    mergeBatches.addToBatch(TEST_SINK_RECORD, INTERMEDIATE_TABLE, new HashMap<>());
+
+    TableResult tableResultReponse = mock(TableResult.class);
+    BigQueryError jobBackendError = new BigQueryError("jobBackendError", null, "The job encountered an error during execution. Retrying the job may solve the problem.");
+    when(bigQuery.query(any(QueryJobConfiguration.class)))
+        .thenThrow(new BigQueryException(400, "mock job backend error", jobBackendError))
+        .thenReturn(tableResultReponse);
+    when(mergeBatches.destinationTableFor(INTERMEDIATE_TABLE)).thenReturn(DESTINATION_TABLE);
+    when(mergeBatches.incrementBatch(INTERMEDIATE_TABLE)).thenReturn(0);
+    when(mergeBatches.prepareToFlush(INTERMEDIATE_TABLE, 0)).thenReturn(true);
+    CountDownLatch latch = new CountDownLatch(1);
+    doAnswer(invocation -> {
+      Runnable runnable = invocation.getArgument(0);
+      runnable.run();
+      latch.countDown();
+      return null;
+    }).when(executor).execute(any(Runnable.class));
+    MergeQueries mergeQueries = spy(mergeQueries(false, true, true));
+
+    // Act
+    mergeQueries.mergeFlush(INTERMEDIATE_TABLE);
+
+    // Assert
+    latch.await();
+    verify(bigQuery, times(3)).query(any(QueryJobConfiguration.class));
+  }
+
+  @Test
   public void testBigQueryInvalidQueryErrorRetry() throws InterruptedException {
     // Arrange
     mergeBatches.addToBatch(TEST_SINK_RECORD, INTERMEDIATE_TABLE, new HashMap<>());


### PR DESCRIPTION
Fixes #212

## Problem

When a `MERGE` flush query fails with the transient BigQuery error `400 jobBackendError`, the retry loop in `MergeQueries.mergeFlush()` does not recognize it as retryable: only `jobInternalError` and "Could not serialize access" errors are retried. The exception propagates out of the write thread and the sink task is killed with an unrecoverable `BigQueryConnectException`, requiring a manual task restart — even though BigQuery's own error message says *"Retrying the job may solve the problem."*

Google's [BigQuery error table](https://cloud.google.com/bigquery/docs/error-messages) documents `jobBackendError` and `jobInternalError` identically (HTTP 400, *"the job was created successfully, but failed with an internal error"*) with the identical recommended action: *"Retry the job with a new jobId."* The connector currently retries one of the two but treats the other as fatal.

See #212 for the full production stack trace and analysis.

## Change

- `BigQueryErrorResponses`: add `isJobBackendError()` matching HTTP 400 + reason `jobBackendError`, mirroring `isJobInternalError()`.
- `MergeQueries.mergeFlush()`: retry on `isJobBackendError(e)` in the existing retry loop (bounded by `bigQueryRetry` / `bigQueryRetryWait`, as before).
- `MergeQueriesTest`: new test `testBigQueryJobBackendErrorRetry`, mirroring the existing `testBigQueryJobInternalErrorRetry`.

## Testing

TDD: the new test was written first and failed on the unpatched code with the exact production failure mode (`BigQueryException: mock job backend error` thrown straight out of `mergeFlush`), then passed after the fix. The full `MergeQueriesTest` class passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
