### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/prs_and_commits.yml
+++ b/.github/workflows/prs_and_commits.yml
@@ -30,6 +30,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 # Disallow concurrent runs for the same PR by cancelling in-progress runs
 # when new commits are pushed
 concurrency:


### PR DESCRIPTION
Potential fix for [https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/security/code-scanning/1](https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/security/code-scanning/1)

Add an explicit workflow-level `permissions` block with least privilege, so all jobs inherit it unless overridden.  
For this workflow, `contents: read` is the correct minimal setting and preserves current functionality (checkout and build/test steps). No new imports, methods, or dependencies are needed.

**Where to change:** `.github/workflows/prs_and_commits.yml`  
**What to change:** Insert:

```yml
permissions:
  contents: read
```

directly after the triggers (`on:` block) and before `concurrency:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
