### PR TITLE
Retry remaining documented-transient BigQuery errors (jobRateLimitExceeded, tableUnavailable, HTTP 504)

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/MergeQueries.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/MergeQueries.java
@@ -241,6 +241,18 @@ public class MergeQueries {
                 intermediateTable,
                 destinationTable,
                 ++attempt);
+          } else if (BigQueryErrorResponses.isJobRateLimitExceededError(e)) {
+            logger.warn(
+                "Job rate limit exceeded while merging from {} to {}, retry attempt {}",
+                intermediateTable,
+                destinationTable,
+                ++attempt);
+          } else if (BigQueryErrorResponses.isTableUnavailableError(e)) {
+            logger.warn(
+                "Table unavailable error while merging from {} to {}, retry attempt {}",
+                intermediateTable,
+                destinationTable,
+                ++attempt);
           } else {
             throw e;
           }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/BigQueryErrorResponses.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/BigQueryErrorResponses.java
@@ -44,16 +44,19 @@ public class BigQueryErrorResponses {
   private static final int INTERNAL_SERVICE_ERROR_CODE = 500;
   private static final int BAD_GATEWAY_CODE = 502;
   private static final int SERVICE_UNAVAILABLE_CODE = 503;
+  private static final int GATEWAY_TIMEOUT_CODE = 504;
 
   private static final String BAD_REQUEST_REASON = "badRequest";
   private static final String INVALID_REASON = "invalid";
   private static final String INVALID_QUERY_REASON = "invalidQuery";
   private static final String JOB_BACKEND_ERROR = "jobBackendError";
   private static final String JOB_INTERNAL_ERROR = "jobInternalError";
+  private static final String JOB_RATE_LIMIT_EXCEEDED_REASON = "jobRateLimitExceeded";
   private static final String NOT_FOUND_REASON = "notFound";
   private static final String QUOTA_EXCEEDED_REASON = "quotaExceeded";
   private static final String RATE_LIMIT_EXCEEDED_REASON = "rateLimitExceeded";
   private static final String STOPPED_REASON = "stopped";
+  private static final String TABLE_UNAVAILABLE_REASON = "tableUnavailable";
 
   public static boolean isNonExistentTableError(BigQueryException exception) {
     String message = message(exception.getError());
@@ -91,7 +94,8 @@ public class BigQueryErrorResponses {
     //       value
     return INTERNAL_SERVICE_ERROR_CODE == exception.getCode()
         || BAD_GATEWAY_CODE == exception.getCode()
-        || SERVICE_UNAVAILABLE_CODE == exception.getCode();
+        || SERVICE_UNAVAILABLE_CODE == exception.getCode()
+        || GATEWAY_TIMEOUT_CODE == exception.getCode();
   }
 
   public static boolean isUnspecifiedBadRequestError(BigQueryException exception) {
@@ -110,6 +114,11 @@ public class BigQueryErrorResponses {
         && JOB_INTERNAL_ERROR.equals(exception.getReason());
   }
 
+  public static boolean isJobRateLimitExceededError(BigQueryException exception) {
+    return BAD_REQUEST_CODE == exception.getCode()
+        && JOB_RATE_LIMIT_EXCEEDED_REASON.equals(exception.getReason());
+  }
+
   public static boolean isQuotaExceededError(BigQueryException exception) {
     return FORBIDDEN_CODE == exception.getCode()
         // TODO: May be able to use exception.getReason() instead of (indirectly)
@@ -124,6 +133,11 @@ public class BigQueryErrorResponses {
         // exception.getError().getReason()
         //       Haven't been able to test yet though, so keeping as-is to avoid breaking anything
         && RATE_LIMIT_EXCEEDED_REASON.equals(reason(exception.getError()));
+  }
+
+  public static boolean isTableUnavailableError(BigQueryException exception) {
+    return BAD_REQUEST_CODE == exception.getCode()
+        && TABLE_UNAVAILABLE_REASON.equals(exception.getReason());
   }
 
   public static boolean isRequestTooLargeError(BigQueryException exception) {

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/MergeQueriesTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/MergeQueriesTest.java
@@ -523,6 +523,81 @@ public class MergeQueriesTest {
   }
 
   @Test
+  public void testBigQueryJobRateLimitExceededRetry() throws InterruptedException {
+    // Arrange
+    mergeBatches.addToBatch(TEST_SINK_RECORD, INTERMEDIATE_TABLE, new HashMap<>());
+
+    TableResult tableResultReponse = mock(TableResult.class);
+    BigQueryError jobRateLimitExceededError =
+        new BigQueryError(
+            "jobRateLimitExceeded",
+            null,
+            "Job exceeded rate limits: Your project_and_region exceeded quota for concurrent queries that append to or overwrite a table.");
+    when(bigQuery.query(any(QueryJobConfiguration.class)))
+        .thenThrow(
+            new BigQueryException(400, "mock job rate limit exceeded", jobRateLimitExceededError))
+        .thenReturn(tableResultReponse);
+    when(mergeBatches.destinationTableFor(INTERMEDIATE_TABLE)).thenReturn(DESTINATION_TABLE);
+    when(mergeBatches.incrementBatch(INTERMEDIATE_TABLE)).thenReturn(0);
+    when(mergeBatches.prepareToFlush(INTERMEDIATE_TABLE, 0)).thenReturn(true);
+    CountDownLatch latch = new CountDownLatch(1);
+    doAnswer(
+            invocation -> {
+              Runnable runnable = invocation.getArgument(0);
+              runnable.run();
+              latch.countDown();
+              return null;
+            })
+        .when(executor)
+        .execute(any(Runnable.class));
+    MergeQueries mergeQueries = spy(mergeQueries(false, true, true));
+
+    // Act
+    mergeQueries.mergeFlush(INTERMEDIATE_TABLE);
+
+    // Assert
+    latch.await();
+    verify(bigQuery, times(3)).query(any(QueryJobConfiguration.class));
+  }
+
+  @Test
+  public void testBigQueryTableUnavailableRetry() throws InterruptedException {
+    // Arrange
+    mergeBatches.addToBatch(TEST_SINK_RECORD, INTERMEDIATE_TABLE, new HashMap<>());
+
+    TableResult tableResultReponse = mock(TableResult.class);
+    BigQueryError tableUnavailableError =
+        new BigQueryError(
+            "tableUnavailable",
+            null,
+            "The table my-project:my_dataset.my_table is currently unavailable. Retry the operation.");
+    when(bigQuery.query(any(QueryJobConfiguration.class)))
+        .thenThrow(new BigQueryException(400, "mock table unavailable", tableUnavailableError))
+        .thenReturn(tableResultReponse);
+    when(mergeBatches.destinationTableFor(INTERMEDIATE_TABLE)).thenReturn(DESTINATION_TABLE);
+    when(mergeBatches.incrementBatch(INTERMEDIATE_TABLE)).thenReturn(0);
+    when(mergeBatches.prepareToFlush(INTERMEDIATE_TABLE, 0)).thenReturn(true);
+    CountDownLatch latch = new CountDownLatch(1);
+    doAnswer(
+            invocation -> {
+              Runnable runnable = invocation.getArgument(0);
+              runnable.run();
+              latch.countDown();
+              return null;
+            })
+        .when(executor)
+        .execute(any(Runnable.class));
+    MergeQueries mergeQueries = spy(mergeQueries(false, true, true));
+
+    // Act
+    mergeQueries.mergeFlush(INTERMEDIATE_TABLE);
+
+    // Assert
+    latch.await();
+    verify(bigQuery, times(3)).query(any(QueryJobConfiguration.class));
+  }
+
+  @Test
   public void testBigQueryInvalidQueryErrorRetry() throws InterruptedException {
     // Arrange
     mergeBatches.addToBatch(TEST_SINK_RECORD, INTERMEDIATE_TABLE, new HashMap<>());

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/exception/BigQueryErrorResponsesTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/exception/BigQueryErrorResponsesTest.java
@@ -50,6 +50,54 @@ public class BigQueryErrorResponsesTest {
   }
 
   @Test
+  public void testIsBackendError() {
+    assertTrue(BigQueryErrorResponses.isBackendError(new BigQueryException(500, "Internal error")));
+    assertTrue(BigQueryErrorResponses.isBackendError(new BigQueryException(502, "Bad gateway")));
+    assertTrue(
+        BigQueryErrorResponses.isBackendError(new BigQueryException(503, "Service unavailable")));
+    assertTrue(
+        BigQueryErrorResponses.isBackendError(new BigQueryException(504, "Gateway timeout")));
+
+    assertFalse(BigQueryErrorResponses.isBackendError(new BigQueryException(400, "Bad request")));
+    assertFalse(BigQueryErrorResponses.isBackendError(new BigQueryException(403, "Forbidden")));
+  }
+
+  @Test
+  public void testIsJobRateLimitExceededError() {
+    String message =
+        "Job exceeded rate limits: Your project_and_region exceeded quota for concurrent queries that append to or overwrite a table.";
+    BigQueryException error =
+        new BigQueryException(
+            400, message, new BigQueryError("jobRateLimitExceeded", null, message));
+    assertTrue(BigQueryErrorResponses.isJobRateLimitExceededError(error));
+
+    // a different 400 reason must not match
+    error = new BigQueryException(400, message, new BigQueryError("invalidQuery", null, message));
+    assertFalse(BigQueryErrorResponses.isJobRateLimitExceededError(error));
+
+    // a 400 without a structured error (no reason) must not match
+    error = new BigQueryException(400, message);
+    assertFalse(BigQueryErrorResponses.isJobRateLimitExceededError(error));
+  }
+
+  @Test
+  public void testIsTableUnavailableError() {
+    String message =
+        "The table my-project:my_dataset.my_table is currently unavailable. Retry the operation.";
+    BigQueryException error =
+        new BigQueryException(400, message, new BigQueryError("tableUnavailable", null, message));
+    assertTrue(BigQueryErrorResponses.isTableUnavailableError(error));
+
+    // a different 400 reason must not match
+    error = new BigQueryException(400, message, new BigQueryError("invalid", null, message));
+    assertFalse(BigQueryErrorResponses.isTableUnavailableError(error));
+
+    // a 400 without a structured error (no reason) must not match
+    error = new BigQueryException(400, message);
+    assertFalse(BigQueryErrorResponses.isTableUnavailableError(error));
+  }
+
+  @Test
   public void testIsAuthenticationError() {
     BigQueryException error = new BigQueryException(0, "......401.....Unauthorized error.....");
     assertTrue(BigQueryErrorResponses.isAuthenticationError(error));

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/row/BigQueryWriterTest.java
@@ -220,6 +220,51 @@ public class BigQueryWriterTest {
   }
 
   @Test
+  public void testGatewayTimeoutRetry() {
+    final String topic = "test_topic";
+    final String dataset = "scratch";
+    final Map<String, String> properties = makeProperties("3", "2000", topic, dataset);
+
+    BigQuery bigQuery = mock(BigQuery.class);
+    Table mockTable = mock(Table.class);
+    when(bigQuery.getTable(any(TableId.class))).thenReturn(mockTable);
+
+    InsertAllResponse insertAllResponse = mock(InsertAllResponse.class);
+    when(insertAllResponse.hasErrors()).thenReturn(false);
+    when(insertAllResponse.getInsertErrors()).thenReturn(Collections.emptyMap());
+
+    BigQueryException gatewayTimeoutException = new BigQueryException(504, "Gateway timeout");
+
+    // first attempt (504 gateway timeout), second attempt (success)
+    when(bigQuery.insertAll(any(InsertAllRequest.class)))
+        .thenThrow(gatewayTimeoutException)
+        .thenReturn(insertAllResponse);
+
+    SinkTaskContext sinkTaskContext = mock(SinkTaskContext.class);
+
+    Storage storage = mock(Storage.class);
+    SchemaRetriever schemaRetriever = mock(SchemaRetriever.class);
+    SchemaManager schemaManager = mock(SchemaManager.class);
+
+    BigQuerySinkTask testTask =
+        BigQuerySinkTaskTest.createTestTask(
+            bigQuery,
+            schemaRetriever,
+            storage,
+            schemaManager,
+            mockedStorageWriteApiDefaultStream,
+            mockedBatchHandler,
+            time);
+    testTask.initialize(sinkTaskContext);
+    testTask.start(properties);
+    testTask.put(
+        Collections.singletonList(spoofSinkRecord(topic, 0, 0, "some_field", "some_value")));
+    testTask.flush(Collections.emptyMap());
+
+    verify(bigQuery, times(2)).insertAll(any(InsertAllRequest.class));
+  }
+
+  @Test
   public void testNonAutoCreateTables() {
     final String topic = "test_topic";
     final String dataset = "scratch";


### PR DESCRIPTION
## Summary

Follow-up to #213 and #215, as discussed in https://github.com/Aiven-Open/bigquery-connector-for-apache-kafka/pull/215#issuecomment-4990015449 — this closes the remaining gaps between the connector's retry classification and the documented-as-retryable errors in the [BigQuery error table](https://cloud.google.com/bigquery/docs/error-messages):

* **`jobRateLimitExceeded` (400)** — documented as retryable; now retried in `MergeQueries`, alongside the existing `jobInternalError`/`jobBackendError` handling.
* **`tableUnavailable` (400)** — documented as "retry the operation"; now retried in `MergeQueries`.
* **HTTP 504 Gateway Timeout** — the docs list 504 under `backendError`, but `isBackendError` only matched 500/502/503, so a 504 during streaming inserts failed the task immediately. Added 504 to the predicate (the GCS load path already retried 504 via the client library's `isRetryable()`).

Unlike #213/#215 these are not failures we have observed in production — they are the remaining documented-transient cases from the cross-check requested in the #215 review discussion, so they follow the exact same pattern and bounded-retry semantics as the existing handling.

## Testing

* New predicate tests in `BigQueryErrorResponsesTest` (positive + negative cases for each new predicate, plus coverage of all four 5xx codes in `isBackendError`).
* New retry tests in `MergeQueriesTest` mirroring the existing `jobInternalError`/`jobBackendError` retry tests.
* New `testGatewayTimeoutRetry` in `BigQueryWriterTest` mirroring the existing transient-error retry test.
* `mvn -pl kcbq-connector -am test -Dtest='BigQueryErrorResponsesTest,MergeQueriesTest,BigQueryWriterTest'` — BUILD SUCCESS, 30 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
