### PR TITLE
docs: add schema evolution recommendations to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,7 @@ JSON-encoded values and writes their values to BigQuery:
   "keyfile": "/tmp/bigquery-credentials.json"
 }
 ```
-
-### Complete docs
-See the [configuration documentation](https://aiven-open.github.io/bigquery-connector-for-apache-kafka/configuration.html) for a list of the connector's
-configuration properties.
-
-## Schema evolution
+### Schema evolution
 
 If your Kafka records evolve over time (for example, new optional fields are added), consider enabling the following options:
 
@@ -104,6 +99,11 @@ are not supported by Kafka Connect's `AvroConverter`. Optional fields should ins
   "default": null
 }
 ```
+
+### Complete docs
+See the [configuration documentation](https://aiven-open.github.io/bigquery-connector-for-apache-kafka/configuration.html) for a list of the connector's
+configuration properties.
+
 ## Download
 
 Download information is available on the [project web site]((https://aiven-open.github.io/bigquery-connector-for-apache-kafka)). 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,38 @@ JSON-encoded values and writes their values to BigQuery:
 See the [configuration documentation](https://aiven-open.github.io/bigquery-connector-for-apache-kafka/configuration.html) for a list of the connector's
 configuration properties.
 
+## Schema evolution
+
+If your Kafka records evolve over time (for example, new optional fields are added), consider enabling the following options:
+
+```json
+{
+  "allowNewBigQueryFields": "true",
+  "allowSchemaUnionization": "true",
+  "allowBigQueryRequiredFieldRelaxation": "true"
+}
+```
+
+These options allow the connector to:
+
+- add newly introduced fields to existing BigQuery tables;
+- reconcile incoming schemas with existing table schemas;
+- relax REQUIRED fields to NULLABLE where supported.
+
+Note that these settings do not resolve invalid Avro schemas. For example, fields defined as:
+
+```json
+{ "type": "null" }
+```
+
+are not supported by Kafka Connect's `AvroConverter`. Optional fields should instead use nullable union types, for example:
+
+```json
+{
+  "type": ["null", "string"],
+  "default": null
+}
+```
 ## Download
 
 Download information is available on the [project web site]((https://aiven-open.github.io/bigquery-connector-for-apache-kafka)). 


### PR DESCRIPTION
## What
Adds a "Schema evolution" section to the README with configuration recommendations for handling schema changes (new fields, nullable fields, nested structures).

## Why
Came out of a support case where the customer struggled with schema  evolution scenarios. The current docs describe each config option individually but don't explain which combinations are recommended for common schema evolution use cases.

## Changes
- Added recommended settings: `allowNewBigQueryFields`,  `allowSchemaUnionization`, `allowBigQueryRequiredFieldRelaxation`
- Added a note about invalid Avro schemas (`{"type": "null"}`) not being supported by Kafka Connect's `AvroConverter`, with the correct nullable union type syntax instead.