### PR TITLE
Retry transient 404 "Not found: Dataset" during streaming inserts

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/BigQueryErrorResponses.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/BigQueryErrorResponses.java
@@ -63,6 +63,15 @@ public class BigQueryErrorResponses {
         && (message.startsWith("Not found: Table ") || message.contains("Table is deleted: "));
   }
 
+  public static boolean isNonExistentDatasetError(BigQueryException exception) {
+    // The streaming backend can transiently report the whole dataset as missing right after an
+    // intermediate table is created, even though the dataset exists; same eventual-consistency
+    // window as the "Not found: Table" case handled above
+    return NOT_FOUND_CODE == exception.getCode()
+        && NOT_FOUND_REASON.equals(exception.getReason())
+        && message(exception.getError()).startsWith("Not found: Dataset ");
+  }
+
   public static boolean isTableMissingSchemaError(BigQueryException exception) {
     // If a table is missing a schema, it will raise a BigQueryException that the input is invalid
     // For more information about BigQueryExceptions, see: https://cloud.google.com/bigquery/troubleshooting-errors

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriter.java
@@ -221,6 +221,9 @@ public abstract class BigQueryWriter {
         } else if (BigQueryErrorResponses.isRateLimitExceededError(err)) {
           logger.warn("Rate limit exceeded for table {}, attempting retry", table);
           retryCount++;
+        } else if (BigQueryErrorResponses.isNonExistentDatasetError(err)) {
+          logger.warn("Dataset not found for table {} (possibly a transient streaming metadata issue), attempting retry", table);
+          retryCount++;
         } else if (BigQueryErrorResponses.isIoError(err)) {
           logger.warn("IO Exception: {}, attempting retry", err.getCause().getMessage());
           retryCount++;

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/exception/BigQueryErrorResponsesTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/exception/BigQueryErrorResponsesTest.java
@@ -26,10 +26,27 @@ package com.wepay.kafka.connect.bigquery.exception;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.cloud.bigquery.BigQueryError;
 import com.google.cloud.bigquery.BigQueryException;
 import org.junit.jupiter.api.Test;
 
 public class BigQueryErrorResponsesTest {
+
+  @Test
+  public void testIsNonExistentDatasetError() {
+    String message = "Not found: Dataset my-project:my_dataset";
+    BigQueryException error = new BigQueryException(404, message, new BigQueryError("notFound", "global", message));
+    assertTrue(BigQueryErrorResponses.isNonExistentDatasetError(error));
+
+    // a table-level 404 must not match
+    message = "Not found: Table my-project:my_dataset.my_table";
+    error = new BigQueryException(404, message, new BigQueryError("notFound", "global", message));
+    assertFalse(BigQueryErrorResponses.isNonExistentDatasetError(error));
+
+    // a 404 without a structured error (no reason) must not match
+    error = new BigQueryException(404, "Not found: Dataset my-project:my_dataset");
+    assertFalse(BigQueryErrorResponses.isNonExistentDatasetError(error));
+  }
 
   @Test
   public void testIsAuthenticationError() {

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriterTest.java
@@ -169,6 +169,54 @@ public class BigQueryWriterTest {
   }
 
   @Test
+  public void testDatasetNotFoundRetry() {
+    final String topic = "test_topic";
+    final String dataset = "scratch";
+    final Map<String, String> properties = makeProperties("3", "2000", topic, dataset);
+
+    BigQuery bigQuery = mock(BigQuery.class);
+    Table mockTable = mock(Table.class);
+    when(bigQuery.getTable(any(TableId.class))).thenReturn(mockTable);
+
+    InsertAllResponse insertAllResponse = mock(InsertAllResponse.class);
+    when(insertAllResponse.hasErrors()).thenReturn(false);
+    when(insertAllResponse.getInsertErrors()).thenReturn(Collections.emptyMap());
+
+    String errorMessage = "Not found: Dataset project:scratch";
+    BigQueryError error = new BigQueryError("notFound", "global", errorMessage);
+    BigQueryException nonExistentDatasetException = new BigQueryException(404, errorMessage, error);
+
+    //first attempt (dataset transiently not visible), second attempt (success)
+    when(bigQuery.insertAll(any(InsertAllRequest.class)))
+        .thenThrow(nonExistentDatasetException)
+        .thenReturn(insertAllResponse);
+
+    SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
+
+    Storage storage = mock(Storage.class);
+    SchemaRetriever schemaRetriever = mock(SchemaRetriever.class);
+    SchemaManager schemaManager = mock(SchemaManager.class);
+
+    BigQuerySinkTask testTask = BigQuerySinkTaskTest.createTestTask(
+        bigQuery,
+        schemaRetriever,
+        storage,
+        schemaManager,
+        mockedStorageWriteApiDefaultStream,
+        mockedBatchHandler,
+        time
+    );
+    testTask.initialize(sinkTaskContext);
+    testTask.start(properties);
+    testTask.put(
+        Collections.singletonList(spoofSinkRecord(topic, 0, 0, "some_field", "some_value")));
+    testTask.flush(Collections.emptyMap());
+
+    verify(bigQuery, times(2)).insertAll(any(InsertAllRequest.class));
+    verify(schemaManager, times(0)).createTable(any(TableId.class), anyList());
+  }
+
+  @Test
   public void testNonAutoCreateTables() {
     final String topic = "test_topic";
     final String dataset = "scratch";


### PR DESCRIPTION
Fixes #214

## Problem

A transient `404 Not Found` with message `Not found: Dataset <project>:<dataset>` returned by `insertAll` escapes all retry handling and kills the sink task with an unrecoverable error — even when the dataset exists (not deleted/recreated, verified via Cloud Audit Logs in the reported incident) and the very next insert would succeed.

The connector already anticipates the *table*-level flavor of this streaming eventual-consistency window: `AdaptiveBigQueryWriter` retries `isNonExistentTableError` (*"Creating tables or updating table schemas in BigQuery takes up to 2~3 minutes to take effect..."*). But that matcher only matches `"Not found: Table "` / `"Table is deleted: "`, so the dataset-level flavor of the same transient condition falls through `AdaptiveBigQueryWriter.performWriteRequest` and the `BigQueryWriter.writeRows` retry loop (which only retries backend 5xx, quota, rate-limit and IO errors), and the write thread dies.

See #214 for the full stack trace and analysis.

## Change

- `BigQueryErrorResponses`: new narrow matcher `isNonExistentDatasetError()` — HTTP 404 + reason `notFound` + message starting with `"Not found: Dataset "`, mirroring the style of `isNonExistentTableError()`.
- `BigQueryWriter.writeRows()`: treat it as retryable in the existing bounded retry loop, alongside backend/quota/rate-limit/IO errors.
- Tests: `BigQueryErrorResponsesTest.testIsNonExistentDatasetError` (positive + table-level and reason-less negatives) and `BigQueryWriterTest.testDatasetNotFoundRetry` (dataset-404 once → retry → success; verifies no table-creation attempt is made).

## Safety notes

Deliberately **not** extending `isNonExistentTableError`: that matcher gates table auto-creation in `AdaptiveBigQueryWriter`, and the connector should not attempt to create tables in a dataset it cannot see. Handling the dataset flavor as a plain bounded retry has no side effects:

- retries are capped by the existing `bigQueryRetry` / `bigQueryRetryWait` settings; the default `bigQueryRetry=0` keeps current behavior unchanged unless retries are explicitly enabled;
- a genuinely missing dataset (misconfiguration) still fails the task with the existing "Exceeded configured N attempts for write request" error instead of hanging;
- on a 404 nothing was persisted server-side, so retrying introduces no new duplicate-row semantics beyond what the existing 5xx retries already allow;
- a bare 404 without a structured error reason (covered by the existing `testNonAutoCreateTables`) still fails fast — the matcher requires reason `notFound` and the exact message prefix.

## Testing

TDD: both tests were written first and observed failing (`testDatasetNotFoundRetry` failed with the exact production failure mode — `BigQueryConnectException: A write thread has failed with an unrecoverable error`), then pass after the fix. Full `kcbq-connector` test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
