### PR TITLE
Add flushTimeoutMs to bound the wait for in-flight writes during flush

### DIFF
--- a/docs/sink-connector-config-options.rst
+++ b/docs/sink-connector-config-options.rst
@@ -233,6 +233,14 @@ BigQuery Sink Connector Configuration Options
   * Default: false
   * Importance: low
 
+``flushTimeoutMs``
+  The maximum time, in milliseconds, to wait for in-flight writes to complete during flush (offset commit) before failing the flush. This bounds the wait when a write hangs; the framework logs the failure and retries from the last committed offsets. Must be set well below the consumer's max.poll.interval.ms. 0 means wait indefinitely.
+
+  * Type: long
+  * Default: 0
+  * Valid Values: [0,...]
+  * Importance: low
+
 ``intermediateTableSuffix``
   A suffix that will be appended to the names of destination tables to create the names for the corresponding intermediate tables. Multiple intermediate tables may be created for a single destination table, but their names will always start with the name of the destination table, followed by this suffix, and possibly followed by an additional suffix.
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -169,6 +169,8 @@ public class BigQuerySinkConfig extends AbstractConfig {
   public static final String QUEUE_SIZE_CONFIG = "queueSize";
   // should this even have a default?
   public static final Long QUEUE_SIZE_DEFAULT = -1L;
+  public static final String FLUSH_TIMEOUT_MS_CONFIG = "flushTimeoutMs";
+  public static final long FLUSH_TIMEOUT_MS_DEFAULT = 0L;
   public static final String BIGQUERY_RETRY_CONFIG = "bigQueryRetry";
   public static final Integer BIGQUERY_RETRY_DEFAULT = 0;
   public static final String BIGQUERY_RETRY_WAIT_CONFIG = "bigQueryRetryWait";
@@ -587,6 +589,14 @@ public class BigQuerySinkConfig extends AbstractConfig {
           + "requests before all topics are paused. This is a soft limit; the size of the queue can "
           + "go over this before topics are paused. All topics will be resumed once a flush is "
           + "requested or the size of the queue drops under half of the maximum size.";
+  private static final ConfigDef.Type FLUSH_TIMEOUT_MS_TYPE = ConfigDef.Type.LONG;
+  private static final ConfigDef.Validator FLUSH_TIMEOUT_MS_VALIDATOR = ConfigDef.Range.atLeast(0);
+  private static final ConfigDef.Importance FLUSH_TIMEOUT_MS_IMPORTANCE = ConfigDef.Importance.LOW;
+  private static final String FLUSH_TIMEOUT_MS_DOC =
+      "The maximum time, in milliseconds, to wait for in-flight writes to complete during flush "
+          + "(offset commit) before failing the flush. This bounds the wait when a write hangs; "
+          + "the framework logs the failure and retries from the last committed offsets. Must be "
+          + "set well below the consumer's max.poll.interval.ms. 0 means wait indefinitely.";
   private static final ConfigDef.Type BIGQUERY_RETRY_TYPE = ConfigDef.Type.INT;
   private static final ConfigDef.Validator BIGQUERY_RETRY_VALIDATOR = ConfigDef.Range.atLeast(0);
   private static final ConfigDef.Importance BIGQUERY_RETRY_IMPORTANCE = ConfigDef.Importance.MEDIUM;
@@ -1073,6 +1083,13 @@ public class BigQuerySinkConfig extends AbstractConfig {
             QUEUE_SIZE_VALIDATOR,
             QUEUE_SIZE_IMPORTANCE,
             QUEUE_SIZE_DOC)
+        .define(
+            FLUSH_TIMEOUT_MS_CONFIG,
+            FLUSH_TIMEOUT_MS_TYPE,
+            FLUSH_TIMEOUT_MS_DEFAULT,
+            FLUSH_TIMEOUT_MS_VALIDATOR,
+            FLUSH_TIMEOUT_MS_IMPORTANCE,
+            FLUSH_TIMEOUT_MS_DOC)
         .define(
             BIGQUERY_RETRY_CONFIG,
             BIGQUERY_RETRY_TYPE,

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KcbqThreadPoolExecutor.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/KcbqThreadPoolExecutor.java
@@ -48,6 +48,8 @@ public class KcbqThreadPoolExecutor extends ThreadPoolExecutor {
 
   private final AtomicReference<Throwable> encounteredError = new AtomicReference<>();
 
+  private final long flushTimeoutMs;
+
   /**
    * @param config the {@link BigQuerySinkTaskConfig}
    * @param workQueue the queue for storing tasks.
@@ -64,6 +66,7 @@ public class KcbqThreadPoolExecutor extends ThreadPoolExecutor {
         TimeUnit.SECONDS,
         workQueue,
         threadFactory);
+    this.flushTimeoutMs = config.getLong(BigQuerySinkTaskConfig.FLUSH_TIMEOUT_MS_CONFIG);
   }
 
   @Override
@@ -82,7 +85,8 @@ public class KcbqThreadPoolExecutor extends ThreadPoolExecutor {
   /**
    * Wait for all the currently queued tasks to complete, and then return.
    *
-   * @throws BigQueryConnectException if any of the tasks failed.
+   * @throws BigQueryConnectException if any of the tasks failed, or if {@code flushTimeoutMs} is
+   *     set and the tasks did not complete within it.
    * @throws InterruptedException if interrupted while waiting.
    */
   public void awaitCurrentTasks() throws InterruptedException, BigQueryConnectException {
@@ -96,8 +100,51 @@ public class KcbqThreadPoolExecutor extends ThreadPoolExecutor {
     for (int i = 0; i < maximumPoolSize; i++) {
       execute(new CountDownRunnable(countDownLatch));
     }
-    countDownLatch.await();
+    if (flushTimeoutMs > 0) {
+      boolean completed;
+      try {
+        completed = countDownLatch.await(flushTimeoutMs, TimeUnit.MILLISECONDS);
+      } catch (InterruptedException e) {
+        releaseBarrier(countDownLatch);
+        throw e;
+      }
+      if (!completed) {
+        final long stillBusy = countDownLatch.getCount();
+        if (stillBusy == 0) {
+          // The last write finished between the timed wait and here; not a timeout.
+          maybeThrowEncounteredError();
+          return;
+        }
+        releaseBarrier(countDownLatch);
+        // A write error recorded before the timeout is the more useful failure to surface.
+        maybeThrowEncounteredError();
+        throw new BigQueryConnectException(
+            "Timed out after "
+                + flushTimeoutMs
+                + "ms waiting for in-flight write tasks to complete; "
+                + stillBusy
+                + " of "
+                + maximumPoolSize
+                + " write threads still busy. Increase flushTimeoutMs if writes legitimately "
+                + "take longer.");
+      }
+    } else {
+      countDownLatch.await();
+    }
     maybeThrowEncounteredError();
+  }
+
+  /**
+   * Release the flush barrier of an abandoned {@link #awaitCurrentTasks()}. {@link
+   * CountDownRunnable} parks each pool thread on the latch until every thread has arrived, so
+   * without this one hung write would keep all pool threads parked and every later flush would
+   * queue more runnables. Only the hung write keeps its thread afterwards.
+   */
+  private void releaseBarrier(CountDownLatch countDownLatch) {
+    getQueue().removeIf(r -> r instanceof CountDownRunnable);
+    while (countDownLatch.getCount() > 0) {
+      countDownLatch.countDown();
+    }
   }
 
   /**

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/batch/KcbqThreadPoolExecutorTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/batch/KcbqThreadPoolExecutorTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2026 Copyright 2022 Aiven Oy and
+ * bigquery-connector-for-apache-kafka project contributors
+ *
+ * This software contains code derived from the Confluent BigQuery
+ * Kafka Connector, Copyright Confluent, Inc, which in turn
+ * contains code derived from the WePay BigQuery Kafka Connector,
+ * Copyright WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wepay.kafka.connect.bigquery.write.batch;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.wepay.kafka.connect.bigquery.SinkTaskPropertiesFactory;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
+import com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+public class KcbqThreadPoolExecutorTest {
+
+  private final CountDownLatch hang = new CountDownLatch(1);
+  private KcbqThreadPoolExecutor executor;
+
+  private KcbqThreadPoolExecutor executor(long flushTimeoutMs) {
+    Map<String, String> properties = new SinkTaskPropertiesFactory().getProperties();
+    properties.put(BigQuerySinkTaskConfig.THREAD_POOL_SIZE_CONFIG, "2");
+    properties.put(BigQuerySinkTaskConfig.FLUSH_TIMEOUT_MS_CONFIG, Long.toString(flushTimeoutMs));
+    executor =
+        new KcbqThreadPoolExecutor(
+            new BigQuerySinkTaskConfig(properties), new LinkedBlockingQueue<>(), Thread::new);
+    return executor;
+  }
+
+  /** Submits a write task that never completes, standing in for a hung write call. */
+  private void submitHungWriteTask(KcbqThreadPoolExecutor executor) {
+    executor.execute(
+        () -> {
+          try {
+            hang.await();
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          }
+        });
+  }
+
+  @AfterEach
+  public void tearDown() {
+    hang.countDown();
+    if (executor != null) {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  public void testAwaitCurrentTasksBlocksIndefinitelyOnHungWriteTaskByDefault() throws Exception {
+    KcbqThreadPoolExecutor executor = executor(0L);
+    submitHungWriteTask(executor);
+
+    CountDownLatch returned = new CountDownLatch(1);
+    Thread flusher =
+        new Thread(
+            () -> {
+              try {
+                executor.awaitCurrentTasks();
+              } catch (Exception e) {
+                // fall through -- either way the call came back
+              }
+              returned.countDown();
+            });
+    flusher.setDaemon(true);
+    flusher.start();
+
+    assertFalse(
+        returned.await(1, TimeUnit.SECONDS),
+        "awaitCurrentTasks() should block while a write task is in flight");
+    flusher.interrupt();
+  }
+
+  @Test
+  public void testAwaitCurrentTasksThrowsAfterFlushTimeoutOnHungWriteTask() {
+    KcbqThreadPoolExecutor executor = executor(500L);
+    submitHungWriteTask(executor);
+
+    assertTimeoutPreemptively(
+        Duration.ofSeconds(10),
+        () -> assertThrows(BigQueryConnectException.class, executor::awaitCurrentTasks));
+  }
+
+  @Test
+  public void testPoolRecoversAfterFlushTimeout() throws Exception {
+    KcbqThreadPoolExecutor executor = executor(500L);
+    submitHungWriteTask(executor);
+    assertThrows(BigQueryConnectException.class, executor::awaitCurrentTasks);
+
+    // The timed-out flush must not leave its barrier behind: no CountDownRunnable stays queued,
+    // and the pool thread not occupied by the hung write is free to run new work.
+    assertTrue(executor.getQueue().stream().noneMatch(r -> r instanceof CountDownRunnable));
+    CountDownLatch ran = new CountDownLatch(1);
+    executor.execute(ran::countDown);
+    assertTrue(ran.await(5, TimeUnit.SECONDS), "new write task did not run after a flush timeout");
+
+    // A later flush with the write still hung times out again instead of blocking forever.
+    assertTimeoutPreemptively(
+        Duration.ofSeconds(10),
+        () -> assertThrows(BigQueryConnectException.class, executor::awaitCurrentTasks));
+  }
+
+  @Test
+  public void testInterruptedFlushReleasesBarrier() throws Exception {
+    KcbqThreadPoolExecutor executor = executor(60_000L);
+    submitHungWriteTask(executor);
+    CountDownLatch interrupted = new CountDownLatch(1);
+    Thread flusher =
+        new Thread(
+            () -> {
+              try {
+                executor.awaitCurrentTasks();
+              } catch (InterruptedException e) {
+                interrupted.countDown();
+              } catch (Exception e) {
+                // not expected
+              }
+            });
+    flusher.setDaemon(true);
+    flusher.start();
+    Thread.sleep(200);
+    flusher.interrupt();
+    assertTrue(interrupted.await(5, TimeUnit.SECONDS));
+
+    assertTrue(executor.getQueue().stream().noneMatch(r -> r instanceof CountDownRunnable));
+    CountDownLatch ran = new CountDownLatch(1);
+    executor.execute(ran::countDown);
+    assertTrue(ran.await(5, TimeUnit.SECONDS), "new write task did not run after an interrupt");
+  }
+
+  @Test
+  public void testAwaitCurrentTasksCompletesNormallyWithinFlushTimeout() {
+    KcbqThreadPoolExecutor executor = executor(5000L);
+    AtomicBoolean ran = new AtomicBoolean();
+    executor.execute(() -> ran.set(true));
+
+    assertTimeoutPreemptively(Duration.ofSeconds(10), () -> executor.awaitCurrentTasks());
+    assertTrue(ran.get());
+  }
+}


### PR DESCRIPTION
Fixes #200.

`flush()`/`preCommit()` waits on `KcbqThreadPoolExecutor.awaitCurrentTasks()` with no timeout. One write task that never completes (e.g. a Storage Write API `AppendRows` call that hangs after a stream reset) blocks the flush path until the consumer group fences the task via `max.poll.interval.ms`, and the rebalance loop in #200 repeats.

This adds a `flushTimeoutMs` sink config (default 0 = current behaviour). When set, `awaitCurrentTasks()` throws `BigQueryConnectException` once the bound elapses; Connect logs it, rewinds to the last committed offsets, retries on the next commit cycle, and the task stays RUNNING with no rebalance.

Because `CountDownRunnable` parks every pool thread on the latch, the timeout path (and an interrupt mid-wait) also drops the queued runnables and drains the latch, so only the hung write keeps its thread and the rest of the pool keeps writing. A write error recorded before the timeout is thrown in preference to it, and a wait that expires just as the last write completes counts as normal completion. During a persistent hang, offsets cannot commit, so each cycle re-sends the uncommitted window (at-least-once duplicates).

`flushTimeoutMs` must stay well below `max.poll.interval.ms`, or the broker fences the consumer first.

Tests (`KcbqThreadPoolExecutorTest`): hung task with the default blocks indefinitely; hung task with a timeout throws within the bound; the pool keeps running new work after a timeout and after an interrupt; normal completion does not throw. Full suite green with `mvn -P ci`. Running in production for several weeks; the timeout path has fired under real load and recovered as described.