### PR TITLE
Deprecate KafkaDatuilder and redistribute variables and methods.

### DIFF
--- a/kcbq-connector/pom.xml
+++ b/kcbq-connector/pom.xml
@@ -291,6 +291,45 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.15</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>PACKAGE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.50</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/BigQuerySinkTask.java
@@ -349,32 +349,7 @@ public class BigQuerySinkTask extends SinkTask {
     if (testSchemaManager != null) {
       return testSchemaManager;
     }
-    return schemaManager.updateAndGet(sm -> sm != null ? sm : newSchemaManager());
-  }
-
-  private SchemaManager newSchemaManager() {
-    schemaRetriever = config.getSchemaRetriever();
-    SchemaConverter<com.google.cloud.bigquery.Schema> schemaConverter =
-        config.getSchemaConverter();
-    Optional<String> kafkaKeyFieldName = config.getKafkaKeyFieldName();
-    Optional<String> kafkaDataFieldName = config.getKafkaDataFieldName();
-    Optional<String> timestampPartitionFieldName = config.getTimestampPartitionFieldName();
-    Optional<Long> partitionExpiration = config.getPartitionExpirationMs();
-    Optional<List<String>> clusteringFieldName = config.getClusteringPartitionFieldNames();
-    Optional<TimePartitioning.Type> timePartitioningType = config.getTimePartitioningType();
-    boolean sanitizeFieldNames = config.getBoolean(BigQuerySinkConfig.SANITIZE_FIELD_NAME_CONFIG);
-    boolean mediateConcurrentSchemaUpdates =
-        config.getBoolean(BigQuerySinkConfig.MEDIATE_CONCURRENT_SCHEMA_UPDATES_CONFIG);
-    long concurrentSchemaUpdateRetryWaitMs =
-        config.getLong(BigQuerySinkConfig.CONCURRENT_SCHEMA_UPDATE_RETRY_WAIT_MS_CONFIG);
-    int concurrentSchemaUpdateMaxRetries =
-        config.getInt(BigQuerySinkConfig.CONCURRENT_SCHEMA_UPDATE_MAX_RETRIES_CONFIG);
-    return new SchemaManager(schemaRetriever, schemaConverter, getBigQuery(),
-        allowNewBigQueryFields, allowRequiredFieldRelaxation, allowSchemaUnionization,
-        sanitizeFieldNames,
-        kafkaKeyFieldName, kafkaDataFieldName,
-        timestampPartitionFieldName, partitionExpiration, clusteringFieldName, timePartitioningType,
-        mediateConcurrentSchemaUpdates, concurrentSchemaUpdateRetryWaitMs, concurrentSchemaUpdateMaxRetries);
+    return schemaManager.updateAndGet(sm -> sm != null ? sm : new SchemaManager(config, getBigQuery()));
   }
 
   private BigQueryWriter getBigQueryWriter(ErrantRecordHandler errantRecordHandler) {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -46,6 +46,8 @@ import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 import com.wepay.kafka.connect.bigquery.utils.FieldNameSanitizer;
 import com.wepay.kafka.connect.bigquery.utils.TableNameUtils;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -62,8 +64,15 @@ import org.slf4j.LoggerFactory;
  */
 public class SchemaManager {
 
-  private static final Logger logger = LoggerFactory.getLogger(SchemaManager.class);
+  public static final String KAFKA_DATA_TOPIC_FIELD_NAME = "topic";
+  public static final String KAFKA_DATA_PARTITION_FIELD_NAME = "partition";
+  public static final String KAFKA_DATA_OFFSET_FIELD_NAME = "offset";
+  public static final String KAFKA_DATA_INSERT_TIME_FIELD_NAME = "insertTime";
+  public static final String KAFKA_DATA_PUT_ATTEMPT_ID_FIELD_NAME = "putAttemptId";
 
+
+  private static final Logger logger = LoggerFactory.getLogger(SchemaManager.class);
+  private final BigQuerySinkConfig config;
   private final SchemaRetriever schemaRetriever;
   private final SchemaConverter<com.google.cloud.bigquery.Schema> schemaConverter;
   private final BigQuery bigQuery;
@@ -86,6 +95,46 @@ public class SchemaManager {
   private final int concurrentSchemaUpdateMaxRetries;
 
   /**
+   * @param config                         a big query sink configuration.
+   * @param bigQuery                       a BigQuery connector to communicate create/update requests to BigQuery.
+   */
+  public SchemaManager(BigQuerySinkConfig config, BigQuery bigQuery) {
+    this(config, bigQuery,  new ConcurrentHashMap<>(), new ConcurrentHashMap<>(), new ConcurrentHashMap<>(), false);
+  }
+
+  private SchemaManager(final BigQuerySinkConfig config, final BigQuery bigQuery,
+      final ConcurrentMap<TableId, Object> tableCreateLocks,
+      final ConcurrentMap<TableId, Object> tableUpdateLocks,
+      final ConcurrentMap<TableId, com.google.cloud.bigquery.Schema> schemaCache,
+      final boolean intermediateTables) {
+    this.config = config;
+    this.bigQuery = bigQuery;
+    this.tableCreateLocks  = tableCreateLocks;
+    this.tableUpdateLocks =  tableUpdateLocks;
+    this.schemaCache = schemaCache;
+    this.intermediateTables = intermediateTables;
+    allowNewBqFields = config.getBoolean(BigQuerySinkConfig.ALLOW_NEW_BIGQUERY_FIELDS_CONFIG);
+    allowBqRequiredFieldRelaxation = config.getBoolean(BigQuerySinkConfig.ALLOW_BIGQUERY_REQUIRED_FIELD_RELAXATION_CONFIG);
+    allowSchemaUnionization = config.getBoolean(BigQuerySinkConfig.ALLOW_SCHEMA_UNIONIZATION_CONFIG);
+    schemaRetriever = config.getSchemaRetriever();
+    schemaConverter = config.getSchemaConverter();
+    kafkaKeyFieldName = config.getKafkaKeyFieldName();
+    kafkaDataFieldName = config.getKafkaDataFieldName();
+    timestampPartitionFieldName = config.getTimestampPartitionFieldName();
+    partitionExpiration = config.getPartitionExpirationMs();
+    clusteringFieldName = config.getClusteringPartitionFieldNames();
+    timePartitioningType = config.getTimePartitioningType();
+
+    sanitizeFieldNames = config.getBoolean(BigQuerySinkConfig.SANITIZE_FIELD_NAME_CONFIG);
+    mediateConcurrentSchemaUpdates =
+            config.getBoolean(BigQuerySinkConfig.MEDIATE_CONCURRENT_SCHEMA_UPDATES_CONFIG);
+    concurrentSchemaUpdateRetryWaitMs =
+            config.getLong(BigQuerySinkConfig.CONCURRENT_SCHEMA_UPDATE_RETRY_WAIT_MS_CONFIG);
+    concurrentSchemaUpdateMaxRetries =
+            config.getInt(BigQuerySinkConfig.CONCURRENT_SCHEMA_UPDATE_MAX_RETRIES_CONFIG);
+  }
+
+  /**
    * @param schemaRetriever                Used to determine the Kafka Connect Schema that should be used for a
    *                                       given table.
    * @param schemaConverter                Used to convert Kafka Connect Schemas into BigQuery format.
@@ -104,7 +153,9 @@ public class SchemaManager {
    *                                       used instead.
    * @param clusteringFieldName
    * @param timePartitioningType           The time partitioning type (HOUR, DAY, etc.) to use for created tables.
+   * @deprecated Use {@code SchemaManager(BigQuerySinkConfig, BigQuery)}
    */
+  @Deprecated
   public SchemaManager(
       SchemaRetriever schemaRetriever,
       SchemaConverter<com.google.cloud.bigquery.Schema> schemaConverter,
@@ -121,51 +172,8 @@ public class SchemaManager {
       Optional<TimePartitioning.Type> timePartitioningType,
       boolean mediateConcurrentSchemaUpdates,
       long concurrentSchemaUpdateRetryWaitMs,
-      int concurrentSchemaUpdateMaxRetries) {
-    this(
-        schemaRetriever,
-        schemaConverter,
-        bigQuery,
-        allowNewBqFields,
-        allowBqRequiredFieldRelaxation,
-        allowSchemaUnionization,
-        sanitizeFieldNames,
-        kafkaKeyFieldName,
-        kafkaDataFieldName,
-        timestampPartitionFieldName,
-        partitionExpiration,
-        clusteringFieldName,
-        timePartitioningType,
-        mediateConcurrentSchemaUpdates,
-        concurrentSchemaUpdateRetryWaitMs,
-        concurrentSchemaUpdateMaxRetries,
-        false,
-        new ConcurrentHashMap<>(),
-        new ConcurrentHashMap<>(),
-        new ConcurrentHashMap<>());
-  }
-
-  private SchemaManager(
-      SchemaRetriever schemaRetriever,
-      SchemaConverter<com.google.cloud.bigquery.Schema> schemaConverter,
-      BigQuery bigQuery,
-      boolean allowNewBqFields,
-      boolean allowBqRequiredFieldRelaxation,
-      boolean allowSchemaUnionization,
-      boolean sanitizeFieldNames,
-      Optional<String> kafkaKeyFieldName,
-      Optional<String> kafkaDataFieldName,
-      Optional<String> timestampPartitionFieldName,
-      Optional<Long> partitionExpiration,
-      Optional<List<String>> clusteringFieldName,
-      Optional<TimePartitioning.Type> timePartitioningType,
-      boolean mediateConcurrentSchemaUpdates,
-      long concurrentSchemaUpdateRetryWaitMs,
       int concurrentSchemaUpdateMaxRetries,
-      boolean intermediateTables,
-      ConcurrentMap<TableId, Object> tableCreateLocks,
-      ConcurrentMap<TableId, Object> tableUpdateLocks,
-      ConcurrentMap<TableId, com.google.cloud.bigquery.Schema> schemaCache) {
+      BigQuerySinkConfig config) {
     this.schemaRetriever = schemaRetriever;
     this.schemaConverter = schemaConverter;
     this.bigQuery = bigQuery;
@@ -182,35 +190,22 @@ public class SchemaManager {
     this.mediateConcurrentSchemaUpdates = mediateConcurrentSchemaUpdates;
     this.concurrentSchemaUpdateRetryWaitMs = concurrentSchemaUpdateRetryWaitMs;
     this.concurrentSchemaUpdateMaxRetries = concurrentSchemaUpdateMaxRetries;
-    this.intermediateTables = intermediateTables;
-    this.tableCreateLocks = tableCreateLocks;
-    this.tableUpdateLocks = tableUpdateLocks;
-    this.schemaCache = schemaCache;
+    this.config = config;
+    this.intermediateTables = false;
+    this.tableCreateLocks = new ConcurrentHashMap<>();
+    this.tableUpdateLocks = new ConcurrentHashMap<>();
+    this.schemaCache = new ConcurrentHashMap<>();
   }
 
+  /**
+   * Creates a SchemaManager for intermediate tables based on this instance.
+   *
+   * @return a new SchemaManager for intermediate tables based on this instance.
+   */
   public SchemaManager forIntermediateTables() {
-    return new SchemaManager(
-        schemaRetriever,
-        schemaConverter,
-        bigQuery,
-        allowNewBqFields,
-        allowBqRequiredFieldRelaxation,
-        allowSchemaUnionization,
-        sanitizeFieldNames,
-        kafkaKeyFieldName,
-        kafkaDataFieldName,
-        timestampPartitionFieldName,
-        partitionExpiration,
-        clusteringFieldName,
-        timePartitioningType,
-        mediateConcurrentSchemaUpdates,
-        concurrentSchemaUpdateRetryWaitMs,
-        concurrentSchemaUpdateMaxRetries,
-        true,
-        tableCreateLocks,
-        tableUpdateLocks,
-        schemaCache
-    );
+    return new SchemaManager(config, bigQuery, tableCreateLocks,
+            tableUpdateLocks,
+            schemaCache, true);
   }
 
   /**
@@ -757,7 +752,7 @@ public class SchemaManager {
       String dataFieldName = sanitizeFieldNames
           ? FieldNameSanitizer.sanitizeName(kafkaDataFieldName.get())
           : kafkaDataFieldName.get();
-      Field kafkaDataField = KafkaDataBuilder.buildKafkaDataField(dataFieldName);
+      Field kafkaDataField = buildKafkaDataField(dataFieldName);
       valueFields.add(kafkaDataField);
     }
 
@@ -802,7 +797,7 @@ public class SchemaManager {
       String dataFieldName = sanitizeFieldNames
           ? FieldNameSanitizer.sanitizeName(kafkaDataFieldName.get())
           : kafkaDataFieldName.get();
-      Field kafkaDataField = KafkaDataBuilder.buildKafkaDataField(dataFieldName);
+      Field kafkaDataField = buildKafkaDataField(dataFieldName);
       result.add(kafkaDataField);
     }
 
@@ -836,5 +831,34 @@ public class SchemaManager {
 
   private Object lock(ConcurrentMap<TableId, Object> locks, TableId table) {
     return locks.computeIfAbsent(table, t -> new Object());
+  }
+
+  /**
+   * Construct schema for Kafka Data Field
+   *
+   * @param kafkaDataFieldName The configured name of Kafka Data Field
+   * @return Field of Kafka Data, with definitions of kafka topic, partition, offset, and insertTime.
+   */
+  @VisibleForTesting
+  Field buildKafkaDataField(String kafkaDataFieldName) {
+    Field topicField = com.google.cloud.bigquery.Field.of(KAFKA_DATA_TOPIC_FIELD_NAME, LegacySQLTypeName.STRING);
+    Field partitionField = com.google.cloud.bigquery.Field.of(KAFKA_DATA_PARTITION_FIELD_NAME, LegacySQLTypeName.INTEGER);
+    Field offsetField = com.google.cloud.bigquery.Field.of(KAFKA_DATA_OFFSET_FIELD_NAME, LegacySQLTypeName.INTEGER);
+    Field insertTimeField = com.google.cloud.bigquery.Field.newBuilder(
+                    KAFKA_DATA_INSERT_TIME_FIELD_NAME, LegacySQLTypeName.TIMESTAMP)
+            .setMode(com.google.cloud.bigquery.Field.Mode.NULLABLE).build();
+
+    List<Field> subFields = new ArrayList<>(
+            Arrays.asList(topicField, partitionField, offsetField, insertTimeField));
+
+    if (config.trackPutAttempts()) {
+      subFields.add(com.google.cloud.bigquery.Field.newBuilder(
+                      KAFKA_DATA_PUT_ATTEMPT_ID_FIELD_NAME, LegacySQLTypeName.STRING)
+              .setMode(com.google.cloud.bigquery.Field.Mode.NULLABLE).build());
+    }
+
+    return Field.newBuilder(kafkaDataFieldName, LegacySQLTypeName.RECORD,
+                    subFields.toArray(new Field[0]))
+            .setMode(com.google.cloud.bigquery.Field.Mode.NULLABLE).build();
   }
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -26,17 +26,19 @@ package com.wepay.kafka.connect.bigquery.config;
 import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.TimePartitioning;
+import com.google.common.annotations.VisibleForTesting;
 import com.wepay.kafka.connect.bigquery.GcpClientBuilder;
 import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
 import com.wepay.kafka.connect.bigquery.convert.BigQueryRecordConverter;
 import com.wepay.kafka.connect.bigquery.convert.BigQuerySchemaConverter;
-import com.wepay.kafka.connect.bigquery.convert.KafkaDataBuilder;
 import com.wepay.kafka.connect.bigquery.convert.RecordConverter;
 import com.wepay.kafka.connect.bigquery.convert.SchemaConverter;
 import com.wepay.kafka.connect.bigquery.retrieve.IdentitySchemaRetriever;
 import io.aiven.kafka.utils.ConfigKeyBuilder;
 import io.aiven.kafka.utils.ExtendedConfigKey;
 import io.debezium.data.VariableScaleDecimal;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
@@ -60,6 +62,7 @@ import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkConnector;
+import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -662,6 +665,12 @@ public class BigQuerySinkConfig extends AbstractConfig {
           + "dropped instead of causing the record to be rejected.\n";
   private static final List<MultiPropertyValidator<BigQuerySinkConfig>> MULTI_PROPERTY_VALIDATIONS = new ArrayList<>();
 
+  /**
+   * This is a marker variable for methods necessary to keep original sink record metadata.
+   * These methods in SinkRecord class are available only since Kafka Connect API version 3.6.
+   */
+  private static boolean KAFKA_CONNECT_API_POST_3_6;
+
   static {
     // Note that order matters here: validations are performed in the order they're added to this list, and if a
     // property or any of the properties that it depends on has an error, validation for it gets skipped.
@@ -678,17 +687,53 @@ public class BigQuerySinkConfig extends AbstractConfig {
     MULTI_PROPERTY_VALIDATIONS.add(new StorageWriteApiValidator.StorageWriteApiBatchValidator());
     MULTI_PROPERTY_VALIDATIONS.add(new UpsertDeleteValidator.UpsertValidator());
     MULTI_PROPERTY_VALIDATIONS.add(new UpsertDeleteValidator.DeleteValidator());
+
+
+    // Determine if we are running under Kafak 3.6 or later
+    boolean kafkaConnectApiPost36;
+    try {
+      MethodHandles.lookup().findVirtual(
+              SinkRecord.class,
+              "originalTopic",
+              MethodType.methodType(String.class)
+      );
+      MethodHandles.lookup().findVirtual(
+              SinkRecord.class,
+              "originalKafkaPartition",
+              MethodType.methodType(Integer.class)
+      );
+      MethodHandles.lookup().findVirtual(
+              SinkRecord.class,
+              "originalKafkaOffset",
+              MethodType.methodType(long.class)
+      );
+      kafkaConnectApiPost36 = true;
+    } catch (NoSuchMethodException | IllegalAccessException e) {
+      logger.warn("This connector cannot retain original topic/partition/offset fields in SinkRecord. "
+              + "If these fields are mutated in upstream SMTs, they will be lost. "
+              + "Upgrade to Kafka Connect 3.6 to provision reliable metadata into resulting table.", e);
+      kafkaConnectApiPost36 = false;
+    }
+    KAFKA_CONNECT_API_POST_3_6 = kafkaConnectApiPost36;
   }
 
   protected BigQuerySinkConfig(ConfigDef config, Map<String, String> properties) {
     super(config, properties);
     logDeprecationWarnings();
-    KafkaDataBuilder.setUseOriginalValues(getBoolean(PRESERVE_KAFKA_TOPIC_PARTITION_OFFSET__CONFIG));
-    KafkaDataBuilder.setTrackPutAttempts(getBoolean(TRACK_PUT_ATTEMPTS_CONFIG));
   }
 
   public BigQuerySinkConfig(Map<String, String> properties) {
     this(getConfig(), properties);
+  }
+
+  /**
+   * Sets the Kafka Post 3.6 flag.  Used in testing.
+   *
+   * @param post36Flag the state of the flag.
+   */
+  @VisibleForTesting
+  protected void setPost3_6Flag(boolean post36Flag) {
+    KAFKA_CONNECT_API_POST_3_6 = post36Flag;
   }
 
   private void logDeprecationWarnings() {
@@ -1304,6 +1349,75 @@ public class BigQuerySinkConfig extends AbstractConfig {
 
   public boolean isIgnoreUnknownFields() {
     return getBoolean(BigQuerySinkConfig.IGNORE_UNKNOWN_FIELDS_CONFIG);
+  }
+
+  /**
+   * Determines if the storageWriteAPI should be used for writing.
+   *
+   * @return {@code true} if the storage write API should be used, {@code false} otherwise.
+   */
+  public boolean useStorageWriteApi() {
+    return getBoolean(USE_STORAGE_WRITE_API_CONFIG);
+  }
+
+  /**
+   * Determines if the Kafka version is 3.6 or higher and {@code preserveKafkaTopicPartitionOffset} parameter is
+   * {@code true}.
+   *
+   * @return {@code true} if the Kafka version is 3.6 or higher and {@code }preserveKafkaTopicPartitionOffset} configuration
+   * parameter is {@code true}.
+   */
+  public boolean useOriginalValues() {
+    return KAFKA_CONNECT_API_POST_3_6 && getBoolean(PRESERVE_KAFKA_TOPIC_PARTITION_OFFSET__CONFIG);
+  }
+
+  /**
+   * Determines if put attempt tracking is enabled.
+   *
+   * @return {@code true} if {@code trackPutAttempts} configuration parameter is {@code true} and {@code kafkaDataFieldName}
+   * has been set.
+   */
+  public boolean trackPutAttempts() {
+    return hasKafkaDataFieldName() && getBoolean(TRACK_PUT_ATTEMPTS_CONFIG);
+  }
+
+  /**
+   * Determines if {@code kafkaDataFieldName} has been set.
+   *
+   * @return {@code true} if  {@code kafkaDataFieldName} has been set.
+   */
+  public boolean hasKafkaDataFieldName() {
+    return get(KAFKA_DATA_FIELD_NAME_CONFIG) != null;
+  }
+
+  /**
+   * Gets the number of records before a flush is called.
+   *
+   * @return the number of record before a flush is called.
+   */
+  public long getMergeThreshold() {
+    return getLong(BigQuerySinkConfig.MERGE_RECORDS_THRESHOLD_CONFIG);
+  }
+
+  /**
+   * Determines if the message time should be used when inserting records.
+   * If not, the connector processing time will be used.
+   *
+   * @return {@code true} if the message time should be used.
+   */
+  public boolean useMessageTime() {
+    return getBoolean(BigQuerySinkConfig.BIGQUERY_MESSAGE_TIME_PARTITIONING_CONFIG);
+  }
+
+  /**
+   * Determines if the partition decorator should be appended ot the BigQuery table name when inserting records.
+   * When enabled, a suffix is added to table names (e.g., table$yyyyMMdd); when disabled, raw table names are used.
+   * Partition decorators are not supported when using Storage Write API batch mode (enableBatchMode=true).
+   *
+   * @return {@code true} if the partition decorator should be appended to the table name.
+   */
+  public boolean appendPartitionDecorator() {
+    return getBoolean(BigQuerySinkConfig.BIGQUERY_PARTITION_DECORATOR_CONFIG);
   }
 
   public Optional<TimePartitioning.Type> getTimePartitioningType() {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -1343,10 +1343,38 @@ public class BigQuerySinkConfig extends AbstractConfig {
     return Optional.ofNullable(getString(KAFKA_DATA_FIELD_NAME_CONFIG));
   }
 
-  public boolean isUpsertDeleteEnabled() {
-    return getBoolean(UPSERT_ENABLED_CONFIG) || getBoolean(DELETE_ENABLED_CONFIG);
+  /**
+   * Determines if upsert is enabled
+   *
+   * @return {@code true} if upsert is enabled.
+   */
+  public boolean isUpsertEnabled() {
+    return getBoolean(UPSERT_ENABLED_CONFIG);
   }
 
+  /**
+   * Determines delete is enabled.
+   *
+   * @return {@code true} if delete is enabled.
+   */
+  public boolean isDeleteEnabled() {
+    return getBoolean(DELETE_ENABLED_CONFIG);
+  }
+
+  /**
+   * Determines field names should be sanitized.
+   *
+   * @return {@code true} if delete is enabled.
+   */
+  public boolean sanitizeFieldNames() {
+    return getBoolean(SANITIZE_FIELD_NAME_CONFIG);
+  }
+
+  /**
+   * Determines unknown fields should be ignored.
+   *
+   * @return {@code true} if unknown fields should be ignored.
+   */
   public boolean isIgnoreUnknownFields() {
     return getBoolean(BigQuerySinkConfig.IGNORE_UNKNOWN_FIELDS_CONFIG);
   }
@@ -1364,7 +1392,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
    * Determines if the Kafka version is 3.6 or higher and {@code preserveKafkaTopicPartitionOffset} parameter is
    * {@code true}.
    *
-   * @return {@code true} if the Kafka version is 3.6 or higher and {@code }preserveKafkaTopicPartitionOffset} configuration
+   * @return {@code true} if the Kafka version is 3.6 or higher and {@code preserveKafkaTopicPartitionOffset} configuration
    * parameter is {@code true}.
    */
   public boolean useOriginalValues() {
@@ -1384,7 +1412,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
   /**
    * Determines if {@code kafkaDataFieldName} has been set.
    *
-   * @return {@code true} if  {@code kafkaDataFieldName} has been set.
+   * @return {@code true} if {@code kafkaDataFieldName} has been set.
    */
   public boolean hasKafkaDataFieldName() {
     return get(KAFKA_DATA_FIELD_NAME_CONFIG) != null;

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataBuilder.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/KafkaDataBuilder.java
@@ -27,6 +27,8 @@ package com.wepay.kafka.connect.bigquery.convert;
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.google.common.annotations.VisibleForTesting;
+import com.wepay.kafka.connect.bigquery.SchemaManager;
+import com.wepay.kafka.connect.bigquery.utils.SinkRecordConverter;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.util.ArrayList;
@@ -40,7 +42,12 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Helper class to construct schema and record for Kafka Data Field.
+ *
+ * @deprecated This class is deprecated because setting values can cause unexpected results
+ * in environments with multiple tasks, or connector instances.  Methods have been moved to
+ * {@link SinkRecordConverter}.
  */
+@Deprecated
 public class KafkaDataBuilder {
 
   private static final Logger logger = LoggerFactory.getLogger(KafkaDataBuilder.class);
@@ -134,6 +141,7 @@ public class KafkaDataBuilder {
    *
    * @param kafkaDataFieldName The configured name of Kafka Data Field
    * @return Field of Kafka Data, with definitions of kafka topic, partition, offset, and insertTime.
+   * @deprecated use {@link SchemaManager} methods.
    */
   public static Field buildKafkaDataField(String kafkaDataFieldName) {
     Field topicField = com.google.cloud.bigquery.Field.of(KAFKA_DATA_TOPIC_FIELD_NAME, LegacySQLTypeName.STRING);
@@ -187,7 +195,9 @@ public class KafkaDataBuilder {
    *
    * @param kafkaConnectRecord Kafka sink record to build kafka data from.
    * @return HashMap which contains the values of kafka topic, partition, offset, and insertTime.
+   * @deprecated use {@link SinkRecordConverter#buildKafkaDataRecord(SinkRecord, String)}.
    */
+  @Deprecated
   public static Map<String, Object> buildKafkaDataRecord(SinkRecord kafkaConnectRecord) {
     return buildKafkaDataRecord(kafkaConnectRecord, null);
   }
@@ -204,7 +214,9 @@ public class KafkaDataBuilder {
    *                     or {@code null} to omit the field.
    * @return HashMap which contains the values of kafka topic, partition, offset, insertTime,
    *         and optionally putAttemptId.
+   * @deprecated use {@link SinkRecordConverter#buildKafkaDataRecord(SinkRecord, String)}.
    */
+  @Deprecated
   public static Map<String, Object> buildKafkaDataRecord(SinkRecord kafkaConnectRecord,
                                                          String putAttemptId) {
     HashMap<String, Object> kafkaData = new HashMap<>();
@@ -224,7 +236,9 @@ public class KafkaDataBuilder {
    *
    * @param kafkaConnectRecord Kafka sink record to build kafka data from.
    * @return HashMap which contains the values of kafka topic, partition, offset, and insertTime in microseconds.
+   * @deprecated use {@link SinkRecordConverter#buildKafkaDataRecord(SinkRecord, String)}.
    */
+  @Deprecated
   public static Map<String, Object> buildKafkaDataRecordStorageApi(SinkRecord kafkaConnectRecord) {
     return buildKafkaDataRecordStorageApi(kafkaConnectRecord, null);
   }
@@ -238,7 +252,9 @@ public class KafkaDataBuilder {
    *                     or {@code null} to omit the field.
    * @return HashMap which contains the values of kafka topic, partition, offset, insertTime in
    *         microseconds, and optionally putAttemptId.
+   * @deprecated use {@link SinkRecordConverter#buildKafkaDataRecord(SinkRecord, String)}.
    */
+  @Deprecated
   public static Map<String, Object> buildKafkaDataRecordStorageApi(SinkRecord kafkaConnectRecord,
                                                                    String putAttemptId) {
     HashMap<String, Object> kafkaData = new HashMap<>();

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/FieldNameSanitizer.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/FieldNameSanitizer.java
@@ -26,10 +26,18 @@ package com.wepay.kafka.connect.bigquery.utils;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Converts illegal field names into BigQuery acceptable names.
+ */
 public class FieldNameSanitizer {
 
-  // Replace all non-letter, non-digit characters with underscore. Append underscore in front of
-  // name if it does not begin with alphabet or underscore.
+  /**
+   * Replaces all non-letter, non-digit characters with underscore. Append underscore in front of
+   * name if it does not begin with letter or underscore.
+   *
+   * @param name The name to sanitize.
+   * @return the sanitized name.
+   */
   public static String sanitizeName(String name) {
     String sanitizedName = name.replaceAll("[^a-zA-Z0-9_]", "_");
     if (sanitizedName.matches("^[^a-zA-Z_].*")) {
@@ -39,10 +47,17 @@ public class FieldNameSanitizer {
   }
 
 
-  // Big Query specifies field name must begin with a alphabet or underscore and can only contain
-  // letters, numbers, and underscores.
-  // Note: a.b and a/b will have the same value after sanitization which will cause Duplicate key
-  // Exception.
+  /**
+   * Big Query specifies field name must begin with a alphabet or underscore and can only contain
+   * letters, numbers, and underscores.  This method replaces all invalid characters with an underscore "_".
+   * Replacement recurses into maps stored within the map.
+   *
+   * Note: "a.b" and "a/b" will have the same value after sanitization which will cause Duplicate key
+   * Exception.
+   *
+   * @param map The map of field names to values.
+   * @return the map data with cleaned field names.
+   */
   @SuppressWarnings("unchecked")
   public static Map<String, Object> replaceInvalidKeys(Map<String, Object> map) {
     Map<String, Object> result = new HashMap<>();

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/FieldNameSanitizer.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/FieldNameSanitizer.java
@@ -51,7 +51,6 @@ public class FieldNameSanitizer {
    * Big Query specifies field name must begin with a alphabet or underscore and can only contain
    * letters, numbers, and underscores.  This method replaces all invalid characters with an underscore "_".
    * Replacement recurses into maps stored within the map.
-   *
    * Note: "a.b" and "a/b" will have the same value after sanitization which will cause Duplicate key
    * Exception.
    *

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverter.java
@@ -25,6 +25,7 @@ package com.wepay.kafka.connect.bigquery.utils;
 
 import com.google.cloud.bigquery.InsertAllRequest;
 import com.google.cloud.bigquery.TableId;
+import com.google.common.annotations.VisibleForTesting;
 import com.wepay.kafka.connect.bigquery.MergeQueries;
 import com.wepay.kafka.connect.bigquery.SchemaManager;
 import com.wepay.kafka.connect.bigquery.api.KafkaSchemaRecordType;
@@ -98,16 +99,23 @@ public class SinkRecordConverter {
    * @param writeAttemptId the write-attempt ID to embed, or {@code null} if tracking is disabled
    */
   public InsertAllRequest.RowToInsert getRecordRow(SinkRecord record, TableId table, String writeAttemptId) {
-    Map<String, Object> convertedRecord = config.isUpsertDeleteEnabled()
+    Map<String, Object> convertedRecord = config.isUpsertEnabled() || config.isDeleteEnabled()
         ? getUpsertDeleteRow(record, table, writeAttemptId)
         : getRegularRow(record, writeAttemptId);
 
     return InsertAllRequest.RowToInsert.of(getRowId(record), convertedRecord);
   }
 
+  /**
+   * Create the converted row for the case where upsert or delete are enabled.
+   * @param record the record to convert.
+   * @param table the table to write to.
+   * @param writeAttemptId the write ID.
+   * @return the map of the converted record.
+   */
   private Map<String, Object> getUpsertDeleteRow(SinkRecord record, TableId table, String writeAttemptId) {
     // Unconditionally allow tombstone records if delete is enabled.
-    Map<String, Object> convertedValue = config.getBoolean(config.DELETE_ENABLED_CONFIG) && record.value() == null
+    Map<String, Object> convertedValue = config.isDeleteEnabled() && record.value() == null
         ? null
         : recordConverter.convertRecord(record, KafkaSchemaRecordType.VALUE);
 
@@ -149,10 +157,21 @@ public class SinkRecordConverter {
     return maybeSanitize(result);
   }
 
+  /**
+   * Converts a SinkRecord to a regular row using the current putAttemptId.
+   * @param record the record to convert.
+   * @return the map of fields to values.
+   */
   public Map<String, Object> getRegularRow(SinkRecord record) {
     return getRegularRow(record, currentPutAttemptId);
   }
 
+  /**
+   * Converts a SinkRecord to a regular row using the specified putAttemptId.
+   * @param record the record to convert.
+   * @param writeAttemptId the write attempt id to use.
+   * @return the map of fields to values.
+   */
   public Map<String, Object> getRegularRow(SinkRecord record, String writeAttemptId) {
     Map<String, Object> result = recordConverter.convertRecord(record, KafkaSchemaRecordType.VALUE);
 
@@ -165,12 +184,23 @@ public class SinkRecordConverter {
     return maybeSanitize(result);
   }
 
+  /**
+   * Converts field names to BigQuery acceptable names if configured to do so.
+   * @param convertedRecord the record to sanitize.
+   * @return the sanitized record if configured to do so, otherwise the unmodified {@code convertedRecord}.
+   */
   private Map<String, Object> maybeSanitize(Map<String, Object> convertedRecord) {
-    return config.getBoolean(config.SANITIZE_FIELD_NAME_CONFIG)
+    return config.sanitizeFieldNames()
         ? FieldNameSanitizer.replaceInvalidKeys(convertedRecord)
         : convertedRecord;
   }
 
+  /**
+   * Generates the row ID for the BigQuery row.  This is constructed from the topic, partition and offset of the
+   * record.  Values are not affected by the use original values configuration option.
+   * @param record The sink record to generate the id for.
+   * @return the ID for the row.
+   */
   private String getRowId(SinkRecord record) {
     return String.format("%s-%d-%d",
         record.topic(),
@@ -178,6 +208,12 @@ public class SinkRecordConverter {
         record.kafkaOffset());
   }
 
+  /**
+   * Returns the original topic or the current topic as appropriate.
+   *
+   * @param kafkaConnectRecord the record to get the topic from.
+   * @return the original topic or the current topic as appropriate.
+   */
   private String maybeGetOriginalTopic(SinkRecord kafkaConnectRecord) {
     if (config.useOriginalValues()) {
       return kafkaConnectRecord.originalTopic();
@@ -186,6 +222,12 @@ public class SinkRecordConverter {
     }
   }
 
+  /**
+   * Returns the original partition or the current partition as appropriate.
+   *
+   * @param kafkaConnectRecord the record to get the partition from.
+   * @return the original partition or the current partition as appropriate.
+   */
   private Integer maybeGetOriginalKafkaPartition(SinkRecord kafkaConnectRecord) {
     if (config.useOriginalValues()) {
       return kafkaConnectRecord.originalKafkaPartition();
@@ -194,6 +236,12 @@ public class SinkRecordConverter {
     }
   }
 
+  /**
+   * Returns the original offset or the current offset as appropriate.
+   *
+   * @param kafkaConnectRecord the record to get the offset from.
+   * @return the original offset or the current offset as appropriate.
+   */
   private long maybeGetOriginalKafkaOffset(SinkRecord kafkaConnectRecord) {
     if (config.useOriginalValues()) {
       return kafkaConnectRecord.originalKafkaOffset();
@@ -209,12 +257,15 @@ public class SinkRecordConverter {
    * includes a {@code putAttemptId} entry so that rows constructed during different
    * {@code put()} invocations can be distinguished downstream.
    *
+   * Note: Future versions of this method will be package private.
+   *
    * @param kafkaConnectRecord Kafka sink record to build kafka data from.
    * @param putAttemptId ULID string generated at the start of the enclosing {@code put()} call,
    *                     or {@code null} to omit the field.
    * @return HashMap which contains the values of kafka topic, partition, offset, insertTime,
    *         and optionally putAttemptId.
    */
+  @VisibleForTesting
   public Map<String, Object> buildKafkaDataRecord(SinkRecord kafkaConnectRecord,
                                                   String putAttemptId) {
     HashMap<String, Object> kafkaData = new HashMap<>();
@@ -231,6 +282,4 @@ public class SinkRecordConverter {
     }
     return kafkaData;
   }
-
-
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverter.java
@@ -26,9 +26,9 @@ package com.wepay.kafka.connect.bigquery.utils;
 import com.google.cloud.bigquery.InsertAllRequest;
 import com.google.cloud.bigquery.TableId;
 import com.wepay.kafka.connect.bigquery.MergeQueries;
+import com.wepay.kafka.connect.bigquery.SchemaManager;
 import com.wepay.kafka.connect.bigquery.api.KafkaSchemaRecordType;
-import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
-import com.wepay.kafka.connect.bigquery.convert.KafkaDataBuilder;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
 import com.wepay.kafka.connect.bigquery.convert.RecordConverter;
 import com.wepay.kafka.connect.bigquery.write.batch.MergeBatches;
 import java.util.HashMap;
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
 public class SinkRecordConverter {
   private static final Logger logger = LoggerFactory.getLogger(SinkRecordConverter.class);
 
-  private final BigQuerySinkTaskConfig config;
+  private final BigQuerySinkConfig config;
   private final MergeBatches mergeBatches;
   private final MergeQueries mergeQueries;
 
@@ -59,18 +59,16 @@ public class SinkRecordConverter {
   private volatile String currentPutAttemptId = null;
 
 
-  public SinkRecordConverter(BigQuerySinkTaskConfig config,
+  public SinkRecordConverter(BigQuerySinkConfig config,
                              MergeBatches mergeBatches, MergeQueries mergeQueries) {
     this.config = config;
     this.mergeBatches = mergeBatches;
     this.mergeQueries = mergeQueries;
 
     this.recordConverter = config.getRecordConverter();
-    this.mergeRecordsThreshold = config.getLong(config.MERGE_RECORDS_THRESHOLD_CONFIG);
-    this.useMessageTimeDatePartitioning =
-        config.getBoolean(config.BIGQUERY_MESSAGE_TIME_PARTITIONING_CONFIG);
-    this.usePartitionDecorator =
-        config.getBoolean(config.BIGQUERY_PARTITION_DECORATOR_CONFIG);
+    this.mergeRecordsThreshold = config.getMergeThreshold();
+    this.useMessageTimeDatePartitioning = config.useMessageTime();
+    this.usePartitionDecorator = config.appendPartitionDecorator();
   }
 
   /**
@@ -115,7 +113,7 @@ public class SinkRecordConverter {
 
     if (convertedValue != null) {
       config.getKafkaDataFieldName().ifPresent(
-          fieldName -> convertedValue.put(fieldName, KafkaDataBuilder.buildKafkaDataRecord(record, writeAttemptId))
+          fieldName -> convertedValue.put(fieldName, buildKafkaDataRecord(record, writeAttemptId))
       );
     }
 
@@ -158,17 +156,11 @@ public class SinkRecordConverter {
   public Map<String, Object> getRegularRow(SinkRecord record, String writeAttemptId) {
     Map<String, Object> result = recordConverter.convertRecord(record, KafkaSchemaRecordType.VALUE);
 
-    config.getKafkaDataFieldName().ifPresent(fieldName -> {
-      Map<String, Object> kafkaDataField = config.getBoolean(config.USE_STORAGE_WRITE_API_CONFIG)
-          ? KafkaDataBuilder.buildKafkaDataRecordStorageApi(record, writeAttemptId)
-          : KafkaDataBuilder.buildKafkaDataRecord(record, writeAttemptId);
-      result.put(fieldName, kafkaDataField);
-    });
+    config.getKafkaDataFieldName().ifPresent(fieldName ->
+            result.put(fieldName, buildKafkaDataRecord(record, writeAttemptId)));
 
-    config.getKafkaKeyFieldName().ifPresent(fieldName -> {
-      Map<String, Object> keyData = recordConverter.convertRecord(record, KafkaSchemaRecordType.KEY);
-      result.put(fieldName, keyData);
-    });
+    config.getKafkaKeyFieldName().ifPresent(fieldName ->
+            result.put(fieldName, recordConverter.convertRecord(record, KafkaSchemaRecordType.KEY)));
 
     return maybeSanitize(result);
   }
@@ -185,4 +177,60 @@ public class SinkRecordConverter {
         record.kafkaPartition(),
         record.kafkaOffset());
   }
+
+  private String maybeGetOriginalTopic(SinkRecord kafkaConnectRecord) {
+    if (config.useOriginalValues()) {
+      return kafkaConnectRecord.originalTopic();
+    } else {
+      return kafkaConnectRecord.topic();
+    }
+  }
+
+  private Integer maybeGetOriginalKafkaPartition(SinkRecord kafkaConnectRecord) {
+    if (config.useOriginalValues()) {
+      return kafkaConnectRecord.originalKafkaPartition();
+    } else {
+      return kafkaConnectRecord.kafkaPartition();
+    }
+  }
+
+  private long maybeGetOriginalKafkaOffset(SinkRecord kafkaConnectRecord) {
+    if (config.useOriginalValues()) {
+      return kafkaConnectRecord.originalKafkaOffset();
+    } else {
+      return kafkaConnectRecord.kafkaOffset();
+    }
+  }
+
+  /**
+   * Construct a map of Kafka Data record, optionally including a put-attempt identifier.
+   *
+   * <p>When {@code TRACK_PUT_ATTEMPTS} is enabled and {@code putAttemptId} is non-null, the map
+   * includes a {@code putAttemptId} entry so that rows constructed during different
+   * {@code put()} invocations can be distinguished downstream.
+   *
+   * @param kafkaConnectRecord Kafka sink record to build kafka data from.
+   * @param putAttemptId ULID string generated at the start of the enclosing {@code put()} call,
+   *                     or {@code null} to omit the field.
+   * @return HashMap which contains the values of kafka topic, partition, offset, insertTime,
+   *         and optionally putAttemptId.
+   */
+  public Map<String, Object> buildKafkaDataRecord(SinkRecord kafkaConnectRecord,
+                                                  String putAttemptId) {
+    HashMap<String, Object> kafkaData = new HashMap<>();
+    kafkaData.put(SchemaManager.KAFKA_DATA_TOPIC_FIELD_NAME, maybeGetOriginalTopic(kafkaConnectRecord));
+    kafkaData.put(SchemaManager.KAFKA_DATA_PARTITION_FIELD_NAME, maybeGetOriginalKafkaPartition(kafkaConnectRecord));
+    kafkaData.put(SchemaManager.KAFKA_DATA_OFFSET_FIELD_NAME, maybeGetOriginalKafkaOffset(kafkaConnectRecord));
+    if (config.useStorageWriteApi()) {
+      kafkaData.put(SchemaManager.KAFKA_DATA_INSERT_TIME_FIELD_NAME, System.currentTimeMillis() * 1000);
+    } else {
+      kafkaData.put(SchemaManager.KAFKA_DATA_INSERT_TIME_FIELD_NAME, System.currentTimeMillis() / 1000.0);
+    }
+    if (config.trackPutAttempts() && putAttemptId != null) {
+      kafkaData.put(SchemaManager.KAFKA_DATA_PUT_ATTEMPT_ID_FIELD_NAME, putAttemptId);
+    }
+    return kafkaData;
+  }
+
+
 }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverter.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
 /**
  * A class for converting a {@link SinkRecord SinkRecord} to {@link InsertAllRequest.RowToInsert BigQuery row}
  */
-public class SinkRecordConverter {
+public final class SinkRecordConverter {
   private static final Logger logger = LoggerFactory.getLogger(SinkRecordConverter.class);
 
   private final BigQuerySinkConfig config;
@@ -108,6 +108,7 @@ public class SinkRecordConverter {
 
   /**
    * Create the converted row for the case where upsert or delete are enabled.
+   *
    * @param record the record to convert.
    * @param table the table to write to.
    * @param writeAttemptId the write ID.
@@ -159,6 +160,7 @@ public class SinkRecordConverter {
 
   /**
    * Converts a SinkRecord to a regular row using the current putAttemptId.
+   *
    * @param record the record to convert.
    * @return the map of fields to values.
    */
@@ -168,6 +170,7 @@ public class SinkRecordConverter {
 
   /**
    * Converts a SinkRecord to a regular row using the specified putAttemptId.
+   *
    * @param record the record to convert.
    * @param writeAttemptId the write attempt id to use.
    * @return the map of fields to values.
@@ -186,6 +189,7 @@ public class SinkRecordConverter {
 
   /**
    * Converts field names to BigQuery acceptable names if configured to do so.
+   *
    * @param convertedRecord the record to sanitize.
    * @return the sanitized record if configured to do so, otherwise the unmodified {@code convertedRecord}.
    */
@@ -198,6 +202,7 @@ public class SinkRecordConverter {
   /**
    * Generates the row ID for the BigQuery row.  This is constructed from the topic, partition and offset of the
    * record.  Values are not affected by the use original values configuration option.
+   *
    * @param record The sink record to generate the id for.
    * @return the ID for the row.
    */
@@ -256,8 +261,10 @@ public class SinkRecordConverter {
    * <p>When {@code TRACK_PUT_ATTEMPTS} is enabled and {@code putAttemptId} is non-null, the map
    * includes a {@code putAttemptId} entry so that rows constructed during different
    * {@code put()} invocations can be distinguished downstream.
-   *
+   * </p>
+   * <p>
    * Note: Future versions of this method will be package private.
+   * </p>
    *
    * @param kafkaConnectRecord Kafka sink record to build kafka data from.
    * @param putAttemptId ULID string generated at the start of the enclosing {@code put()} call,

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBase.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBase.java
@@ -181,7 +181,7 @@ public abstract class StorageWriteApiBase {
    * @deprecated Use {@link #initializeAndWriteRecords(PartitionedTableId, List, String)} instead.
    */
   @Deprecated
-  public void initializeAndWriteRecords(TableName tableName, List<ConvertedRecord> rows, String streamName) {
+  public final void initializeAndWriteRecords(TableName tableName, List<ConvertedRecord> rows, String streamName) {
     initializeAndWriteRecords(TableNameUtils.partitionedTableId(tableName), rows, streamName);
   }
 
@@ -194,7 +194,7 @@ public abstract class StorageWriteApiBase {
    *                   Pre-conversion sink records are required for DLQ routing
    * @param streamName The stream to use to write table to table.
    */
-  public void initializeAndWriteRecords(PartitionedTableId table, List<ConvertedRecord> rows, String streamName) {
+  public final void initializeAndWriteRecords(PartitionedTableId table, List<ConvertedRecord> rows, String streamName) {
     initializeAndWriteRecords(table, rows, streamName, null, null);
   }
 
@@ -211,7 +211,7 @@ public abstract class StorageWriteApiBase {
    * @param recordConverter  Converter used to rebuild rows with a fresh ULID; may be {@code null}.
    * @param ulidSupplier     Supplier of write-attempt ULIDs; may be {@code null}.
    */
-  public void initializeAndWriteRecords(PartitionedTableId table, List<ConvertedRecord> rows, String streamName,
+  public final void initializeAndWriteRecords(PartitionedTableId table, List<ConvertedRecord> rows, String streamName,
                                         SinkRecordConverter recordConverter, Supplier<String> ulidSupplier) {
     TableName tableName = TableNameUtils.tableName(table.getFullTableId());
     StorageWriteApiRetryHandler retryHandler = new StorageWriteApiRetryHandler(table.getBaseTableId(), getSinkRecords(rows), retry, retryWait, time);

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
@@ -24,15 +24,18 @@
 package com.wepay.kafka.connect.bigquery;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.api.services.bigquery.Bigquery;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.Field;
@@ -44,9 +47,13 @@ import com.google.cloud.bigquery.TableDefinition;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableInfo;
 import com.google.cloud.bigquery.TimePartitioning;
+import com.google.cloud.bigquery.storage.v1.BigQueryWriteSettings;
 import com.google.common.collect.ImmutableList;
 import com.wepay.kafka.connect.bigquery.api.SchemaRetriever;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
 import com.wepay.kafka.connect.bigquery.convert.BigQuerySchemaConverter;
+import com.wepay.kafka.connect.bigquery.convert.KafkaDataBuilder;
 import com.wepay.kafka.connect.bigquery.convert.SchemaConverter;
 import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
 import com.wepay.kafka.connect.bigquery.retrieve.IdentitySchemaRetriever;
@@ -54,9 +61,14 @@ import com.wepay.kafka.connect.bigquery.utils.FieldNameSanitizer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import com.wepay.kafka.connect.bigquery.utils.TestingBigQuerySinkConfig;
+import com.wepay.kafka.connect.bigquery.utils.Time;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -91,12 +103,19 @@ public class SchemaManagerTest {
 
   @Test
   public void testBQTableDescription() {
-    Optional<String> kafkaKeyFieldName = Optional.of("kafkaKey");
-    Optional<String> kafkaDataFieldName = Optional.of("kafkaData");
-    SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
-        mockBigQuery, false, false, false, false, kafkaKeyFieldName, kafkaDataFieldName,
-        Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(TimePartitioning.Type.DAY),
-        false, 0L, 1);
+    SchemaManagerTestConfig sinkConfig = createConfig(Map.of(
+            BigQuerySinkConfig.KAFKA_KEY_FIELD_NAME_CONFIG, "kafkaKey",
+            BigQuerySinkConfig.KAFKA_DATA_FIELD_NAME_CONFIG, "kafkaData",
+            BigQuerySinkConfig.SCHEMA_RETRIEVER_CONFIG, IdentitySchemaRetriever.class.getName(),
+            BigQuerySinkConfig.TIME_PARTITIONING_TYPE_CONFIG, TimePartitioning.Type.DAY.toString(),
+            BigQuerySinkConfig.MEDIATE_CONCURRENT_SCHEMA_UPDATES_CONFIG, "false",
+            BigQuerySinkConfig.CONCURRENT_SCHEMA_UPDATE_RETRY_WAIT_MS_CONFIG, "0",
+            BigQuerySinkConfig.CONCURRENT_SCHEMA_UPDATE_MAX_RETRIES_CONFIG, "1"
+    ));
+
+    sinkConfig.schemaConverter = mockSchemaConverter;
+
+    SchemaManager schemaManager = new SchemaManager(sinkConfig, mockBigQuery);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
@@ -122,10 +141,11 @@ public class SchemaManagerTest {
   @Test
   public void testTimestampPartitionSet() {
     Optional<String> testField = Optional.of("testField");
+    BigQuerySinkConfig sinkConfig = createConfig(new HashMap<>());
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), testField,
         Optional.empty(), Optional.empty(), Optional.of(TimePartitioning.Type.DAY),
-        false, 0L, 1);
+        false, 0L, 1, sinkConfig);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
@@ -154,10 +174,11 @@ public class SchemaManagerTest {
 
   @Test
   public void testAlternativeTimestampPartitionType() {
+    BigQuerySinkConfig sinkConfig = createConfig(new HashMap<>());
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), Optional.empty(),
         Optional.empty(), Optional.empty(), Optional.of(TimePartitioning.Type.HOUR),
-        false, 0L, 1);
+        false, 0L, 1, sinkConfig);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
@@ -177,10 +198,11 @@ public class SchemaManagerTest {
 
   @Test
   public void testNoTimestampPartitionType() {
+    BigQuerySinkConfig sinkConfig = createConfig(new HashMap<>());
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), Optional.empty(),
         Optional.empty(), Optional.empty(), Optional.empty(),
-        false, 0L, 1);
+        false, 0L, 1, sinkConfig);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
@@ -200,10 +222,11 @@ public class SchemaManagerTest {
   @Test
   public void testUpdateTimestampPartitionNull() {
     Optional<String> testField = Optional.of("testField");
+    BigQuerySinkConfig sinkConfig = createConfig(new HashMap<>());
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), testField,
         Optional.empty(), Optional.empty(), Optional.of(TimePartitioning.Type.DAY),
-        false, 0L, 1);
+        false, 0L, 1, sinkConfig);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
@@ -225,10 +248,11 @@ public class SchemaManagerTest {
   @Test
   public void testUpdateTimestampPartitionNotSet() {
     Optional<String> testField = Optional.of("testField");
+    BigQuerySinkConfig sinkConfig = createConfig(new HashMap<>());
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), testField,
         Optional.empty(), Optional.empty(), Optional.of(TimePartitioning.Type.DAY),
-        false, 0L, 1);
+        false, 0L, 1, sinkConfig);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
@@ -253,7 +277,7 @@ public class SchemaManagerTest {
     schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), updateField, Optional.empty(), Optional.empty(),
         Optional.of(TimePartitioning.Type.DAY),
-        false, 0L, 1);
+        false, 0L, 1, sinkConfig);
 
     tableInfo = schemaManager
         .constructTableInfo(tableId, fakeBigQuerySchema, testDoc, false);
@@ -267,10 +291,11 @@ public class SchemaManagerTest {
   @Test
   public void testPartitionExpirationSetWithoutFieldName() {
     Optional<Long> testExpirationMs = Optional.of(86400000L);
+    BigQuerySinkConfig sinkConfig = createConfig(new HashMap<>());
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), Optional.empty(),
         testExpirationMs, Optional.empty(), Optional.of(TimePartitioning.Type.DAY),
-        false, 0L, 1);
+        false, 0L, 1, sinkConfig);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
@@ -299,10 +324,11 @@ public class SchemaManagerTest {
   public void testPartitionExpirationSetWithFieldName() {
     Optional<Long> testExpirationMs = Optional.of(86400000L);
     Optional<String> testField = Optional.of("testField");
+    BigQuerySinkConfig sinkConfig = createConfig(new HashMap<>());
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), testField,
         testExpirationMs, Optional.empty(), Optional.of(TimePartitioning.Type.DAY),
-        false, 0L, 1);
+        false, 0L, 1, sinkConfig);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
@@ -332,10 +358,11 @@ public class SchemaManagerTest {
   public void testClusteringPartitionSet() {
     Optional<String> timestampPartitionFieldName = Optional.of("testField");
     Optional<List<String>> testField = Optional.of(Arrays.asList("column1", "column2"));
+    BigQuerySinkConfig sinkConfig = createConfig(new HashMap<>());
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), timestampPartitionFieldName,
         Optional.empty(), testField, Optional.of(TimePartitioning.Type.DAY),
-        false, 0L, 1);
+        false, 0L, 1, sinkConfig);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
@@ -361,10 +388,11 @@ public class SchemaManagerTest {
   public void testUpdateClusteringPartitionNull() {
     Optional<String> timestampPartitionFieldName = Optional.of("testField");
     Optional<List<String>> testField = Optional.of(Arrays.asList("column1", "column2"));
+    BigQuerySinkConfig sinkConfig = createConfig(new HashMap<>());
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), timestampPartitionFieldName,
         Optional.empty(), testField, Optional.of(TimePartitioning.Type.DAY),
-        false, 0L, 1);
+        false, 0L, 1, sinkConfig);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
@@ -388,10 +416,11 @@ public class SchemaManagerTest {
   public void testUpdateClusteringPartitionNotSet() {
     Optional<String> timestampPartitionFieldName = Optional.of("testField");
     Optional<List<String>> testField = Optional.of(Arrays.asList("column1", "column2"));
+    BigQuerySinkConfig sinkConfig = createConfig(new HashMap<>());
     SchemaManager schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), timestampPartitionFieldName,
         Optional.empty(), testField, Optional.of(TimePartitioning.Type.DAY),
-        false, 0L, 1);
+        false, 0L, 1, sinkConfig);
 
     when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
     when(mockKafkaSchema.doc()).thenReturn(testDoc);
@@ -416,7 +445,7 @@ public class SchemaManagerTest {
     schemaManager = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
         mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), timestampPartitionFieldName,
         Optional.empty(), updateTestField, Optional.of(TimePartitioning.Type.DAY),
-        false, 0L, 1);
+        false, 0L, 1, sinkConfig);
 
     tableInfo = schemaManager
         .constructTableInfo(tableId, fakeBigQuerySchema, testDoc, false);
@@ -838,30 +867,66 @@ public class SchemaManagerTest {
 
   private SchemaManager createSchemaManager(
       boolean allowNewFields, boolean allowFieldRelaxation, boolean allowUnionization, boolean sanitizeFieldNames, SchemaConverter<com.google.cloud.bigquery.Schema> converter) {
+    BigQuerySinkConfig sinkConfig = createConfig(new HashMap<>());
+
     return new SchemaManager(new IdentitySchemaRetriever(), converter, mockBigQuery,
         allowNewFields, allowFieldRelaxation, allowUnionization, sanitizeFieldNames,
         Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
         Optional.of(TimePartitioning.Type.DAY),
-        false, 0L, 1);
+        false, 0L, 1, sinkConfig);
   }
 
+
+  /**
+   * Creates a configuration that allows setting of specific values.
+   * @param overrides overrides for defaults.
+   * @return a SchemaManagerTestConfig implementaiton.
+   */
+  private static SchemaManagerTestConfig createConfig(Map<String, String> overrides) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("project", "project");
+    properties.put("defaultDataset", "defaultDataset");
+    properties.put("taskId", "1");
+    properties.put(BigQuerySinkConfig.MEDIATE_CONCURRENT_SCHEMA_UPDATES_CONFIG, "false");
+    properties.put(BigQuerySinkConfig.CONCURRENT_SCHEMA_UPDATE_RETRY_WAIT_MS_CONFIG, "0");
+    properties.put(BigQuerySinkConfig.CONCURRENT_SCHEMA_UPDATE_MAX_RETRIES_CONFIG, "1");
+    properties.putAll(overrides);
+    return new SchemaManagerTestConfig(properties);
+  }
+
+  /**
+   * Creates a SchemaManager with specified config and using the {@link #mockSchemaConverter}.
+   * @param allowNewFields
+   * @param allowFieldRelaxation
+   * @param allowUnionization
+   * @return A configured SchemaManager
+   */
   private SchemaManager createSchemaManager(
       boolean allowNewFields, boolean allowFieldRelaxation, boolean allowUnionization) {
-    return new SchemaManager(new IdentitySchemaRetriever(), mockSchemaConverter, mockBigQuery,
-        allowNewFields, allowFieldRelaxation, allowUnionization, false,
-        Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
-        Optional.of(TimePartitioning.Type.DAY),
-        false, 0L, 1);
+
+    SchemaManagerTestConfig config = createConfig(Map.of(
+            BigQuerySinkConfig.ALLOW_NEW_BIGQUERY_FIELDS_CONFIG, Boolean.toString(allowNewFields),
+            BigQuerySinkConfig.ALLOW_BIGQUERY_REQUIRED_FIELD_RELAXATION_CONFIG, Boolean.toString(allowFieldRelaxation),
+            BigQuerySinkConfig.ALLOW_SCHEMA_UNIONIZATION_CONFIG, Boolean.toString(allowUnionization),
+            BigQuerySinkConfig.SCHEMA_RETRIEVER_CONFIG, IdentitySchemaRetriever.class.getName(),
+            BigQuerySinkConfig.BIGQUERY_TIMESTAMP_PARTITION_FIELD_NAME_CONFIG, TimePartitioning.Type.DAY.toString()
+    ));
+
+    config.schemaConverter = mockSchemaConverter;
+
+    return new SchemaManager(config, mockBigQuery);
   }
 
   private SchemaManager createSchemaManagerWithConcurrentRetry(
       boolean allowNewFields, boolean allowFieldRelaxation,
       boolean mediateConcurrentSchemaUpdates, long concurrentRetryWaitMs, int maxRetries) {
+    BigQuerySinkConfig sinkConfig = createConfig(new HashMap<>());
+
     return new SchemaManager(new IdentitySchemaRetriever(), mockSchemaConverter, mockBigQuery,
         allowNewFields, allowFieldRelaxation, false, false,
         Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
         Optional.of(TimePartitioning.Type.DAY),
-        mediateConcurrentSchemaUpdates, concurrentRetryWaitMs, maxRetries);
+        mediateConcurrentSchemaUpdates, concurrentRetryWaitMs, maxRetries, sinkConfig);
   }
 
   private void testGetAndValidateProposedSchema(
@@ -1206,6 +1271,93 @@ public class SchemaManagerTest {
     assertEquals(
         expected, sm.unionizeSchemas(schema1, schema2)
     );
+  }
+
+  @Test
+  public void testBuildKafkaDataField() {
+    BigQuerySinkConfig sinkConfig = createConfig(new HashMap<>());
+    SchemaManager underTest = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
+            mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), Optional.empty(),
+            Optional.empty(), Optional.empty(), Optional.of(TimePartitioning.Type.HOUR),
+            false, 0L, 1, sinkConfig);
+
+    Field topicField = Field.of(SchemaManager.KAFKA_DATA_TOPIC_FIELD_NAME, LegacySQLTypeName.STRING);
+    Field partitionField = Field.of(SchemaManager.KAFKA_DATA_PARTITION_FIELD_NAME, LegacySQLTypeName.INTEGER);
+    Field offsetField = Field.of(SchemaManager.KAFKA_DATA_OFFSET_FIELD_NAME, LegacySQLTypeName.INTEGER);
+    Field insertTimeField = Field.newBuilder(SchemaManager.KAFKA_DATA_INSERT_TIME_FIELD_NAME, LegacySQLTypeName.TIMESTAMP)
+            .setMode(Field.Mode.NULLABLE)
+            .build();
+
+    Field expectedBigQuerySchema = Field.newBuilder("kafkaDataFieldName",
+                    LegacySQLTypeName.RECORD,
+                    topicField,
+                    partitionField,
+                    offsetField,
+                    insertTimeField)
+            .setMode(Field.Mode.NULLABLE)
+            .build();
+    Field actualBigQuerySchema = underTest.buildKafkaDataField("kafkaDataFieldName");
+    assertEquals(expectedBigQuerySchema, actualBigQuerySchema);
+  }
+
+  @Test
+  public void testBuildKafkaDataField_flagEnabled_includesPutAttemptIdSubfield() {
+    BigQuerySinkConfig sinkConfig = createConfig(Map.of(
+            BigQuerySinkConfig.KAFKA_DATA_FIELD_NAME_CONFIG, "kafkaDataFieldName",
+            BigQuerySinkConfig.TRACK_PUT_ATTEMPTS_CONFIG, "true",
+            BigQuerySinkConfig.SCHEMA_RETRIEVER_CONFIG, IdentitySchemaRetriever.class.getName(),
+            BigQuerySinkConfig.TIME_PARTITIONING_TYPE_CONFIG, TimePartitioning.Type.HOUR.toString()
+            ));
+    SchemaManager underTest = new SchemaManager(sinkConfig, mockBigQuery);
+
+    Field recordField = underTest.buildKafkaDataField("kafkaDataFieldName");
+
+    boolean found = recordField.getSubFields().stream()
+            .anyMatch(f -> SchemaManager.KAFKA_DATA_PUT_ATTEMPT_ID_FIELD_NAME.equals(f.getName())
+                    && LegacySQLTypeName.STRING.equals(f.getType())
+                    && Field.Mode.NULLABLE.equals(f.getMode()));
+    assertTrue(found, "putAttemptId STRING NULLABLE subfield should be present when flag is enabled");
+  }
+
+  @Test
+  public void testBuildKafkaDataField_flagDisabled_excludesPutAttemptIdSubfield() {
+    SchemaManagerTestConfig sinkConfig = createConfig(Map.of(BigQuerySinkConfig.TRACK_PUT_ATTEMPTS_CONFIG, "false"));
+    sinkConfig.schemaConverter = mockSchemaConverter;
+
+    SchemaManager underTest = new SchemaManager(mockSchemaRetriever, mockSchemaConverter,
+            mockBigQuery, false, false, false, false, Optional.empty(), Optional.empty(), Optional.empty(),
+            Optional.empty(), Optional.empty(), Optional.of(TimePartitioning.Type.HOUR),
+            false, 0L, 1, sinkConfig);
+
+    Field recordField = underTest.buildKafkaDataField("kafkaDataFieldName");
+
+    boolean found = recordField.getSubFields().stream()
+            .anyMatch(f -> SchemaManager.KAFKA_DATA_PUT_ATTEMPT_ID_FIELD_NAME.equals(f.getName()));
+    assertFalse(found, "putAttemptId subfield should not be present when flag is disabled");
+  }
+
+  class TestingSchemaConverter implements SchemaConverter<com.google.cloud.bigquery.Schema> {
+
+    static com.google.cloud.bigquery.Schema result;
+
+    @Override
+    public com.google.cloud.bigquery.Schema convertSchema(Schema schema) {
+      return result;
+    }
+  }
+
+  static class SchemaManagerTestConfig extends BigQuerySinkConfig {
+
+    SchemaConverter<com.google.cloud.bigquery.Schema> schemaConverter;
+
+    public SchemaManagerTestConfig(Map<String, String> properties) {
+      super(properties);
+    }
+
+    @Override
+    public SchemaConverter<com.google.cloud.bigquery.Schema> getSchemaConverter() { /// Update it later
+      return schemaConverter == null ? super.getSchemaConverter() : schemaConverter;
+    }
   }
 
 }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/ApplicationStreamIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/ApplicationStreamIT.java
@@ -161,9 +161,9 @@ public class ApplicationStreamIT extends BaseConnectorIT {
         attempts--;
       }
     } catch (BigQueryException ex) {
-      if (!ex.getError().getReason().equalsIgnoreCase("duplicate"))
-        throw new ConnectException("Failed to create table: ", ex);
-      else
+      if (ex.getError() != null && !ex.getError().getReason().equalsIgnoreCase("duplicate")) {
+        throw new ConnectException("Failed to create table " + table,  ex);
+      } else
         logger.info("Table {} already exist", table);
     }
   }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverterTest.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright 2026 Aiven Oy and
+ * bigquery-connector-for-apache-kafka project contributors
+ *
+ * This software contains code derived from the Confluent BigQuery
+ * Kafka Connector, Copyright Confluent, Inc, which in turn
+ * contains code derived from the WePay BigQuery Kafka Connector,
+ * Copyright WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wepay.kafka.connect.bigquery.utils;
+
+
+import com.wepay.kafka.connect.bigquery.SchemaManager;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
+import de.huxhorn.sulky.ulid.ULID;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SinkRecordConverterTest {
+
+  private static final String kafkaDataTopicValue = "testTopic";
+  private static final int kafkaDataPartitionValue = 101;
+  private static final long kafkaDataOffsetValue = 1337;
+  private static final String kafkaDataMutatedTopicValue = "mutatedTopic";
+  private static final int kafkaDataMutatedPartitionValue = 201;
+  private static final long kafkaDataMutatedOffsetValue = 456;
+  private static final ULID ulid = new ULID();
+
+
+  private static Map<String, Object> defaultExpectedFields() {
+    return new HashMap<>(Map.of(SchemaManager.KAFKA_DATA_TOPIC_FIELD_NAME, kafkaDataTopicValue,
+            SchemaManager.KAFKA_DATA_PARTITION_FIELD_NAME, kafkaDataPartitionValue,
+            SchemaManager.KAFKA_DATA_OFFSET_FIELD_NAME, kafkaDataOffsetValue));
+  }
+
+  private static TestingBigQuerySinkConfig createConfig(Map<String, String> overrides) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("project", "project");
+    properties.put("defaultDataset", "defaultDataset");
+    properties.put("taskId", "1");
+    properties.putAll(overrides);
+    return new TestingBigQuerySinkConfig(properties);
+  }
+
+  @ParameterizedTest(name = "{index} {0}")
+  @MethodSource("testGetRegularRowData")
+  void testGetRegularRow(String name, BigQuerySinkConfig config, String ulid, Map<String, String> expected) {
+    SinkRecord record = new SinkRecord(kafkaDataTopicValue, kafkaDataPartitionValue, null, null, null, Map.of("one", "1", "two", "2"), kafkaDataOffsetValue);
+    SinkRecordConverter underTest = new SinkRecordConverter(config, null, null);
+    Map<String, Object> regularRow = underTest.getRegularRow(record, ulid);
+    assertEquals("1", regularRow.get("one"));
+    assertEquals("2", regularRow.get("two"));
+    if (expected == null) {
+      assertNull(regularRow.get("kafkaDataFieldName"));
+    } else {
+      Map<String, String> actual = (Map<String, String>) regularRow.get("kafkaDataFieldName");
+      assertNotNull(actual.get(SchemaManager.KAFKA_DATA_INSERT_TIME_FIELD_NAME));
+      actual.remove(SchemaManager.KAFKA_DATA_INSERT_TIME_FIELD_NAME);
+      assertEquals(expected, actual);
+    }
+  }
+
+  static List<Arguments> testGetRegularRowData() {
+    String putAttempt = ulid.nextULID();
+    return List.of(
+            Arguments.of("+data+attempt", createConfig(Map.of(BigQuerySinkConfig.TRACK_PUT_ATTEMPTS_CONFIG, "true",
+                    BigQuerySinkConfig.KAFKA_DATA_FIELD_NAME_CONFIG, "kafkaDataFieldName")), putAttempt,
+                    Map.of(SchemaManager.KAFKA_DATA_PARTITION_FIELD_NAME, kafkaDataPartitionValue,
+                            SchemaManager.KAFKA_DATA_OFFSET_FIELD_NAME, kafkaDataOffsetValue,
+                            SchemaManager.KAFKA_DATA_TOPIC_FIELD_NAME, kafkaDataTopicValue,
+                            SchemaManager.KAFKA_DATA_PUT_ATTEMPT_ID_FIELD_NAME, putAttempt)),
+            Arguments.of("+data-null_attempt", createConfig(Map.of(BigQuerySinkConfig.TRACK_PUT_ATTEMPTS_CONFIG, "true",
+                            BigQuerySinkConfig.KAFKA_DATA_FIELD_NAME_CONFIG, "kafkaDataFieldName")), null,
+                    Map.of(SchemaManager.KAFKA_DATA_PARTITION_FIELD_NAME, kafkaDataPartitionValue,
+                            SchemaManager.KAFKA_DATA_OFFSET_FIELD_NAME, kafkaDataOffsetValue,
+                            SchemaManager.KAFKA_DATA_TOPIC_FIELD_NAME, kafkaDataTopicValue)),
+            Arguments.of("+data-attempt", createConfig(Map.of(BigQuerySinkConfig.KAFKA_DATA_FIELD_NAME_CONFIG, "kafkaDataFieldName")), putAttempt,
+                    Map.of(SchemaManager.KAFKA_DATA_PARTITION_FIELD_NAME, kafkaDataPartitionValue,
+                            SchemaManager.KAFKA_DATA_OFFSET_FIELD_NAME, kafkaDataOffsetValue,
+                            SchemaManager.KAFKA_DATA_TOPIC_FIELD_NAME, kafkaDataTopicValue)),
+
+            Arguments.of("-data+attempt", createConfig(Map.of(BigQuerySinkConfig.TRACK_PUT_ATTEMPTS_CONFIG, "true")), putAttempt, null)
+            );
+  }
+
+  @ParameterizedTest(name="{index} {0}")
+  @MethodSource("testBuildKafkaDataRecordData")
+  void testBuildKafkaDataRecord(String testId, BigQuerySinkConfig config, String putAttemptId, Map<String, String> expectedResults) {
+    SinkRecord record = new SinkRecord(kafkaDataTopicValue, kafkaDataPartitionValue, null, null, null, null, kafkaDataOffsetValue);
+    SinkRecordConverter underTest = new SinkRecordConverter(config, null, null);
+    Map<String, Object> actualKafkaDataFields = underTest.buildKafkaDataRecord(record, putAttemptId);
+
+    // time field is calculated when created so verify it exists and remove it before comparing with expectedKafakDataFields
+    assertTrue(actualKafkaDataFields.containsKey(SchemaManager.KAFKA_DATA_INSERT_TIME_FIELD_NAME));
+    assertInstanceOf(Double.class, actualKafkaDataFields.get(SchemaManager.KAFKA_DATA_INSERT_TIME_FIELD_NAME));
+    actualKafkaDataFields.remove(SchemaManager.KAFKA_DATA_INSERT_TIME_FIELD_NAME);
+
+    assertEquals(expectedResults, actualKafkaDataFields);
+  }
+
+  static List<Arguments> testBuildKafkaDataRecordData() {
+    String putAttemptId = ulid.nextULID();
+    Map<String, Object> expectedKafkaDataFields = defaultExpectedFields();
+    expectedKafkaDataFields.put(SchemaManager.KAFKA_DATA_PUT_ATTEMPT_ID_FIELD_NAME, putAttemptId);
+
+    return List.of(
+            Arguments.of("true-id", createConfig(Map.of(BigQuerySinkConfig.TRACK_PUT_ATTEMPTS_CONFIG, "true",
+                    BigQuerySinkConfig.KAFKA_DATA_FIELD_NAME_CONFIG, "kafkaDataFieldName")), putAttemptId, expectedKafkaDataFields),
+            Arguments.of("true-null", createConfig(Map.of(BigQuerySinkConfig.TRACK_PUT_ATTEMPTS_CONFIG, "true",
+                    BigQuerySinkConfig.KAFKA_DATA_FIELD_NAME_CONFIG, "kafkaDataFieldName")), null, defaultExpectedFields()),
+            Arguments.of("false-id", createConfig(Map.of(BigQuerySinkConfig.TRACK_PUT_ATTEMPTS_CONFIG, "false",
+                    BigQuerySinkConfig.KAFKA_DATA_FIELD_NAME_CONFIG, "kafkaDataFieldName")), putAttemptId, defaultExpectedFields()),
+            Arguments.of("false-null", createConfig(Map.of(BigQuerySinkConfig.TRACK_PUT_ATTEMPTS_CONFIG, "false",
+                    BigQuerySinkConfig.KAFKA_DATA_FIELD_NAME_CONFIG, "kafkaDataFieldName")), putAttemptId, defaultExpectedFields())
+    );
+  }
+
+  @ParameterizedTest(name = "{index} {0}")
+  @MethodSource("mutatedDataTestData")
+  void mutatedDataTest(String name, BigQuerySinkConfig config,  Map<String,Object> expectedData) {
+    SinkRecord record = new  SinkRecord(kafkaDataMutatedTopicValue, kafkaDataMutatedPartitionValue, null, null, null, null,
+    kafkaDataMutatedOffsetValue, System.currentTimeMillis(), TimestampType.CREATE_TIME, Collections.emptyList(), kafkaDataTopicValue,
+    kafkaDataPartitionValue, kafkaDataOffsetValue);
+
+
+    SinkRecordConverter underTest = new SinkRecordConverter(config, null,  null);
+    Map<String, Object> actualKafkaDataFields = underTest.buildKafkaDataRecord(record, ulid.nextULID());
+    actualKafkaDataFields.remove(SchemaManager.KAFKA_DATA_INSERT_TIME_FIELD_NAME);
+    assertEquals(expectedData, actualKafkaDataFields);
+  }
+
+  static List<Arguments> mutatedDataTestData() {
+    List<Arguments> result = new ArrayList<>();
+    TestingBigQuerySinkConfig config = createConfig(Map.of(BigQuerySinkConfig.PRESERVE_KAFKA_TOPIC_PARTITION_OFFSET__CONFIG, "true"));
+    config.setPost3_6Flag(false);
+    result.add(Arguments.of("preserve-<3.6", config, Map.of(SchemaManager.KAFKA_DATA_TOPIC_FIELD_NAME, kafkaDataTopicValue,
+            SchemaManager.KAFKA_DATA_OFFSET_FIELD_NAME, kafkaDataOffsetValue,
+            SchemaManager.KAFKA_DATA_PARTITION_FIELD_NAME, kafkaDataPartitionValue)));
+
+    config = createConfig(Map.of(BigQuerySinkConfig.PRESERVE_KAFKA_TOPIC_PARTITION_OFFSET__CONFIG, "true"));
+    config.setPost3_6Flag(true);
+    result.add(Arguments.of("preserve-3.6+", config, Map.of(SchemaManager.KAFKA_DATA_TOPIC_FIELD_NAME, kafkaDataTopicValue,
+            SchemaManager.KAFKA_DATA_OFFSET_FIELD_NAME, kafkaDataOffsetValue,
+            SchemaManager.KAFKA_DATA_PARTITION_FIELD_NAME, kafkaDataPartitionValue)));
+
+    config = createConfig(Map.of(BigQuerySinkConfig.PRESERVE_KAFKA_TOPIC_PARTITION_OFFSET__CONFIG, "false"));
+    config.setPost3_6Flag(false);
+    result.add(Arguments.of("not preserve-<3.6", config, Map.of(SchemaManager.KAFKA_DATA_TOPIC_FIELD_NAME, kafkaDataMutatedTopicValue,
+            SchemaManager.KAFKA_DATA_OFFSET_FIELD_NAME, kafkaDataMutatedOffsetValue,
+            SchemaManager.KAFKA_DATA_PARTITION_FIELD_NAME, kafkaDataMutatedPartitionValue)));
+
+    config = createConfig(Map.of(BigQuerySinkConfig.PRESERVE_KAFKA_TOPIC_PARTITION_OFFSET__CONFIG, "false"));
+    config.setPost3_6Flag(true);
+    result.add(Arguments.of("not preserve-3.6+", config, Map.of(SchemaManager.KAFKA_DATA_TOPIC_FIELD_NAME, kafkaDataMutatedTopicValue,
+            SchemaManager.KAFKA_DATA_OFFSET_FIELD_NAME, kafkaDataMutatedOffsetValue,
+            SchemaManager.KAFKA_DATA_PARTITION_FIELD_NAME, kafkaDataMutatedPartitionValue)));
+
+    return result;
+  }
+
+  // ---- trackPutAttempts tests ----
+
+  @Test
+  public void testBuildKafkaDataRecord_flagEnabled_includesPutAttemptId() {
+    SinkRecord record = new SinkRecord(kafkaDataTopicValue, kafkaDataPartitionValue, null, null, null, null, kafkaDataOffsetValue);
+    TestingBigQuerySinkConfig config = createConfig(Map.of(BigQuerySinkConfig.TRACK_PUT_ATTEMPTS_CONFIG, "true",
+            BigQuerySinkConfig.KAFKA_DATA_FIELD_NAME_CONFIG, "kafkaDataFieldName"));
+    SinkRecordConverter underTest = new SinkRecordConverter(config, null,  null);
+
+    Map<String, Object> result = underTest.buildKafkaDataRecord(record, "attempt-abc");
+
+    assertTrue(result.containsKey(SchemaManager.KAFKA_DATA_PUT_ATTEMPT_ID_FIELD_NAME));
+    assertEquals("attempt-abc", result.get(SchemaManager.KAFKA_DATA_PUT_ATTEMPT_ID_FIELD_NAME));
+    assertInstanceOf(Double.class, result.get(SchemaManager.KAFKA_DATA_INSERT_TIME_FIELD_NAME));
+  }
+
+  @Test
+  public void testBuildKafkaDataRecord_flagDisabled_excludesPutAttemptId() {
+    SinkRecord record = new SinkRecord(kafkaDataTopicValue, kafkaDataPartitionValue, null, null, null, null, kafkaDataOffsetValue);
+    TestingBigQuerySinkConfig config = createConfig(Map.of(BigQuerySinkConfig.TRACK_PUT_ATTEMPTS_CONFIG, "false",
+            BigQuerySinkConfig.KAFKA_DATA_FIELD_NAME_CONFIG, "kafkaDataFieldName"));
+    SinkRecordConverter underTest = new SinkRecordConverter(config, null,  null);
+
+    Map<String, Object> result = underTest.buildKafkaDataRecord(record, "attempt-abc");
+
+    assertFalse(result.containsKey(SchemaManager.KAFKA_DATA_PUT_ATTEMPT_ID_FIELD_NAME));
+  }
+
+  @Test
+  public void testBuildKafkaDataRecord_flagEnabled_nullAttemptId_excludesPutAttemptId() {
+    SinkRecord record = new SinkRecord(kafkaDataTopicValue, kafkaDataPartitionValue, null, null, null, null, kafkaDataOffsetValue);
+    TestingBigQuerySinkConfig config = createConfig(Map.of(BigQuerySinkConfig.TRACK_PUT_ATTEMPTS_CONFIG, "true"));
+    SinkRecordConverter underTest = new SinkRecordConverter(config, null,  null);
+
+    Map<String, Object> result = underTest.buildKafkaDataRecord(record, null);
+
+    assertFalse(result.containsKey(SchemaManager.KAFKA_DATA_PUT_ATTEMPT_ID_FIELD_NAME));
+  }
+
+  @Test
+  public void testBuildKafkaDataRecord_twoAttemptsProduceDifferentIds() {
+    SinkRecord record = new SinkRecord(kafkaDataTopicValue, kafkaDataPartitionValue, null, null, null, null, kafkaDataOffsetValue);
+    TestingBigQuerySinkConfig config = createConfig(Map.of(BigQuerySinkConfig.TRACK_PUT_ATTEMPTS_CONFIG, "true",
+            BigQuerySinkConfig.KAFKA_DATA_FIELD_NAME_CONFIG, "kafkaDataFieldName"));
+    SinkRecordConverter underTest = new SinkRecordConverter(config, null,  null);
+
+    Map<String, Object> row1 = underTest.buildKafkaDataRecord(record, "attempt-1");
+    Map<String, Object> row2 = underTest.buildKafkaDataRecord(record, "attempt-2");
+
+    assertNotEquals(
+        row1.get(SchemaManager.KAFKA_DATA_PUT_ATTEMPT_ID_FIELD_NAME),
+        row2.get(SchemaManager.KAFKA_DATA_PUT_ATTEMPT_ID_FIELD_NAME)
+    );
+  }
+
+
+  @Test
+  public void testBuildKafkaDataRecord_noArgOverload_backwardCompatible() {
+    SinkRecord record = new SinkRecord(kafkaDataTopicValue, kafkaDataPartitionValue, null, null, null, null, kafkaDataOffsetValue);
+    TestingBigQuerySinkConfig config = createConfig(Map.of(BigQuerySinkConfig.TRACK_PUT_ATTEMPTS_CONFIG, "false",
+            BigQuerySinkConfig.KAFKA_DATA_FIELD_NAME_CONFIG, "kafkaDataFieldName"));
+    SinkRecordConverter underTest = new SinkRecordConverter(config, null,  null);
+
+    Map<String, Object> result = underTest.buildKafkaDataRecord(record, ulid.nextULID());
+
+    assertFalse(result.containsKey(SchemaManager.KAFKA_DATA_PUT_ATTEMPT_ID_FIELD_NAME));
+    assertTrue(result.containsKey(SchemaManager.KAFKA_DATA_TOPIC_FIELD_NAME));
+    assertTrue(result.containsKey(SchemaManager.KAFKA_DATA_PARTITION_FIELD_NAME));
+    assertTrue(result.containsKey(SchemaManager.KAFKA_DATA_OFFSET_FIELD_NAME));
+    assertTrue(result.containsKey(SchemaManager.KAFKA_DATA_INSERT_TIME_FIELD_NAME));
+  }
+
+}

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/TestingBigQuerySinkConfig.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/TestingBigQuerySinkConfig.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Aiven Oy and
+ * bigquery-connector-for-apache-kafka project contributors
+ *
+ * This software contains code derived from the Confluent BigQuery
+ * Kafka Connector, Copyright Confluent, Inc, which in turn
+ * contains code derived from the WePay BigQuery Kafka Connector,
+ * Copyright WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.wepay.kafka.connect.bigquery.utils;
+
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
+
+import java.util.Map;
+
+public class TestingBigQuerySinkConfig extends BigQuerySinkConfig {
+
+    public TestingBigQuerySinkConfig(Map<String, String> properties) {
+        super(properties);
+    }
+
+    @Override
+    public void setPost3_6Flag(boolean state) {
+        super.setPost3_6Flag(state);
+    }
+}

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBaseTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBaseTest.java
@@ -1,0 +1,356 @@
+/*
+ * Copyright 2026 Aiven Oy and
+ * bigquery-connector-for-apache-kafka project contributors
+ *
+ * This software contains code derived from the Confluent BigQuery
+ * Kafka Connector, Copyright Confluent, Inc, which in turn
+ * contains code derived from the WePay BigQuery Kafka Connector,
+ * Copyright WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.wepay.kafka.connect.bigquery.write.storage;
+
+import com.google.api.core.ApiFuture;
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.storage.v1.AppendRowsResponse;
+import com.google.cloud.bigquery.storage.v1.BigQueryWriteClient;
+import com.google.cloud.bigquery.storage.v1.BigQueryWriteSettings;
+import com.google.cloud.bigquery.storage.v1.Exceptions;
+import com.google.rpc.Code;
+import com.wepay.kafka.connect.bigquery.ErrantRecordHandler;
+import com.wepay.kafka.connect.bigquery.SchemaManager;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
+import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
+import com.wepay.kafka.connect.bigquery.utils.SinkRecordConverter;
+import de.huxhorn.sulky.ulid.ULID;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class StorageWriteApiBaseTest {
+
+    private static final ULID ULID_GENERATOR = new ULID();
+
+    private List<ConvertedRecord> mmkConvertedRecords(int count) {
+        List<ConvertedRecord> convertedRecords = new ArrayList<>();
+
+        Schema valueSchema = SchemaBuilder.struct()
+                .field("value", Schema.STRING_SCHEMA);
+
+
+        for (int i = 0; i < count; i++) {
+            Struct value = new Struct(valueSchema);
+            value.put("value", "value" + i);
+            SinkRecord sinkRecord = new SinkRecord("topic", 1, Schema.STRING_SCHEMA, "key " + i,
+                    valueSchema,value, (long)i);
+
+            convertedRecords.add(new ConvertedRecord(sinkRecord, mock(JSONObject.class)));
+        }
+        return convertedRecords;
+    }
+
+    private Map<String, String> defaultMap = Map.of("project", "project", "defaultDataset", "defaultDataset",
+            "kafkaDataFieldName", "kafkaDataFieldName", "taskId", "1");
+
+    private void executeInitializeAndWriteRecordsTestData(TestingStreamWriter streamWriter, BigQuerySinkTaskConfig config, SchemaManager schemaManager) {
+        SinkRecordConverter recordConverter = new SinkRecordConverter(config, null, null);
+
+        BigQueryWriteClient bigQueryWriteClient = mock(BigQueryWriteClient.class);
+        int retry = 5;
+        long retryWait = 5000;
+        BigQueryWriteSettings writeSettings = mock(BigQueryWriteSettings.class);
+        boolean autoCreateTables = true;
+        ErrantRecordHandler errantRecordHandler = null;
+        boolean allowNewBigQueryFields = config.getBoolean(BigQuerySinkConfig.ALLOW_NEW_BIGQUERY_FIELDS_CONFIG);
+        boolean allowRequiredFieldRelaxation = config.getBoolean(BigQuerySinkConfig.ALLOW_BIGQUERY_REQUIRED_FIELD_RELAXATION_CONFIG);
+        boolean attemptSchemaUpdate = allowNewBigQueryFields || allowRequiredFieldRelaxation;
+
+        // create an instance
+        StorageWriteApiBase underTest = new StorageWriteApiBase(retry, retryWait, writeSettings, autoCreateTables, errantRecordHandler,
+                schemaManager, attemptSchemaUpdate, config) {
+
+            @Override
+            public void preShutdown() {
+
+            }
+
+            @Override
+            protected StreamWriter streamWriter(PartitionedTableId table, String streamName, List<ConvertedRecord> records) {
+                return streamWriter;
+            }
+
+            @Override
+            protected BigQueryWriteClient getWriteClient() {
+                return bigQueryWriteClient;
+            }
+        };
+        PartitionedTableId partitionTableId = new PartitionedTableId.Builder("dataset", "baseTable").setPartition("partition")
+                .setProject("project").build();
+        List<ConvertedRecord> rows = mmkConvertedRecords(5);
+        String streamName = "initializeAndWriteRecordsTest";
+        Supplier<String> ulidSupplier = ULID_GENERATOR::nextULID;
+
+        underTest.initializeAndWriteRecords(partitionTableId, rows, streamName, recordConverter, ulidSupplier);
+    }
+
+    @Test
+    void appendRowsTooLargeTestWithStorageWriteAPI() {
+        RowsTooLargeStreamWriter streamWriter = new RowsTooLargeStreamWriter("appendRowsTooLargeTestWithStorageWriteAPI");
+        BigQuerySinkTaskConfig config = storageWriteApiConfig();
+        executeInitializeAndWriteRecordsTestData(streamWriter, config, null);
+
+        // verify the results
+        List<JSONArray> result = streamWriter.appendCalls;
+        Set<String> ulid = new LinkedHashSet<>();
+        // 1 failure, 2 groups of 2, 1 gorup of 1 = 4 attempts
+        assertEquals(4, result.size());
+        Set<String> ulids = new HashSet<>();
+        // we should have 2 ulids.  The one from the first set that failed
+        // and the one from the 2nd set (3 entries) that succeeded.
+        for (int i = 0; i < result.size(); i++) {
+            ulids.add(assertSameUlid(result.get(i)));
+        }
+        assertEquals(4, ulids.size(), ulids::toString);
+    }
+
+    @Test
+    void appendRowsTooLargeTestWithStorageWriteGCS() {
+        RowsTooLargeStreamWriter streamWriter = new RowsTooLargeStreamWriter("appendRowsTooLargeTestWithStorageWriteGCS");
+        BigQuerySinkTaskConfig config = storageWriteGCSConfig();
+        executeInitializeAndWriteRecordsTestData(streamWriter, config, null);
+
+        // verify the results
+        List<JSONArray> result = streamWriter.appendCalls;
+        Set<String> ulid = new LinkedHashSet<>();
+        // 1 failure, 2 groups of 2, 1 gorup of 1 = 4 attempts
+        assertEquals(4, result.size());
+        Set<String> ulids = new HashSet<>();
+        // we should have 2 ulids.  The one from the first set that failed
+        // and the one from the 2nd set (3 entries) that succeeded.
+        for (int i = 0; i < result.size(); i++) {
+            ulids.add(assertSameUlid(result.get(i)));
+        }
+        assertEquals(4, ulids.size(), ulids::toString);
+    }
+
+    @Test
+    void updateSchemaTestWithStorageWriteAPI() {
+
+        BigQuerySinkTaskConfig config = storageWriteApiConfig();
+
+        UpdatedSchemaStreamWriter streamWriter = new UpdatedSchemaStreamWriter("updateSchemaTestWithStorageWriteAPI");
+
+        SchemaManager schemaManager = mock(SchemaManager.class);
+        executeInitializeAndWriteRecordsTestData(streamWriter, config,  schemaManager);
+
+        verify(schemaManager, times(1)).updateSchema(any(TableId.class), any(List.class));
+
+        // verify the results
+;        List<JSONArray> result = streamWriter.appendCalls;
+        Set<String> ulid = new LinkedHashSet<>();
+        // 1 failure (schema change), 1 success = 2 attempts
+        assertEquals(2, result.size());
+        // we should have 2 ulids.  The one from the first set that failed
+        // and the one from the 2nd set (3 entries) that succeeded.
+        String ulid1 = assertSameUlid(result.get(0));
+        String ulid2 = assertSameUlid(result.get(1));
+        assertNotEquals(ulid2, ulid1);
+    }
+
+    @Test
+    void updateSchemaTestWithStorageWriteGCS() {
+
+        BigQuerySinkTaskConfig config = storageWriteGCSConfig();
+
+        UpdatedSchemaStreamWriter streamWriter = new UpdatedSchemaStreamWriter("updateSchemaTestWithStorageWriteGCS");
+
+        SchemaManager schemaManager = mock(SchemaManager.class);
+        executeInitializeAndWriteRecordsTestData(streamWriter, config,  schemaManager);
+
+        verify(schemaManager, times(1)).updateSchema(any(TableId.class), any(List.class));
+
+        // verify the results
+        ;        List<JSONArray> result = streamWriter.appendCalls;
+        Set<String> ulid = new LinkedHashSet<>();
+        // 1 failure (schema change), 1 success = 2 attempts
+        assertEquals(2, result.size());
+        // we should have 2 ulids.  The one from the first set that failed
+        // and the one from the 2nd set (3 entries) that succeeded.
+        String ulid1 = assertSameUlid(result.get(0));
+        String ulid2 = assertSameUlid(result.get(1));
+        assertNotEquals(ulid2, ulid1);
+    }
+
+    private String assertSameUlid(JSONArray ary) {
+        Set<String> ulids = new HashSet<>();
+        for (int i=0; i<ary.length(); i++) {
+            ulids.add(ary.getJSONObject(i).getJSONObject("kafkaDataFieldName").getString("putAttemptId"));
+        }
+        assertEquals(1, ulids.size(), "more than one ULID in JSONArray");
+        return ulids.iterator().next();
+    }
+
+    BigQuerySinkTaskConfig storageWriteApiConfig() {
+        Map<String, String> params = new HashMap<>(defaultMap);
+        params.put("useStorageWriteApi", "true");
+        params.put("trackPutAttempts", "true");
+        params.put("allowNewBigQueryFields", "true");
+        return new BigQuerySinkTaskConfig(params);
+    }
+
+    BigQuerySinkTaskConfig storageWriteGCSConfig() {
+        Map<String, String> params = new HashMap<>(defaultMap);
+        params.put("useStorageWriteApi", "false");
+        params.put("trackPutAttempts", "true");
+        params.put("allowNewBigQueryFields", "true");
+        return new BigQuerySinkTaskConfig(params);
+    }
+
+    /**
+     * A StreamWriter implementation that simply captures the rows sent in the appendRows() method and creates
+     * a future to simulate Storage activity.
+     */
+    private abstract static class TestingStreamWriter implements StreamWriter {
+        final String name;
+        final List<JSONArray> appendCalls = new ArrayList<>();
+        int successCount;
+        int refreshCount;
+
+        TestingStreamWriter(String name) {
+            this.name = name;
+        }
+
+        abstract ApiFuture<AppendRowsResponse> createFuture();
+
+        @Override
+        final public String streamName() {
+            return name;
+        }
+        @Override
+        public String toString() {
+            return name;
+        }
+        @Override
+        public ApiFuture<AppendRowsResponse> appendRows(JSONArray rows)  {
+            appendCalls.add(rows);
+            return createFuture();
+        }
+
+        @Override
+        public void refresh() {
+            refreshCount++;
+        }
+
+        @Override
+        public void onSuccess() {
+            successCount++;
+        }
+
+    };
+
+    static class RowsTooLargeStreamWriter extends TestingStreamWriter {
+
+        RowsTooLargeStreamWriter(String name) {
+            super(name);
+        }
+
+        // createFuture implementation that fails the first write with a "request too large" error
+        // and then accepts the rest.
+        @Override
+        ApiFuture<AppendRowsResponse> createFuture() {
+
+            ApiFuture<AppendRowsResponse> future = mock(ApiFuture.class);
+            try {
+                if (appendCalls.size() == 1) {
+                    Exceptions.AppendSerializtionError err = new Exceptions.AppendSerializtionError(
+                            Code.INVALID_ARGUMENT.getNumber(),
+                            "AppendRows request too large",
+                            "appendRowsTooLargeTest",
+                            Collections.emptyMap());
+
+                    when(future.get()).thenThrow(err);
+                } else {
+                    AppendRowsResponse response = mock(AppendRowsResponse.class);
+                    when(future.get()).thenReturn(response);
+                    when(response.hasUpdatedSchema()).thenReturn(false);
+                    when(response.hasError()).thenReturn(false);
+                    when(response.hasAppendResult()).thenReturn(true);
+                }
+            } catch (ExecutionException | InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            return future;
+        }
+    }
+
+    static class UpdatedSchemaStreamWriter extends TestingStreamWriter {
+
+        UpdatedSchemaStreamWriter(String name) {
+            super(name);
+        }
+
+        // createFuture implementation that fails the first write with a "request too large" error
+        // and then accepts the rest.
+        @Override
+        ApiFuture<AppendRowsResponse> createFuture() {
+
+            ApiFuture<AppendRowsResponse> future = mock(ApiFuture.class);
+            try {
+                if (appendCalls.size() == 1) {
+                    AppendRowsResponse response = mock(AppendRowsResponse.class);
+                    when(future.get()).thenReturn(response);
+                    when(response.hasUpdatedSchema()).thenReturn(true);
+                    when(response.hasError()).thenReturn(false);
+                    when(response.hasAppendResult()).thenReturn(true); // does this matter?
+                } else {
+                    AppendRowsResponse response = mock(AppendRowsResponse.class);
+                    when(future.get()).thenReturn(response);
+                    when(response.hasUpdatedSchema()).thenReturn(false);
+                    when(response.hasError()).thenReturn(false);
+                    when(response.hasAppendResult()).thenReturn(true);
+                }
+            } catch (ExecutionException | InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            return future;
+        }
+    }
+}

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiWriterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiWriterTest.java
@@ -25,6 +25,7 @@ package com.wepay.kafka.connect.bigquery.write.storage;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -50,8 +51,10 @@ import com.wepay.kafka.connect.bigquery.utils.MockTime;
 import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
 import com.wepay.kafka.connect.bigquery.utils.SinkRecordConverter;
 import com.wepay.kafka.connect.bigquery.utils.TableNameUtils;
+import com.wepay.kafka.connect.bigquery.utils.TestingBigQuerySinkConfig;
 import com.wepay.kafka.connect.bigquery.write.batch.TableWriterBuilder;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -79,18 +82,28 @@ public class StorageWriteApiWriterTest {
           .field("bytes_check", Schema.BYTES_SCHEMA)
           .build();
 
+  private static BigQuerySinkTaskConfig createConfig(Map<String, String> overrides) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("project", "project");
+    properties.put("defaultDataset", "defaultDataset");
+    properties.put("taskId", "1");
+    properties.putAll(overrides);
+    return new BigQuerySinkTaskConfig(properties);
+  }
+
   @Test
   public void testRecordConversion() {
     StorageWriteApiBase mockStreamWriter = Mockito.mock(StorageWriteApiBase.class);
-    BigQuerySinkTaskConfig mockedConfig = Mockito.mock(BigQuerySinkTaskConfig.class);
-    when(mockedConfig.getBoolean(BigQuerySinkConfig.USE_STORAGE_WRITE_API_CONFIG)).thenReturn(true);
-    RecordConverter<Map<String, Object>> recordConverter = new BigQueryRecordConverter(
-        false,
-        true
-    );
-    when(mockedConfig.getRecordConverter()).thenReturn(recordConverter);
+    BigQuerySinkTaskConfig config = createConfig(Map.of(
+      BigQuerySinkConfig.KAFKA_DATA_FIELD_NAME_CONFIG, "i_am_kafka_record_detail",
+      BigQuerySinkConfig.KAFKA_KEY_FIELD_NAME_CONFIG, "i_am_kafka_key",
+      BigQuerySinkConfig.SANITIZE_FIELD_NAME_CONFIG, "true",
+      BigQuerySinkConfig.USE_STORAGE_WRITE_API_CONFIG, "true",
+            BigQuerySinkConfig.CONVERT_DOUBLE_SPECIAL_VALUES_CONFIG, "false"));
+
+
     StorageApiBatchModeHandler batchModeHandler = mock(StorageApiBatchModeHandler.class);
-    SinkRecordConverter sinkRecordConverter = new SinkRecordConverter(mockedConfig, null, null);
+    SinkRecordConverter sinkRecordConverter = new SinkRecordConverter(config, null, null);
     PartitionedTableId table = new PartitionedTableId.Builder(
             TableId.of("test-project", "scratch", "dummy_table")
     ).build();
@@ -107,15 +120,12 @@ public class StorageWriteApiWriterTest {
     expectedKeys.add("i_am_kafka_record_detail");
     expectedKeys.add("bytes_check");
 
-    Mockito.when(mockedConfig.getKafkaDataFieldName()).thenReturn(Optional.of("i_am_kafka_record_detail"));
-    Mockito.when(mockedConfig.getKafkaKeyFieldName()).thenReturn(Optional.of("i_am_kafka_key"));
-    Mockito.when(mockedConfig.getBoolean(BigQuerySinkConfig.SANITIZE_FIELD_NAME_CONFIG)).thenReturn(true);
 
     builder.addRow(createRecord("abc", 100), null);
     builder.build().run();
 
     verify(mockStreamWriter, times(1))
-        .initializeAndWriteRecords(any(PartitionedTableId.class), records.capture(), any());
+        .initializeAndWriteRecords(any(PartitionedTableId.class), records.capture(), anyString());
     assertEquals(1, records.getValue().size());
 
     JSONObject actual = records.getValue().get(0).converted();
@@ -179,10 +189,9 @@ public class StorageWriteApiWriterTest {
 
   @Test
   public void testWriteAttemptIdRefreshedOnStorageApiInternalRetry() throws Exception {
-    KafkaDataBuilder.setTrackPutAttempts(true);
-    try {
-      BigQuerySinkTaskConfig mockedConfig = buildTrackedConfig();
-      SinkRecordConverter sinkRecordConverter = new SinkRecordConverter(mockedConfig, null, null);
+
+      BigQuerySinkTaskConfig config = buildTrackedConfig(true);
+      SinkRecordConverter sinkRecordConverter = new SinkRecordConverter(config, null, null);
 
       StorageWriteApiDefaultStream stream = mock(StorageWriteApiDefaultStream.class, CALLS_REAL_METHODS);
       JsonStreamWriter jsonWriter = mock(JsonStreamWriter.class);
@@ -227,17 +236,12 @@ public class StorageWriteApiWriterTest {
       assertNotNull(idRetry, "Retry attempt should have a putAttemptId");
       assertNotEquals(idFirst, idRetry,
           "Internal retry must produce a different putAttemptId than the first attempt");
-    } finally {
-      KafkaDataBuilder.setTrackPutAttempts(false);
-    }
   }
 
   @Test
   public void testWriteAttemptIdNotSetWhenTrackingDisabledStorageApi() throws Exception {
-    KafkaDataBuilder.setTrackPutAttempts(false);
-
-    BigQuerySinkTaskConfig mockedConfig = buildTrackedConfig();
-    SinkRecordConverter sinkRecordConverter = new SinkRecordConverter(mockedConfig, null, null);
+    BigQuerySinkTaskConfig config = buildTrackedConfig(false);
+    SinkRecordConverter sinkRecordConverter = new SinkRecordConverter(config, null, null);
 
     StorageWriteApiDefaultStream stream = mock(StorageWriteApiDefaultStream.class, CALLS_REAL_METHODS);
     JsonStreamWriter jsonWriter = mock(JsonStreamWriter.class);
@@ -281,57 +285,50 @@ public class StorageWriteApiWriterTest {
 
   @Test
   public void testWriteAttemptIdPresentOnFirstAttemptStorageApi() throws Exception {
-    KafkaDataBuilder.setTrackPutAttempts(true);
-    try {
-      BigQuerySinkTaskConfig mockedConfig = buildTrackedConfig();
-      SinkRecordConverter sinkRecordConverter = new SinkRecordConverter(mockedConfig, null, null);
+    BigQuerySinkTaskConfig config = buildTrackedConfig(true);
+    SinkRecordConverter sinkRecordConverter = new SinkRecordConverter(config, null, null);
 
-      StorageWriteApiDefaultStream stream = mock(StorageWriteApiDefaultStream.class, CALLS_REAL_METHODS);
-      JsonStreamWriter jsonWriter = mock(JsonStreamWriter.class);
-      stream.tableToStream = new ConcurrentHashMap<>();
-      stream.schemaManager = mock(SchemaManager.class);
-      stream.errantRecordHandler = mock(ErrantRecordHandler.class);
-      stream.time = new MockTime();
-      doReturn(jsonWriter).when(stream).getDefaultStream(any(), any());
+    StorageWriteApiDefaultStream stream = mock(StorageWriteApiDefaultStream.class, CALLS_REAL_METHODS);
+    JsonStreamWriter jsonWriter = mock(JsonStreamWriter.class);
+    stream.tableToStream = new ConcurrentHashMap<>();
+    stream.schemaManager = mock(SchemaManager.class);
+    stream.errantRecordHandler = mock(ErrantRecordHandler.class);
+    stream.time = new MockTime();
+    doReturn(jsonWriter).when(stream).getDefaultStream(any(), any());
 
-      AppendRowsResponse successResponse = AppendRowsResponse.newBuilder()
-          .setAppendResult(AppendRowsResponse.AppendResult.newBuilder().getDefaultInstanceForType())
-          .build();
-      ApiFuture<AppendRowsResponse> future = mock(ApiFuture.class);
-      when(future.get()).thenReturn(successResponse);
-      when(jsonWriter.append(any(JSONArray.class))).thenReturn(future);
+    AppendRowsResponse successResponse = AppendRowsResponse.newBuilder()
+            .setAppendResult(AppendRowsResponse.AppendResult.newBuilder().getDefaultInstanceForType())
+            .build();
+    ApiFuture<AppendRowsResponse> future = mock(ApiFuture.class);
+    when(future.get()).thenReturn(successResponse);
+    when(jsonWriter.append(any(JSONArray.class))).thenReturn(future);
 
-      AtomicInteger counter = new AtomicInteger(0);
-      Supplier<String> ulidSupplier = () -> "ULID-" + counter.incrementAndGet();
+    AtomicInteger counter = new AtomicInteger(0);
+    Supplier<String> ulidSupplier = () -> "ULID-" + counter.incrementAndGet();
 
-      PartitionedTableId table = new PartitionedTableId.Builder(
-          TableId.of("test-project", "scratch", "dummy_table")).build();
-      StorageApiBatchModeHandler batchModeHandler = mock(StorageApiBatchModeHandler.class);
-      StorageWriteApiWriter.Builder builder = new StorageWriteApiWriter.Builder(
-          stream, table, sinkRecordConverter, batchModeHandler);
-      builder.withUlidSupplier(ulidSupplier);
-      builder.addRow(createRecord("abc", 100), null);
-      builder.build().run();
+    PartitionedTableId table = new PartitionedTableId.Builder(
+            TableId.of("test-project", "scratch", "dummy_table")).build();
+    StorageApiBatchModeHandler batchModeHandler = mock(StorageApiBatchModeHandler.class);
+    StorageWriteApiWriter.Builder builder = new StorageWriteApiWriter.Builder(
+            stream, table, sinkRecordConverter, batchModeHandler);
+    builder.withUlidSupplier(ulidSupplier);
+    builder.addRow(createRecord("abc", 100), null);
+    builder.build().run();
 
-      ArgumentCaptor<JSONArray> captor = ArgumentCaptor.forClass(JSONArray.class);
-      verify(jsonWriter, times(1)).append(captor.capture());
+    ArgumentCaptor<JSONArray> captor = ArgumentCaptor.forClass(JSONArray.class);
+    verify(jsonWriter, times(1)).append(captor.capture());
 
-      String writeAttemptId = extractPutAttemptId(captor.getValue());
-      assertNotNull(writeAttemptId, "First (and only) write attempt should carry a write-attempt ID");
-    } finally {
-      KafkaDataBuilder.setTrackPutAttempts(false);
-    }
+    String writeAttemptId = extractPutAttemptId(captor.getValue());
+    assertNotNull(writeAttemptId, "First (and only) write attempt should carry a write-attempt ID");
   }
 
-  private BigQuerySinkTaskConfig buildTrackedConfig() {
-    BigQuerySinkTaskConfig mockedConfig = Mockito.mock(BigQuerySinkTaskConfig.class);
-    when(mockedConfig.getBoolean(BigQuerySinkConfig.USE_STORAGE_WRITE_API_CONFIG)).thenReturn(true);
-    when(mockedConfig.getKafkaDataFieldName()).thenReturn(Optional.of("_kafka_data"));
-    when(mockedConfig.getKafkaKeyFieldName()).thenReturn(Optional.empty());
-    when(mockedConfig.getBoolean(BigQuerySinkConfig.SANITIZE_FIELD_NAME_CONFIG)).thenReturn(false);
-    RecordConverter<Map<String, Object>> rc = new BigQueryRecordConverter(false, false);
-    when(mockedConfig.getRecordConverter()).thenReturn(rc);
-    return mockedConfig;
+  private BigQuerySinkTaskConfig buildTrackedConfig(boolean useWriteApi) {
+    return createConfig(Map.of(
+            BigQuerySinkConfig.KAFKA_DATA_FIELD_NAME_CONFIG, "_kafka_data",
+            BigQuerySinkConfig.SANITIZE_FIELD_NAME_CONFIG, "false",
+            BigQuerySinkConfig.USE_STORAGE_WRITE_API_CONFIG, "true",
+            BigQuerySinkConfig.CONVERT_DOUBLE_SPECIAL_VALUES_CONFIG, Boolean.toString(useWriteApi),
+            BigQuerySinkConfig.TRACK_PUT_ATTEMPTS_CONFIG, "true"));
   }
 
   private String extractPutAttemptId(JSONArray records) {


### PR DESCRIPTION
Fixes #217 

Variables and functions distributed to
-   `BigQuerySinkConfig`
-  `SinkRecordConverter`
-   `SchemaManager`

`SchemaManager` constructor simplified to accept `BigQuerySinkConfig` and `BigQuery` instances.
 Test cases updated.
Documentation updated.