### PR TITLE
Potential fix for code scanning alert no. 2: Use of a cryptographic algorithm with insufficient key size

### DIFF
--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/GcpClientBuilderProjectTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/GcpClientBuilderProjectTest.java
@@ -41,7 +41,7 @@ public class GcpClientBuilderProjectTest {
 
   private static GoogleCredentials creds(String projectId, String quotaProject) throws NoSuchAlgorithmException {
     KeyPairGenerator gen = KeyPairGenerator.getInstance("RSA");
-    gen.initialize(1024);
+    gen.initialize(2048);
     KeyPair pair = gen.generateKeyPair();
 
     ServiceAccountCredentials.Builder builder = ServiceAccountCredentials.newBuilder()


### PR DESCRIPTION
Potential fix for [https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/security/code-scanning/2](https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/security/code-scanning/2)

Use an RSA key size of at least 2048 bits when initializing `KeyPairGenerator`.

Best fix (minimal, no functional behavior change): in `kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/GcpClientBuilderProjectTest.java`, update the `creds(...)` helper so that:

- `gen.initialize(1024);` becomes `gen.initialize(2048);`

No new methods, imports, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
