### PR TITLE
Implementing CDC Integration to Big Query

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -214,8 +214,9 @@ public class SchemaManager {
     this.tableUpdateLocks = new ConcurrentHashMap<>();
     this.schemaCache = new ConcurrentHashMap<>();
 
-    kafkaKeyAsPrimaryKey = config.isUpsertEnabled() && config.useStorageWriteApi();
-    this.tableMaxStaleness = config.getInt(BigQuerySinkConfig.TABLE_MAX_STALENESS_CONFIG);
+    kafkaKeyAsPrimaryKey = config != null && config.isUpsertEnabled() && config.useStorageWriteApi();
+    this.tableMaxStaleness =
+        config != null ? config.getInt(BigQuerySinkConfig.TABLE_MAX_STALENESS_CONFIG) : null;
   }
 
   /**
@@ -1059,6 +1060,13 @@ public class SchemaManager {
     }
   }
 
+  /**
+   * Checks and applies the {@code max_staleness} table option on the specified BigQuery table.
+   * Queries {@code INFORMATION_SCHEMA.TABLE_OPTIONS} to avoid redundant {@code ALTER TABLE}
+   * statements if the table already has the expected {@code max_staleness} configured.
+   *
+   * @param table the BigQuery table to inspect and update
+   */
   private void applyMaxStaleness(TableId table) {
     Integer maxStalenessVal = tableMaxStaleness;
     String expectedStalenessString = String.format("INTERVAL %d SECOND", maxStalenessVal);
@@ -1090,9 +1098,10 @@ public class SchemaManager {
       throw new BigQueryConnectException(
           "Interrupted while checking existing max_staleness option on table " + table(table), e);
     } catch (Exception e) {
-      logger.debug(
+      logger.warn(
           "Could not verify existing max_staleness option, proceeding with ALTER TABLE. Reason: {}",
-          e.getMessage());
+          e.getMessage(),
+          e);
     }
 
     String fullyQualifiedTable =

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -95,7 +95,7 @@ public class SchemaManager {
   private final boolean mediateConcurrentSchemaUpdates;
   private final long concurrentSchemaUpdateRetryWaitMs;
   private final int concurrentSchemaUpdateMaxRetries;
-  private final Optional<Integer> tableMaxStaleness;
+  private final Integer tableMaxStaleness;
 
   /**
    * @param config a big query sink configuration.
@@ -147,8 +147,7 @@ public class SchemaManager {
     concurrentSchemaUpdateMaxRetries =
         config.getInt(BigQuerySinkConfig.CONCURRENT_SCHEMA_UPDATE_MAX_RETRIES_CONFIG);
 
-    tableMaxStaleness =
-        Optional.ofNullable(config.getInt(BigQuerySinkConfig.TABLE_MAX_STALENESS_CONFIG));
+    tableMaxStaleness = config.getInt(BigQuerySinkConfig.TABLE_MAX_STALENESS_CONFIG);
   }
 
   /**
@@ -216,8 +215,7 @@ public class SchemaManager {
     this.schemaCache = new ConcurrentHashMap<>();
 
     kafkaKeyAsPrimaryKey = config.isUpsertEnabled() && config.useStorageWriteApi();
-    this.tableMaxStaleness =
-        Optional.ofNullable(config.getInt(BigQuerySinkConfig.TABLE_MAX_STALENESS_CONFIG));
+    this.tableMaxStaleness = config.getInt(BigQuerySinkConfig.TABLE_MAX_STALENESS_CONFIG);
   }
 
   /**
@@ -291,7 +289,7 @@ public class SchemaManager {
         bigQuery.create(tableInfo);
         logger.debug("Successfully created {}", table(table));
         schemaCache.put(table, SchemaAndPrimaryKeyColumns.of(tableInfo));
-        if (tableMaxStaleness != null && tableMaxStaleness.isPresent()) {
+        if (tableMaxStaleness != null) {
           applyMaxStaleness(table);
           checkedTableOptions.add(table);
         }
@@ -331,7 +329,7 @@ public class SchemaManager {
           bigQuery.update(tableInfo);
           logger.debug("Successfully updated {}", table(table));
           schemaCache.put(table, SchemaAndPrimaryKeyColumns.of(tableInfo));
-          if (tableMaxStaleness != null && tableMaxStaleness.isPresent()) {
+          if (tableMaxStaleness != null) {
             applyMaxStaleness(table);
             checkedTableOptions.add(table);
           }
@@ -977,12 +975,12 @@ public class SchemaManager {
    */
   private List<String> getPrimaryKeys(List<SinkRecord> records) {
     if (records == null || records.isEmpty()) {
-      return null;
+      return Collections.emptyList();
     }
     SinkRecord record = records.get(0);
     Schema keySchema = schemaRetriever.retrieveKeySchema(record);
-    if (keySchema == null) {
-      return null;
+    if (keySchema == null || keySchema.type() != Schema.Type.STRUCT || keySchema.fields() == null) {
+      return Collections.emptyList();
     }
     List<String> pkColumns = new ArrayList<>();
     for (org.apache.kafka.connect.data.Field field : keySchema.fields()) {
@@ -1043,7 +1041,7 @@ public class SchemaManager {
     if (intermediateTables) {
       return;
     }
-    if (!tableMaxStaleness.isPresent()) {
+    if (tableMaxStaleness == null) {
       return;
     }
     if (checkedTableOptions.contains(table)) {
@@ -1062,7 +1060,7 @@ public class SchemaManager {
   }
 
   private void applyMaxStaleness(TableId table) {
-    Integer maxStalenessVal = tableMaxStaleness.get();
+    Integer maxStalenessVal = tableMaxStaleness;
     String expectedStalenessString = String.format("INTERVAL %d SECOND", maxStalenessVal);
 
     String projectId =
@@ -1080,7 +1078,7 @@ public class SchemaManager {
           bigQuery.query(com.google.cloud.bigquery.QueryJobConfiguration.of(checkQuery));
       for (com.google.cloud.bigquery.FieldValueList row : result.iterateAll()) {
         if (expectedStalenessString.equalsIgnoreCase(row.get("option_value").getStringValue())) {
-          logger.info(
+          logger.debug(
               "max_staleness is already set to {} on table {}; skipping ALTER TABLE",
               maxStalenessVal,
               table(table));

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -95,6 +95,7 @@ public class SchemaManager {
   private final boolean mediateConcurrentSchemaUpdates;
   private final long concurrentSchemaUpdateRetryWaitMs;
   private final int concurrentSchemaUpdateMaxRetries;
+  private final Optional<Integer> tableMaxStaleness;
 
   /**
    * @param config a big query sink configuration.
@@ -145,6 +146,9 @@ public class SchemaManager {
         config.getLong(BigQuerySinkConfig.CONCURRENT_SCHEMA_UPDATE_RETRY_WAIT_MS_CONFIG);
     concurrentSchemaUpdateMaxRetries =
         config.getInt(BigQuerySinkConfig.CONCURRENT_SCHEMA_UPDATE_MAX_RETRIES_CONFIG);
+
+    tableMaxStaleness =
+        Optional.ofNullable(config.getInt(BigQuerySinkConfig.TABLE_MAX_STALENESS_CONFIG));
   }
 
   /**
@@ -210,7 +214,10 @@ public class SchemaManager {
     this.tableCreateLocks = new ConcurrentHashMap<>();
     this.tableUpdateLocks = new ConcurrentHashMap<>();
     this.schemaCache = new ConcurrentHashMap<>();
+
     kafkaKeyAsPrimaryKey = config.isUpsertEnabled() && config.useStorageWriteApi();
+    this.tableMaxStaleness =
+        Optional.ofNullable(config.getInt(BigQuerySinkConfig.TABLE_MAX_STALENESS_CONFIG));
   }
 
   /**
@@ -284,6 +291,10 @@ public class SchemaManager {
         bigQuery.create(tableInfo);
         logger.debug("Successfully created {}", table(table));
         schemaCache.put(table, SchemaAndPrimaryKeyColumns.of(tableInfo));
+        if (tableMaxStaleness != null && tableMaxStaleness.isPresent()) {
+          applyMaxStaleness(table);
+          checkedTableOptions.add(table);
+        }
         return true;
       } catch (BigQueryException e) {
         if (e.getCode() == 409) {
@@ -320,6 +331,10 @@ public class SchemaManager {
           bigQuery.update(tableInfo);
           logger.debug("Successfully updated {}", table(table));
           schemaCache.put(table, SchemaAndPrimaryKeyColumns.of(tableInfo));
+          if (tableMaxStaleness != null && tableMaxStaleness.isPresent()) {
+            applyMaxStaleness(table);
+            checkedTableOptions.add(table);
+          }
         } catch (BigQueryException e) {
           if (!mediateConcurrentSchemaUpdates) {
             throw e;
@@ -433,6 +448,13 @@ public class SchemaManager {
     } catch (BigQueryConnectException exception) {
       throw new BigQueryConnectException(
           "Failed to unionize schemas of records for the table " + table, exception);
+    }
+    List<String> primaryKeys = getPrimaryKeys(records);
+    if (primaryKeys != null && !primaryKeys.isEmpty()) {
+      com.google.cloud.bigquery.Schema relaxedSchema =
+          relaxNonKeyFields(proposedSchema.schema(), primaryKeys);
+      proposedSchema =
+          new SchemaAndPrimaryKeyColumns(relaxedSchema, proposedSchema.primaryKeyColumns());
     }
     return constructTableInfo(table, proposedSchema, tableDescription, createSchema);
   }
@@ -762,6 +784,15 @@ public class SchemaManager {
     StandardTableDefinition.Builder builder =
         StandardTableDefinition.newBuilder().setSchema(bigQuerySchema.schema());
 
+    if (createSchema
+        && bigQuerySchema.primaryKeyColumns() != null
+        && !bigQuerySchema.primaryKeyColumns().isEmpty()) {
+      PrimaryKey pk =
+          PrimaryKey.newBuilder().setColumns(bigQuerySchema.primaryKeyColumns()).build();
+      TableConstraints constraints = TableConstraints.newBuilder().setPrimaryKey(pk).build();
+      builder.setTableConstraints(constraints);
+    }
+
     if (intermediateTables) {
       // Shameful hack: make the table ingestion time-partitioned here so that the _PARTITIONTIME
       // pseudocolumn can be queried to filter out rows that are still in the streaming buffer
@@ -937,6 +968,60 @@ public class SchemaManager {
         com.google.cloud.bigquery.Schema.of(fields), primaryKeyColumns);
   }
 
+  /**
+   * Extracts primary key column names from the key schema of the first record in the batch. If
+   * field name sanitization is enabled, the column names are sanitized.
+   *
+   * @param records The batch of records to inspect
+   * @return A list of primary key column names, or null if no key schema is found
+   */
+  private List<String> getPrimaryKeys(List<SinkRecord> records) {
+    if (records == null || records.isEmpty()) {
+      return null;
+    }
+    SinkRecord record = records.get(0);
+    Schema keySchema = schemaRetriever.retrieveKeySchema(record);
+    if (keySchema == null) {
+      return null;
+    }
+    List<String> pkColumns = new ArrayList<>();
+    for (org.apache.kafka.connect.data.Field field : keySchema.fields()) {
+      String name = field.name();
+      if (sanitizeFieldNames) {
+        name = FieldNameSanitizer.sanitizeName(name);
+      }
+      pkColumns.add(name);
+    }
+    return pkColumns;
+  }
+
+  /**
+   * Relaxes the schema by converting non-primary-key required fields to nullable. This is necessary
+   * for CDC deletes (tombstones or rewritten deletes), which only populate primary key columns and
+   * omit required non-key columns. Without this relaxation, write operations for deletes would
+   * crash due to missing required fields.
+   *
+   * @param schema The proposed BigQuery schema
+   * @param primaryKeys The list of primary key columns
+   * @return The modified schema with relaxed non-key fields
+   */
+  private com.google.cloud.bigquery.Schema relaxNonKeyFields(
+      com.google.cloud.bigquery.Schema schema, List<String> primaryKeys) {
+    List<Field> relaxedFields = new ArrayList<>();
+    for (Field field : schema.getFields()) {
+      if (primaryKeys.contains(field.getName())) {
+        relaxedFields.add(field);
+      } else {
+        if (field.getMode() == Field.Mode.REQUIRED) {
+          relaxedFields.add(field.toBuilder().setMode(Field.Mode.NULLABLE).build());
+        } else {
+          relaxedFields.add(field);
+        }
+      }
+    }
+    return com.google.cloud.bigquery.Schema.of(relaxedFields);
+  }
+
   private String table(TableId table) {
     return intermediateTables ? TableNameUtils.intTable(table) : TableNameUtils.table(table);
   }
@@ -950,6 +1035,92 @@ public class SchemaManager {
 
   private Object lock(ConcurrentMap<TableId, Object> locks, TableId table) {
     return locks.computeIfAbsent(table, t -> new Object());
+  }
+
+  private final java.util.Set<TableId> checkedTableOptions = ConcurrentHashMap.newKeySet();
+
+  public void checkAndApplyTableOptions(TableId table) {
+    if (intermediateTables) {
+      return;
+    }
+    if (!tableMaxStaleness.isPresent()) {
+      return;
+    }
+    if (checkedTableOptions.contains(table)) {
+      return;
+    }
+
+    synchronized (lock(tableUpdateLocks, table)) {
+      if (checkedTableOptions.contains(table)) {
+        return;
+      }
+      if (bigQuery.getTable(table) != null) {
+        applyMaxStaleness(table);
+        checkedTableOptions.add(table);
+      }
+    }
+  }
+
+  private void applyMaxStaleness(TableId table) {
+    Integer maxStalenessVal = tableMaxStaleness.get();
+    String expectedStalenessString = String.format("INTERVAL %d SECOND", maxStalenessVal);
+
+    String projectId =
+        table.getProject() != null
+            ? table.getProject()
+            : bigQuery.getOptions() != null ? bigQuery.getOptions().getProjectId() : "mock-project";
+    String checkQuery =
+        String.format(
+            "SELECT option_value FROM `%s.%s.INFORMATION_SCHEMA.TABLE_OPTIONS` "
+                + "WHERE table_name = '%s' AND option_name = 'max_staleness'",
+            projectId, table.getDataset(), table.getTable());
+
+    try {
+      com.google.cloud.bigquery.TableResult result =
+          bigQuery.query(com.google.cloud.bigquery.QueryJobConfiguration.of(checkQuery));
+      for (com.google.cloud.bigquery.FieldValueList row : result.iterateAll()) {
+        if (expectedStalenessString.equalsIgnoreCase(row.get("option_value").getStringValue())) {
+          logger.info(
+              "max_staleness is already set to {} on table {}; skipping ALTER TABLE",
+              maxStalenessVal,
+              table(table));
+          return;
+        }
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new BigQueryConnectException(
+          "Interrupted while checking existing max_staleness option on table " + table(table), e);
+    } catch (Exception e) {
+      logger.debug(
+          "Could not verify existing max_staleness option, proceeding with ALTER TABLE. Reason: {}",
+          e.getMessage());
+    }
+
+    String fullyQualifiedTable =
+        table.getProject() != null
+            ? String.format(
+                "`%s`.`%s`.`%s`", table.getProject(), table.getDataset(), table.getTable())
+            : String.format("`%s`.`%s`", table.getDataset(), table.getTable());
+
+    String query =
+        String.format(
+            "ALTER TABLE %s SET OPTIONS (max_staleness = INTERVAL %d SECOND)",
+            fullyQualifiedTable, maxStalenessVal);
+
+    logger.info(
+        "Applying max_staleness option of '{}' to table {} using query: {}",
+        maxStalenessVal,
+        table(table),
+        query);
+    try {
+      bigQuery.query(com.google.cloud.bigquery.QueryJobConfiguration.of(query));
+      logger.info(
+          "Successfully set max_staleness to '{}' on table {}", maxStalenessVal, table(table));
+    } catch (Exception e) {
+      throw new BigQueryConnectException(
+          "Failed to apply max_staleness option to table " + table(table), e);
+    }
   }
 
   /**

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -214,7 +214,8 @@ public class SchemaManager {
     this.tableUpdateLocks = new ConcurrentHashMap<>();
     this.schemaCache = new ConcurrentHashMap<>();
 
-    kafkaKeyAsPrimaryKey = config != null && config.isUpsertEnabled() && config.useStorageWriteApi();
+    kafkaKeyAsPrimaryKey =
+        config != null && config.isUpsertEnabled() && config.useStorageWriteApi();
     this.tableMaxStaleness =
         config != null ? config.getInt(BigQuerySinkConfig.TABLE_MAX_STALENESS_CONFIG) : null;
   }
@@ -452,8 +453,12 @@ public class SchemaManager {
     if (primaryKeys != null && !primaryKeys.isEmpty()) {
       com.google.cloud.bigquery.Schema relaxedSchema =
           relaxNonKeyFields(proposedSchema.schema(), primaryKeys);
-      proposedSchema =
-          new SchemaAndPrimaryKeyColumns(relaxedSchema, proposedSchema.primaryKeyColumns());
+      List<String> pkColumns =
+          (proposedSchema.primaryKeyColumns() != null
+                  && !proposedSchema.primaryKeyColumns().isEmpty())
+              ? proposedSchema.primaryKeyColumns()
+              : primaryKeys;
+      proposedSchema = new SchemaAndPrimaryKeyColumns(relaxedSchema, pkColumns);
     }
     return constructTableInfo(table, proposedSchema, tableDescription, createSchema);
   }
@@ -817,16 +822,16 @@ public class SchemaManager {
       // This must be applied regardless of whether time-partitioning is configured,
       // so it lives outside the timePartitioningType.ifPresent() block.
       if (kafkaKeyAsPrimaryKey) {
-        if (!Optional.of("").equals(kafkaKeyFieldName)) {
-          throw new IllegalStateException(
-              "kafkaKeyFieldName must be '' when kafkaKeyAsPrimaryKey is true");
+        if (bigQuerySchema.primaryKeyColumns() != null
+            && !bigQuerySchema.primaryKeyColumns().isEmpty()) {
+          builder.setTableConstraints(
+              TableConstraints.newBuilder()
+                  .setPrimaryKey(
+                      PrimaryKey.newBuilder()
+                          .setColumns(bigQuerySchema.primaryKeyColumns())
+                          .build())
+                  .build());
         }
-
-        builder.setTableConstraints(
-            TableConstraints.newBuilder()
-                .setPrimaryKey(
-                    PrimaryKey.newBuilder().setColumns(bigQuerySchema.primaryKeyColumns()).build())
-                .build());
       }
     }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/SchemaManager.java
@@ -449,16 +449,11 @@ public class SchemaManager {
       throw new BigQueryConnectException(
           "Failed to unionize schemas of records for the table " + table, exception);
     }
-    List<String> primaryKeys = getPrimaryKeys(records);
+    List<String> primaryKeys = proposedSchema.primaryKeyColumns();
     if (primaryKeys != null && !primaryKeys.isEmpty()) {
       com.google.cloud.bigquery.Schema relaxedSchema =
           relaxNonKeyFields(proposedSchema.schema(), primaryKeys);
-      List<String> pkColumns =
-          (proposedSchema.primaryKeyColumns() != null
-                  && !proposedSchema.primaryKeyColumns().isEmpty())
-              ? proposedSchema.primaryKeyColumns()
-              : primaryKeys;
-      proposedSchema = new SchemaAndPrimaryKeyColumns(relaxedSchema, pkColumns);
+      proposedSchema = new SchemaAndPrimaryKeyColumns(relaxedSchema, primaryKeys);
     }
     return constructTableInfo(table, proposedSchema, tableDescription, createSchema);
   }
@@ -788,15 +783,6 @@ public class SchemaManager {
     StandardTableDefinition.Builder builder =
         StandardTableDefinition.newBuilder().setSchema(bigQuerySchema.schema());
 
-    if (createSchema
-        && bigQuerySchema.primaryKeyColumns() != null
-        && !bigQuerySchema.primaryKeyColumns().isEmpty()) {
-      PrimaryKey pk =
-          PrimaryKey.newBuilder().setColumns(bigQuerySchema.primaryKeyColumns()).build();
-      TableConstraints constraints = TableConstraints.newBuilder().setPrimaryKey(pk).build();
-      builder.setTableConstraints(constraints);
-    }
-
     if (intermediateTables) {
       // Shameful hack: make the table ingestion time-partitioned here so that the _PARTITIONTIME
       // pseudocolumn can be queried to filter out rows that are still in the streaming buffer
@@ -821,17 +807,13 @@ public class SchemaManager {
       // Primary key constraints are needed for Storage Write API upsert CDC semantics.
       // This must be applied regardless of whether time-partitioning is configured,
       // so it lives outside the timePartitioningType.ifPresent() block.
-      if (kafkaKeyAsPrimaryKey) {
-        if (bigQuerySchema.primaryKeyColumns() != null
-            && !bigQuerySchema.primaryKeyColumns().isEmpty()) {
-          builder.setTableConstraints(
-              TableConstraints.newBuilder()
-                  .setPrimaryKey(
-                      PrimaryKey.newBuilder()
-                          .setColumns(bigQuerySchema.primaryKeyColumns())
-                          .build())
-                  .build());
-        }
+      if (kafkaKeyAsPrimaryKey
+          && bigQuerySchema.primaryKeyColumns() != null
+          && !bigQuerySchema.primaryKeyColumns().isEmpty()) {
+        PrimaryKey pk =
+            PrimaryKey.newBuilder().setColumns(bigQuerySchema.primaryKeyColumns()).build();
+        TableConstraints constraints = TableConstraints.newBuilder().setPrimaryKey(pk).build();
+        builder.setTableConstraints(constraints);
       }
     }
 
@@ -973,33 +955,6 @@ public class SchemaManager {
   }
 
   /**
-   * Extracts primary key column names from the key schema of the first record in the batch. If
-   * field name sanitization is enabled, the column names are sanitized.
-   *
-   * @param records The batch of records to inspect
-   * @return A list of primary key column names, or null if no key schema is found
-   */
-  private List<String> getPrimaryKeys(List<SinkRecord> records) {
-    if (records == null || records.isEmpty()) {
-      return Collections.emptyList();
-    }
-    SinkRecord record = records.get(0);
-    Schema keySchema = schemaRetriever.retrieveKeySchema(record);
-    if (keySchema == null || keySchema.type() != Schema.Type.STRUCT || keySchema.fields() == null) {
-      return Collections.emptyList();
-    }
-    List<String> pkColumns = new ArrayList<>();
-    for (org.apache.kafka.connect.data.Field field : keySchema.fields()) {
-      String name = field.name();
-      if (sanitizeFieldNames) {
-        name = FieldNameSanitizer.sanitizeName(name);
-      }
-      pkColumns.add(name);
-    }
-    return pkColumns;
-  }
-
-  /**
    * Relaxes the schema by converting non-primary-key required fields to nullable. This is necessary
    * for CDC deletes (tombstones or rewritten deletes), which only populate primary key columns and
    * omit required non-key columns. Without this relaxation, write operations for deletes would
@@ -1129,6 +1084,23 @@ public class SchemaManager {
       bigQuery.query(com.google.cloud.bigquery.QueryJobConfiguration.of(query));
       logger.info(
           "Successfully set max_staleness to '{}' on table {}", maxStalenessVal, table(table));
+    } catch (BigQueryException e) {
+      if (e.getCode() == 409
+          || (e.getMessage() != null
+              && (e.getMessage().contains("Already Exists")
+                  || e.getMessage().toLowerCase().contains("concurrent")))) {
+        logger.debug(
+            "Concurrent DDL conflict when applying max_staleness to table {} (possibly applied by another task): {}",
+            table(table),
+            e.getMessage());
+      } else {
+        throw new BigQueryConnectException(
+            "Failed to apply max_staleness option to table " + table(table), e);
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new BigQueryConnectException(
+          "Interrupted while applying max_staleness option to table " + table(table), e);
     } catch (Exception e) {
       throw new BigQueryConnectException(
           "Failed to apply max_staleness option to table " + table(table), e);

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -176,6 +176,18 @@ public class BigQuerySinkConfig extends AbstractConfig {
   private static final String TABLE_MAX_STALENESS_DOC =
       "The maximum staleness allowed for the destination BigQuery table in seconds. "
           + "Only applicable if upsert/delete (CDC) is enabled with the Storage Write API.";
+  public static final String IS_CDC_ENABLED_CONFIG = "isCdcEnabled";
+  public static final Boolean IS_CDC_ENABLED_DEFAULT = false;
+  private static final ConfigDef.Type IS_CDC_ENABLED_TYPE = ConfigDef.Type.BOOLEAN;
+  private static final ConfigDef.Importance IS_CDC_ENABLED_IMPORTANCE = ConfigDef.Importance.MEDIUM;
+  private static final String IS_CDC_ENABLED_DOC =
+      "Enable BigQuery Change Data Capture (CDC) with the Storage Write API. "
+          + "When true, records are ingested as upserts or deletes using BigQuery CDC.";
+  public static final String CONFIG_PRESET_CONFIG = "configPreset";
+  public static final String CONFIG_PRESET_DEFAULT = null;
+  private static final ConfigDef.Type CONFIG_PRESET_TYPE = ConfigDef.Type.STRING;
+  private static final ConfigDef.Importance CONFIG_PRESET_IMPORTANCE = ConfigDef.Importance.LOW;
+  private static final String CONFIG_PRESET_DOC = "Configuration preset (e.g. debezium_cdc).";
   public static final String MERGE_INTERVAL_MS_CONFIG = "mergeIntervalMs";
   public static final String MERGE_RECORDS_THRESHOLD_CONFIG = "mergeRecordsThreshold";
   public static final long MERGE_INTERVAL_MS_DEFAULT = 60_000L;
@@ -1062,6 +1074,18 @@ public class BigQuerySinkConfig extends AbstractConfig {
             TABLE_MAX_STALENESS_IMPORTANCE,
             TABLE_MAX_STALENESS_DOC)
         .define(
+            IS_CDC_ENABLED_CONFIG,
+            IS_CDC_ENABLED_TYPE,
+            IS_CDC_ENABLED_DEFAULT,
+            IS_CDC_ENABLED_IMPORTANCE,
+            IS_CDC_ENABLED_DOC)
+        .define(
+            CONFIG_PRESET_CONFIG,
+            CONFIG_PRESET_TYPE,
+            CONFIG_PRESET_DEFAULT,
+            CONFIG_PRESET_IMPORTANCE,
+            CONFIG_PRESET_DOC)
+        .define(
             INTERMEDIATE_TABLE_SUFFIX_CONFIG,
             INTERMEDIATE_TABLE_SUFFIX_TYPE,
             INTERMEDIATE_TABLE_SUFFIX_DEFAULT,
@@ -1511,8 +1535,19 @@ public class BigQuerySinkConfig extends AbstractConfig {
     return Optional.ofNullable(getInt(TABLE_MAX_STALENESS_CONFIG));
   }
 
+  /**
+   * Determines if CDC is enabled either explicitly via isCdcEnabled or via
+   * configPreset=debezium_cdc.
+   *
+   * @return {@code true} if CDC is enabled.
+   */
+  public boolean isCdcEnabled() {
+    return getBoolean(IS_CDC_ENABLED_CONFIG)
+        || "debezium_cdc".equalsIgnoreCase(getString(CONFIG_PRESET_CONFIG));
+  }
+
   public boolean isUpsertDeleteEnabled() {
-    return getBoolean(UPSERT_ENABLED_CONFIG) || getBoolean(DELETE_ENABLED_CONFIG);
+    return getBoolean(UPSERT_ENABLED_CONFIG) || getBoolean(DELETE_ENABLED_CONFIG) || isCdcEnabled();
   }
 
   /**
@@ -1521,7 +1556,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
    * @return {@code true} if upsert is enabled.
    */
   public boolean isUpsertEnabled() {
-    return getBoolean(UPSERT_ENABLED_CONFIG);
+    return getBoolean(UPSERT_ENABLED_CONFIG) || isCdcEnabled();
   }
 
   /**
@@ -1530,7 +1565,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
    * @return {@code true} if delete is enabled.
    */
   public boolean isDeleteEnabled() {
-    return getBoolean(DELETE_ENABLED_CONFIG);
+    return getBoolean(DELETE_ENABLED_CONFIG) || isCdcEnabled();
   }
 
   /**

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -163,6 +163,14 @@ public class BigQuerySinkConfig extends AbstractConfig {
   public static final String TABLE_MAX_STALENESS_CONFIG = "tableMaxStaleness";
   public static final Integer TABLE_MAX_STALENESS_DEFAULT = null;
   private static final ConfigDef.Type TABLE_MAX_STALENESS_TYPE = ConfigDef.Type.INT;
+  private static final ConfigDef.Validator TABLE_MAX_STALENESS_VALIDATOR =
+      ConfigDef.LambdaValidator.with(
+          (name, value) -> {
+            if (value != null) {
+              ConfigDef.Range.atLeast(0).ensureValid(name, value);
+            }
+          },
+          () -> "if set the value must be at least 0");
   private static final ConfigDef.Importance TABLE_MAX_STALENESS_IMPORTANCE =
       ConfigDef.Importance.MEDIUM;
   private static final String TABLE_MAX_STALENESS_DOC =
@@ -1050,6 +1058,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
             TABLE_MAX_STALENESS_CONFIG,
             TABLE_MAX_STALENESS_TYPE,
             TABLE_MAX_STALENESS_DEFAULT,
+            TABLE_MAX_STALENESS_VALIDATOR,
             TABLE_MAX_STALENESS_IMPORTANCE,
             TABLE_MAX_STALENESS_DOC)
         .define(

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -160,6 +160,14 @@ public class BigQuerySinkConfig extends AbstractConfig {
   public static final boolean DELETE_ENABLED_DEFAULT = false;
   public static final String INTERMEDIATE_TABLE_SUFFIX_CONFIG = "intermediateTableSuffix";
   public static final String INTERMEDIATE_TABLE_SUFFIX_DEFAULT = "tmp";
+  public static final String TABLE_MAX_STALENESS_CONFIG = "tableMaxStaleness";
+  public static final Integer TABLE_MAX_STALENESS_DEFAULT = null;
+  private static final ConfigDef.Type TABLE_MAX_STALENESS_TYPE = ConfigDef.Type.INT;
+  private static final ConfigDef.Importance TABLE_MAX_STALENESS_IMPORTANCE =
+      ConfigDef.Importance.MEDIUM;
+  private static final String TABLE_MAX_STALENESS_DOC =
+      "The maximum staleness allowed for the destination BigQuery table in seconds. "
+          + "Only applicable if upsert/delete (CDC) is enabled with the Storage Write API.";
   public static final String MERGE_INTERVAL_MS_CONFIG = "mergeIntervalMs";
   public static final String MERGE_RECORDS_THRESHOLD_CONFIG = "mergeRecordsThreshold";
   public static final long MERGE_INTERVAL_MS_DEFAULT = 60_000L;
@@ -1039,6 +1047,12 @@ public class BigQuerySinkConfig extends AbstractConfig {
                     KAFKA_KEY_FIELD_NAME_CONFIG)
                 .build())
         .define(
+            TABLE_MAX_STALENESS_CONFIG,
+            TABLE_MAX_STALENESS_TYPE,
+            TABLE_MAX_STALENESS_DEFAULT,
+            TABLE_MAX_STALENESS_IMPORTANCE,
+            TABLE_MAX_STALENESS_DOC)
+        .define(
             INTERMEDIATE_TABLE_SUFFIX_CONFIG,
             INTERMEDIATE_TABLE_SUFFIX_TYPE,
             INTERMEDIATE_TABLE_SUFFIX_DEFAULT,
@@ -1482,6 +1496,14 @@ public class BigQuerySinkConfig extends AbstractConfig {
    */
   public Optional<String> getKafkaDataFieldName() {
     return Optional.ofNullable(getString(KAFKA_DATA_FIELD_NAME_CONFIG));
+  }
+
+  public Optional<Integer> getTableMaxStaleness() {
+    return Optional.ofNullable(getInt(TABLE_MAX_STALENESS_CONFIG));
+  }
+
+  public boolean isUpsertDeleteEnabled() {
+    return getBoolean(UPSERT_ENABLED_CONFIG) || getBoolean(DELETE_ENABLED_CONFIG);
   }
 
   /**

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -55,7 +55,6 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
@@ -1511,13 +1510,19 @@ public class BigQuerySinkConfig extends AbstractConfig {
    * @return Field name of Kafka Key to be used in BigQuery
    */
   public Optional<String> getKafkaKeyFieldName() {
-    String value = getString(KAFKA_KEY_FIELD_NAME_CONFIG);
-    if (StringUtils.isBlank(value)
-        && (isUpsertEnabled() || isDeleteEnabled())
-        && useStorageWriteApi()) {
+    if (isCdcEnabled()) {
+      String value = getString(KAFKA_KEY_FIELD_NAME_CONFIG);
+      if (value != null && !value.trim().isEmpty()) {
+        logger.warn(
+            "{} is configured as '{}', but it will be ignored because CDC upsert/delete with "
+                + "Storage Write API requires Kafka keys to be flattened into root schema columns "
+                + "for BigQuery primary keys.",
+            KAFKA_KEY_FIELD_NAME_CONFIG,
+            value);
+      }
       return Optional.of("");
     }
-    return Optional.ofNullable(value);
+    return Optional.ofNullable(getString(KAFKA_KEY_FIELD_NAME_CONFIG));
   }
 
   /**
@@ -1536,18 +1541,30 @@ public class BigQuerySinkConfig extends AbstractConfig {
   }
 
   /**
-   * Determines if CDC is enabled either explicitly via isCdcEnabled or via
+   * Determines if CDC is configured either explicitly via isCdcEnabled or via
    * configPreset=debezium_cdc.
    *
-   * @return {@code true} if CDC is enabled.
+   * @return {@code true} if CDC is configured.
    */
-  public boolean isCdcEnabled() {
+  public boolean isCdcConfigured() {
     return getBoolean(IS_CDC_ENABLED_CONFIG)
         || "debezium_cdc".equalsIgnoreCase(getString(CONFIG_PRESET_CONFIG));
   }
 
+  /**
+   * Determines if BigQuery CDC ingestion is enabled (i.e. Storage Write API is used and upsert or
+   * delete is enabled).
+   *
+   * @return {@code true} if CDC is enabled with Storage Write API.
+   */
+  public boolean isCdcEnabled() {
+    return useStorageWriteApi() && isUpsertDeleteEnabled();
+  }
+
   public boolean isUpsertDeleteEnabled() {
-    return getBoolean(UPSERT_ENABLED_CONFIG) || getBoolean(DELETE_ENABLED_CONFIG) || isCdcEnabled();
+    return getBoolean(UPSERT_ENABLED_CONFIG)
+        || getBoolean(DELETE_ENABLED_CONFIG)
+        || isCdcConfigured();
   }
 
   /**
@@ -1556,7 +1573,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
    * @return {@code true} if upsert is enabled.
    */
   public boolean isUpsertEnabled() {
-    return getBoolean(UPSERT_ENABLED_CONFIG) || isCdcEnabled();
+    return getBoolean(UPSERT_ENABLED_CONFIG) || isCdcConfigured();
   }
 
   /**
@@ -1565,7 +1582,7 @@ public class BigQuerySinkConfig extends AbstractConfig {
    * @return {@code true} if delete is enabled.
    */
   public boolean isDeleteEnabled() {
-    return getBoolean(DELETE_ENABLED_CONFIG) || isCdcEnabled();
+    return getBoolean(DELETE_ENABLED_CONFIG) || isCdcConfigured();
   }
 
   /**

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
@@ -113,6 +113,7 @@ public class BigQuerySchemaConverter implements SchemaConverter<com.google.cloud
 
     List<com.google.cloud.bigquery.Field> fields =
         kafkaConnectSchema.fields().stream()
+            .filter(kafkaConnectField -> !kafkaConnectField.name().equals("__deleted"))
             .flatMap(
                 kafkaConnectField ->
                     convertField(kafkaConnectField.schema(), kafkaConnectField.name())
@@ -213,6 +214,7 @@ public class BigQuerySchemaConverter implements SchemaConverter<com.google.cloud
       Schema kafkaConnectSchema, String fieldName) {
     List<com.google.cloud.bigquery.Field> bigQueryRecordFields =
         kafkaConnectSchema.fields().stream()
+            .filter(kafkaConnectField -> !kafkaConnectField.name().equals("__deleted"))
             .flatMap(
                 kafkaConnectField ->
                     convertField(kafkaConnectField.schema(), kafkaConnectField.name())

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/convert/BigQuerySchemaConverter.java
@@ -51,6 +51,9 @@ public class BigQuerySchemaConverter implements SchemaConverter<com.google.cloud
   /** The name of the field that contains values keys from a converted Kafka Connect map. */
   public static final String MAP_VALUE_FIELD_NAME = "value";
 
+  /** The name of the Debezium pseudo column representing whether a row is deleted. */
+  public static final String DELETED_PSEUDO_COLUMN = "__deleted";
+
   private static final Map<Schema.Type, LegacySQLTypeName> PRIMITIVE_TYPE_MAP;
 
   static {
@@ -113,7 +116,7 @@ public class BigQuerySchemaConverter implements SchemaConverter<com.google.cloud
 
     List<com.google.cloud.bigquery.Field> fields =
         kafkaConnectSchema.fields().stream()
-            .filter(kafkaConnectField -> !kafkaConnectField.name().equals("__deleted"))
+            .filter(kafkaConnectField -> !DELETED_PSEUDO_COLUMN.equals(kafkaConnectField.name()))
             .flatMap(
                 kafkaConnectField ->
                     convertField(kafkaConnectField.schema(), kafkaConnectField.name())
@@ -214,7 +217,7 @@ public class BigQuerySchemaConverter implements SchemaConverter<com.google.cloud
       Schema kafkaConnectSchema, String fieldName) {
     List<com.google.cloud.bigquery.Field> bigQueryRecordFields =
         kafkaConnectSchema.fields().stream()
-            .filter(kafkaConnectField -> !kafkaConnectField.name().equals("__deleted"))
+            .filter(kafkaConnectField -> !DELETED_PSEUDO_COLUMN.equals(kafkaConnectField.name()))
             .flatMap(
                 kafkaConnectField ->
                     convertField(kafkaConnectField.schema(), kafkaConnectField.name())

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverter.java
@@ -189,6 +189,12 @@ public final class SinkRecordConverter {
    * @return the map of fields to values.
    */
   public Map<String, Object> getRegularRow(SinkRecord record, String writeAttemptId) {
+    logger.info(
+        "getRegularRow INPUT - Topic: {}, Offset: {}, Value: {}",
+        record.topic(),
+        record.kafkaOffset(),
+        record.value());
+
     // if delete is enabled and there is a null value then the record was deleted.  In other cases a
     // null value may be appropriate and the converter will determine if there are any issues.
     Map<String, Object> result =
@@ -214,7 +220,100 @@ public final class SinkRecordConverter {
               }
             });
 
+    logger.info(
+        "getRegularRow OUTPUT - Topic: {}, Offset: {}, Result Map: {}",
+        record.topic(),
+        record.kafkaOffset(),
+        result);
     return maybeSanitize(result);
+  }
+
+  public Map<String, Object> getCdcRow(SinkRecord record) {
+    return getCdcRow(record, currentPutAttemptId);
+  }
+
+  public Map<String, Object> getCdcRow(SinkRecord record, String writeAttemptId) {
+    logger.info(
+        "getCdcRow INPUT - Topic: {}, Offset: {}, Key: {}, Value: {}",
+        record.topic(),
+        record.kafkaOffset(),
+        record.key(),
+        record.value());
+    Map<String, Object> result = new HashMap<>();
+
+    // 1. Extract the Key fields
+    Map<String, Object> convertedKey =
+        recordConverter.convertRecord(record, KafkaSchemaRecordType.KEY);
+    if (convertedKey != null) {
+      result.putAll(convertedKey);
+    } else if (record.value() == null) {
+      // If the value is null, it's a DELETE. We cannot delete a row if we don't know
+      // its key!
+      throw new ConnectException("Record keys must be non-null when upsert/delete is enabled");
+    }
+
+    // 2. Extract the Value fields (only if it's not a tombstone record)
+    Map<String, Object> convertedValue = null;
+    if (record.value() != null) {
+      convertedValue = recordConverter.convertRecord(record, KafkaSchemaRecordType.VALUE);
+      if (convertedValue != null) {
+        result.putAll(convertedValue); // Merges value fields into the root of the map
+      }
+    }
+
+    // 3. Optional Kafka metadata (e.g. insert time, topic, partition, offset)
+    config
+        .getKafkaDataFieldName()
+        .ifPresent(
+            fieldName -> {
+              Map<String, Object> kafkaDataField = buildKafkaDataRecord(record, writeAttemptId);
+              result.put(fieldName, kafkaDataField);
+            });
+
+    // 4. Set the CDC metadata columns
+    String changeType = "UPSERT";
+    if (record.value() == null) {
+      logger.info(
+          "Tombstone record (null value) detected for key {} at offset {}",
+          record.key(),
+          record.kafkaOffset());
+      changeType = "DELETE";
+    } else if (convertedValue != null) {
+      Object deletedVal = convertedValue.get("__deleted");
+      if (deletedVal instanceof Boolean && (Boolean) deletedVal) {
+        changeType = "DELETE";
+      } else if (deletedVal instanceof String && Boolean.parseBoolean((String) deletedVal)) {
+        changeType = "DELETE";
+      }
+    }
+    result.put("_CHANGE_TYPE", changeType);
+    // Strip the transient __deleted metadata field to prevent BigQuery ingestion crashes due to
+    // unknown fields.
+    result.remove("__deleted");
+    // For PR 1: Default Kafka Offset Sequencing (Zero-Padded to 20 digits for BigQuery
+    // Lexicographical Sorting)
+    result.put("_CHANGE_SEQUENCE_NUMBER", String.format("%016X", record.kafkaOffset()));
+
+    logger.info(
+        "getCdcRow OUTPUT - Topic: {}, Offset: {}, Result Map: {}",
+        record.topic(),
+        record.kafkaOffset(),
+        result);
+
+    // 5. Sanitize column names if the user turned on the sanitize option (replacing
+    // spaces/special characters)
+    return maybeSanitize(result);
+  }
+
+  public boolean isCdcEnabled() {
+    boolean enabled =
+        config.getBoolean(config.USE_STORAGE_WRITE_API_CONFIG) && config.isUpsertDeleteEnabled();
+    logger.info(
+        "isCdcEnabled check - USE_STORAGE_WRITE_API: {}, isUpsertDeleteEnabled: {}, Result: {}",
+        config.getBoolean(config.USE_STORAGE_WRITE_API_CONFIG),
+        config.isUpsertDeleteEnabled(),
+        enabled);
+    return enabled;
   }
 
   /**

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverter.java
@@ -30,6 +30,7 @@ import com.wepay.kafka.connect.bigquery.MergeQueries;
 import com.wepay.kafka.connect.bigquery.SchemaManager;
 import com.wepay.kafka.connect.bigquery.api.KafkaSchemaRecordType;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
+import com.wepay.kafka.connect.bigquery.convert.BigQuerySchemaConverter;
 import com.wepay.kafka.connect.bigquery.convert.RecordConverter;
 import com.wepay.kafka.connect.bigquery.write.batch.MergeBatches;
 import java.util.HashMap;
@@ -46,6 +47,12 @@ import org.slf4j.LoggerFactory;
  */
 public final class SinkRecordConverter {
   private static final Logger logger = LoggerFactory.getLogger(SinkRecordConverter.class);
+
+  public static final String CDC_CHANGE_TYPE_FIELD = "_CHANGE_TYPE";
+  public static final String CDC_CHANGE_SEQUENCE_NUMBER_FIELD = "_CHANGE_SEQUENCE_NUMBER";
+  public static final String CDC_CHANGE_TYPE_UPSERT = "UPSERT";
+  public static final String CDC_CHANGE_TYPE_DELETE = "DELETE";
+  public static final String DELETED_PSEUDO_COLUMN = BigQuerySchemaConverter.DELETED_PSEUDO_COLUMN;
 
   private final BigQuerySinkConfig config;
   private final MergeBatches mergeBatches;
@@ -189,7 +196,7 @@ public final class SinkRecordConverter {
    * @return the map of fields to values.
    */
   public Map<String, Object> getRegularRow(SinkRecord record, String writeAttemptId) {
-    logger.info(
+    logger.trace(
         "getRegularRow INPUT - Topic: {}, Offset: {}, Value: {}",
         record.topic(),
         record.kafkaOffset(),
@@ -220,7 +227,7 @@ public final class SinkRecordConverter {
               }
             });
 
-    logger.info(
+    logger.trace(
         "getRegularRow OUTPUT - Topic: {}, Offset: {}, Result Map: {}",
         record.topic(),
         record.kafkaOffset(),
@@ -233,7 +240,7 @@ public final class SinkRecordConverter {
   }
 
   public Map<String, Object> getCdcRow(SinkRecord record, String writeAttemptId) {
-    logger.info(
+    logger.trace(
         "getCdcRow INPUT - Topic: {}, Offset: {}, Key: {}, Value: {}",
         record.topic(),
         record.kafkaOffset(),
@@ -271,30 +278,32 @@ public final class SinkRecordConverter {
             });
 
     // 4. Set the CDC metadata columns
-    String changeType = "UPSERT";
+    String changeType = CDC_CHANGE_TYPE_UPSERT;
     if (record.value() == null) {
-      logger.info(
+      logger.debug(
           "Tombstone record (null value) detected for key {} at offset {}",
           record.key(),
           record.kafkaOffset());
-      changeType = "DELETE";
+      changeType = CDC_CHANGE_TYPE_DELETE;
     } else if (convertedValue != null) {
-      Object deletedVal = convertedValue.get("__deleted");
+      Object deletedVal = convertedValue.get(DELETED_PSEUDO_COLUMN);
       if (deletedVal instanceof Boolean && (Boolean) deletedVal) {
-        changeType = "DELETE";
+        changeType = CDC_CHANGE_TYPE_DELETE;
       } else if (deletedVal instanceof String && Boolean.parseBoolean((String) deletedVal)) {
-        changeType = "DELETE";
+        changeType = CDC_CHANGE_TYPE_DELETE;
       }
     }
-    result.put("_CHANGE_TYPE", changeType);
+    result.put(CDC_CHANGE_TYPE_FIELD, changeType);
     // Strip the transient __deleted metadata field to prevent BigQuery ingestion crashes due to
     // unknown fields.
-    result.remove("__deleted");
-    // For PR 1: Default Kafka Offset Sequencing (Zero-Padded to 20 digits for BigQuery
+    result.remove(DELETED_PSEUDO_COLUMN);
+    // For PR 1: Default Kafka Partition/Offset Composite Sequencing (%08X/%016X for BigQuery
     // Lexicographical Sorting)
-    result.put("_CHANGE_SEQUENCE_NUMBER", String.format("%016X", record.kafkaOffset()));
+    result.put(
+        CDC_CHANGE_SEQUENCE_NUMBER_FIELD,
+        String.format("%08X/%016X", record.kafkaPartition(), record.kafkaOffset()));
 
-    logger.info(
+    logger.trace(
         "getCdcRow OUTPUT - Topic: {}, Offset: {}, Result Map: {}",
         record.topic(),
         record.kafkaOffset(),
@@ -308,7 +317,7 @@ public final class SinkRecordConverter {
   public boolean isCdcEnabled() {
     boolean enabled =
         config.getBoolean(config.USE_STORAGE_WRITE_API_CONFIG) && config.isUpsertDeleteEnabled();
-    logger.info(
+    logger.trace(
         "isCdcEnabled check - USE_STORAGE_WRITE_API: {}, isUpsertDeleteEnabled: {}, Result: {}",
         config.getBoolean(config.USE_STORAGE_WRITE_API_CONFIG),
         config.isUpsertDeleteEnabled(),

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverter.java
@@ -246,9 +246,9 @@ public final class SinkRecordConverter {
   }
 
   /**
-   * Converts a SinkRecord to a CDC row using the specified writeAttemptId.
-   * Extracts both Key fields (as primary key columns) and Value fields, handles
-   * tombstone records for deletes, and adds Kafka metadata fields if configured.
+   * Converts a SinkRecord to a CDC row using the specified writeAttemptId. Extracts both Key fields
+   * (as primary key columns) and Value fields, handles tombstone records for deletes, and adds
+   * Kafka metadata fields if configured.
    *
    * @param record the record to convert.
    * @param writeAttemptId the write attempt id to use.
@@ -312,11 +312,15 @@ public final class SinkRecordConverter {
     // Strip the transient __deleted metadata field to prevent BigQuery ingestion crashes due to
     // unknown fields.
     result.remove(DELETED_PSEUDO_COLUMN);
-    // For PR 1: Default Kafka Partition/Offset Composite Sequencing (%08X/%016X for BigQuery
-    // Lexicographical Sorting)
+    // Default: Kafka Record Timestamp, followed by Offset, followed by Partition
+    Long recordTimestamp = record.timestamp();
+    long ts =
+        (recordTimestamp != null && recordTimestamp >= 0)
+            ? recordTimestamp
+            : System.currentTimeMillis();
     result.put(
         CDC_CHANGE_SEQUENCE_NUMBER_FIELD,
-        String.format("%08X/%016X", record.kafkaPartition(), record.kafkaOffset()));
+        String.format("%016X/%016X/%08X", ts, record.kafkaOffset(), record.kafkaPartition()));
 
     logger.trace(
         "getCdcRow OUTPUT - Topic: {}, Offset: {}, Result Map: {}",

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverter.java
@@ -235,10 +235,25 @@ public final class SinkRecordConverter {
     return maybeSanitize(result);
   }
 
+  /**
+   * Converts a SinkRecord to a CDC row using the shared {@code currentPutAttemptId}.
+   *
+   * @param record the record to convert.
+   * @return the map of fields to values representing the CDC row.
+   */
   public Map<String, Object> getCdcRow(SinkRecord record) {
     return getCdcRow(record, currentPutAttemptId);
   }
 
+  /**
+   * Converts a SinkRecord to a CDC row using the specified writeAttemptId.
+   * Extracts both Key fields (as primary key columns) and Value fields, handles
+   * tombstone records for deletes, and adds Kafka metadata fields if configured.
+   *
+   * @param record the record to convert.
+   * @param writeAttemptId the write attempt id to use.
+   * @return the map of fields to values representing the CDC row.
+   */
   public Map<String, Object> getCdcRow(SinkRecord record, String writeAttemptId) {
     logger.trace(
         "getCdcRow INPUT - Topic: {}, Offset: {}, Key: {}, Value: {}",

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverter.java
@@ -314,10 +314,7 @@ public final class SinkRecordConverter {
     result.remove(DELETED_PSEUDO_COLUMN);
     // Default: Kafka Record Timestamp, followed by Offset, followed by Partition
     Long recordTimestamp = record.timestamp();
-    long ts =
-        (recordTimestamp != null && recordTimestamp >= 0)
-            ? recordTimestamp
-            : System.currentTimeMillis();
+    long ts = (recordTimestamp != null && recordTimestamp >= 0) ? recordTimestamp : 0L;
     result.put(
         CDC_CHANGE_SEQUENCE_NUMBER_FIELD,
         String.format("%016X/%016X/%08X", ts, record.kafkaOffset(), record.kafkaPartition()));

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverter.java
@@ -331,13 +331,8 @@ public final class SinkRecordConverter {
   }
 
   public boolean isCdcEnabled() {
-    boolean enabled =
-        config.getBoolean(config.USE_STORAGE_WRITE_API_CONFIG) && config.isUpsertDeleteEnabled();
-    logger.trace(
-        "isCdcEnabled check - USE_STORAGE_WRITE_API: {}, isUpsertDeleteEnabled: {}, Result: {}",
-        config.getBoolean(config.USE_STORAGE_WRITE_API_CONFIG),
-        config.isUpsertDeleteEnabled(),
-        enabled);
+    boolean enabled = config.isCdcEnabled();
+    logger.trace("isCdcEnabled check - Result: {}", enabled);
     return enabled;
   }
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBase.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBase.java
@@ -75,8 +75,10 @@ public abstract class StorageWriteApiBase {
   /** The requried suffix for default streams. */
   private static final String DEFAULT_STREAM_NAME_SUFFIX = "/_default";
 
-  protected static final String CHANGE_TYPE_PSEUDO_COLUMN = "_CHANGE_TYPE";
-  protected static final String CHANGE_SEQUENCE_NUMBER_PSEUDO_COLUMN = "_CHANGE_SEQUENCE_NUMBER";
+  protected static final String CHANGE_TYPE_PSEUDO_COLUMN =
+      SinkRecordConverter.CDC_CHANGE_TYPE_FIELD;
+  protected static final String CHANGE_SEQUENCE_NUMBER_PSEUDO_COLUMN =
+      SinkRecordConverter.CDC_CHANGE_SEQUENCE_NUMBER_FIELD;
   private static final double RETRY_DELAY_MULTIPLIER = 1.1;
   private static final int MAX_RETRY_DELAY_MINUTES = 1;
   public static final String TRACE_ID_FORMAT = "AivenKafkaConnector:%s";

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBase.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBase.java
@@ -87,8 +87,11 @@ public abstract class StorageWriteApiBase {
   private final boolean ignoreUnknownFields;
   private final BigQueryWriteSettings writeSettings;
   private final boolean attemptSchemaUpdate;
+
+  protected final boolean isCdcEnabled;
   protected final boolean upsertEnabled;
   protected final boolean deleteEnabled;
+
   protected SchemaManager schemaManager;
   @VisibleForTesting protected Time time;
   ErrantRecordHandler errantRecordHandler;
@@ -122,6 +125,9 @@ public abstract class StorageWriteApiBase {
     this.upsertEnabled = config.isUpsertEnabled();
     this.deleteEnabled = config.isDeleteEnabled();
     this.ignoreUnknownFields = config.isIgnoreUnknownFields();
+    this.isCdcEnabled =
+        config.getBoolean(BigQuerySinkConfig.USE_STORAGE_WRITE_API_CONFIG)
+            && config.isUpsertDeleteEnabled();
     try {
       this.writeClient = getWriteClient();
     } catch (IOException e) {
@@ -164,6 +170,7 @@ public abstract class StorageWriteApiBase {
     this.schemaManager = schemaManager;
     this.attemptSchemaUpdate = attemptSchemaUpdate;
     this.ignoreUnknownFields = false;
+    this.isCdcEnabled = false;
     this.upsertEnabled = false;
     this.deleteEnabled = false;
     try {
@@ -236,6 +243,8 @@ public abstract class StorageWriteApiBase {
       String streamName,
       SinkRecordConverter recordConverter,
       Supplier<String> ulidSupplier) {
+    schemaManager.checkAndApplyTableOptions(table.getBaseTableId());
+
     TableName tableName = TableNameUtils.tableName(table.getFullTableId());
     StorageWriteApiRetryHandler retryHandler =
         new StorageWriteApiRetryHandler(
@@ -489,7 +498,7 @@ public abstract class StorageWriteApiBase {
   private TableSchema getTableSchemaWithPseudoColumns(String streamName) {
     try {
       TableSchema.Builder schemaBuilder = createTableSchemaBuilder(streamName);
-      if (upsertEnabled || deleteEnabled) {
+      if (upsertEnabled || deleteEnabled || isCdcEnabled) {
         addUpsertDeletePseudoColumns(schemaBuilder);
       }
       return schemaBuilder.build();
@@ -515,7 +524,7 @@ public abstract class StorageWriteApiBase {
             .build();
     return streamOrTableName -> {
       JsonStreamWriter.Builder builder;
-      if (upsertEnabled || deleteEnabled) {
+      if (upsertEnabled || deleteEnabled || isCdcEnabled) {
         String streamNameForSchema = streamOrTableName;
         if (!streamNameForSchema.contains(DEFAULT_STREAM_NAME_TRIGGER)) {
           streamNameForSchema += DEFAULT_STREAM_NAME_SUFFIX;
@@ -672,15 +681,21 @@ public abstract class StorageWriteApiBase {
       JSONObject converted = item.converted();
       if ((item.original().value() != null && upsertEnabled)
           || (item.original().value() == null && deleteEnabled)) {
-        Long timestamp = item.original().timestamp();
-        long ts = (timestamp != null && timestamp >= 0) ? timestamp : 0L;
-        String sequenceNumber =
-            String.format(
-                "%016X/%08X/%016X",
-                ts, item.original().kafkaPartition(), item.original().kafkaOffset());
-        converted.put(
-            CHANGE_TYPE_PSEUDO_COLUMN, item.original().value() != null ? "UPSERT" : "DELETE");
-        converted.put(CHANGE_SEQUENCE_NUMBER_PSEUDO_COLUMN, sequenceNumber);
+
+        if (!converted.has(CHANGE_TYPE_PSEUDO_COLUMN)) {
+          converted.put(
+              CHANGE_TYPE_PSEUDO_COLUMN, item.original().value() != null ? "UPSERT" : "DELETE");
+        }
+
+        if (!converted.has(CHANGE_SEQUENCE_NUMBER_PSEUDO_COLUMN)) {
+          Long timestamp = item.original().timestamp();
+          long ts = (timestamp != null && timestamp >= 0) ? timestamp : 0L;
+          String sequenceNumber =
+              String.format(
+                  "%016X/%08X/%016X",
+                  ts, item.original().kafkaPartition(), item.original().kafkaOffset());
+          converted.put(CHANGE_SEQUENCE_NUMBER_PSEUDO_COLUMN, sequenceNumber);
+        }
       }
       jsonRecords.put(converted);
     }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBase.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBase.java
@@ -677,7 +677,8 @@ public abstract class StorageWriteApiBase {
     return jsonObject;
   }
 
-  private JSONArray getJsonRecords(List<ConvertedRecord> rows) {
+  @VisibleForTesting
+  JSONArray getJsonRecords(List<ConvertedRecord> rows) {
     JSONArray jsonRecords = new JSONArray();
     for (ConvertedRecord item : rows) {
       JSONObject converted = item.converted();
@@ -694,8 +695,8 @@ public abstract class StorageWriteApiBase {
           long ts = (timestamp != null && timestamp >= 0) ? timestamp : 0L;
           String sequenceNumber =
               String.format(
-                  "%016X/%08X/%016X",
-                  ts, item.original().kafkaPartition(), item.original().kafkaOffset());
+                  "%016X/%016X/%08X",
+                  ts, item.original().kafkaOffset(), item.original().kafkaPartition());
           converted.put(CHANGE_SEQUENCE_NUMBER_PSEUDO_COLUMN, sequenceNumber);
         }
       }

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBase.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBase.java
@@ -55,6 +55,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -122,14 +123,12 @@ public abstract class StorageWriteApiBase {
     this.autoCreateTables = autoCreateTables;
     this.writeSettings = writeSettings;
     this.errantRecordHandler = errantRecordHandler;
-    this.schemaManager = schemaManager;
+    this.schemaManager = Objects.requireNonNull(schemaManager, "schemaManager cannot be null");
     this.attemptSchemaUpdate = attemptSchemaUpdate;
     this.upsertEnabled = config.isUpsertEnabled();
     this.deleteEnabled = config.isDeleteEnabled();
     this.ignoreUnknownFields = config.isIgnoreUnknownFields();
-    this.isCdcEnabled =
-        config.getBoolean(BigQuerySinkConfig.USE_STORAGE_WRITE_API_CONFIG)
-            && config.isUpsertDeleteEnabled();
+    this.isCdcEnabled = config.isCdcEnabled();
     try {
       this.writeClient = getWriteClient();
     } catch (IOException e) {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiWriter.java
@@ -178,7 +178,10 @@ public class StorageWriteApiWriter implements Runnable {
      * @return converted record as JSONObject
      */
     private JSONObject convertRecord(SinkRecord record) {
-      Map<String, Object> convertedRecord = recordConverter.getRegularRow(record);
+      Map<String, Object> convertedRecord =
+          recordConverter.isCdcEnabled()
+              ? recordConverter.getCdcRow(record)
+              : recordConverter.getRegularRow(record);
       return StorageWriteApiBase.getJsonFromMap(convertedRecord);
     }
 

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
@@ -23,6 +23,7 @@
 
 package com.wepay.kafka.connect.bigquery;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -1659,6 +1660,30 @@ public class SchemaManagerTest {
     schemaManager.checkAndApplyTableOptions(tableId);
     verify(mockBigQuery, org.mockito.Mockito.never())
         .query(any(com.google.cloud.bigquery.QueryJobConfiguration.class));
+  }
+
+  @Test
+  public void testCreateTableWithPrimitiveKeySchema() {
+    SchemaManagerTestConfig config = createConfig(Collections.emptyMap());
+    config.schemaConverter = mockSchemaConverter;
+    SchemaManager schemaManager = new SchemaManager(config, mockBigQuery);
+
+    SinkRecord record =
+        new SinkRecord(
+            "test_topic",
+            0,
+            org.apache.kafka.connect.data.Schema.INT64_SCHEMA,
+            123L,
+            mockKafkaSchema,
+            null,
+            0);
+
+    when(mockSchemaRetriever.retrieveKeySchema(record))
+        .thenReturn(org.apache.kafka.connect.data.Schema.INT64_SCHEMA);
+    when(mockSchemaConverter.convertSchema(mockKafkaSchema)).thenReturn(fakeBigQuerySchema);
+    when(mockBigQuery.create(any(TableInfo.class))).thenReturn(mock(Table.class));
+
+    assertDoesNotThrow(() -> schemaManager.createTable(tableId, Collections.singletonList(record)));
   }
 
   static class SchemaManagerTestConfig extends BigQuerySinkConfig {

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
@@ -1619,6 +1619,48 @@ public class SchemaManagerTest {
     }
   }
 
+  @Test
+  public void testCheckAndApplyTableOptions() throws Exception {
+    int maxStalenessSeconds = 0;
+    SchemaManagerTestConfig config =
+        createConfig(
+            Map.of(
+                BigQuerySinkConfig.TABLE_MAX_STALENESS_CONFIG,
+                Integer.toString(maxStalenessSeconds)));
+    config.schemaConverter = mockSchemaConverter;
+    SchemaManager schemaManager = new SchemaManager(config, mockBigQuery);
+
+    Table mockTable = mock(Table.class);
+    when(mockBigQuery.getTable(tableId)).thenReturn(mockTable);
+
+    com.google.cloud.bigquery.TableResult mockResult =
+        mock(com.google.cloud.bigquery.TableResult.class);
+    when(mockBigQuery.query(any(com.google.cloud.bigquery.QueryJobConfiguration.class)))
+        .thenReturn(mockResult);
+
+    // 1. First invocation: should execute the query
+    schemaManager.checkAndApplyTableOptions(tableId);
+
+    String expectedQuery =
+        String.format(
+            "ALTER TABLE `%s`.`%s` SET OPTIONS (max_staleness = INTERVAL %d SECOND)",
+            tableId.getDataset(), tableId.getTable(), maxStalenessSeconds);
+
+    ArgumentCaptor<com.google.cloud.bigquery.QueryJobConfiguration> captor =
+        ArgumentCaptor.forClass(com.google.cloud.bigquery.QueryJobConfiguration.class);
+    verify(mockBigQuery, times(2)).query(captor.capture());
+    assertEquals(expectedQuery, captor.getValue().getQuery());
+
+    // Reset mock for next assertion
+    org.mockito.Mockito.clearInvocations(mockBigQuery);
+    when(mockBigQuery.getTable(tableId)).thenReturn(mockTable);
+
+    // 2. Second invocation: should skip query execution (deduped via checkedTableOptions)
+    schemaManager.checkAndApplyTableOptions(tableId);
+    verify(mockBigQuery, org.mockito.Mockito.never())
+        .query(any(com.google.cloud.bigquery.QueryJobConfiguration.class));
+  }
+
   static class SchemaManagerTestConfig extends BigQuerySinkConfig {
 
     SchemaConverter<com.google.cloud.bigquery.Schema> schemaConverter;

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/SchemaManagerTest.java
@@ -1663,6 +1663,111 @@ public class SchemaManagerTest {
   }
 
   @Test
+  public void testCheckAndApplyTableOptions_swallows409AndConcurrentConflict()
+      throws InterruptedException {
+    int maxStalenessSeconds = 60;
+    SchemaManagerTestConfig config =
+        createConfig(
+            Map.of(
+                BigQuerySinkConfig.TABLE_MAX_STALENESS_CONFIG,
+                Integer.toString(maxStalenessSeconds)));
+    config.schemaConverter = mockSchemaConverter;
+    SchemaManager schemaManager = new SchemaManager(config, mockBigQuery);
+
+    Table mockTable = mock(Table.class);
+    when(mockBigQuery.getTable(tableId)).thenReturn(mockTable);
+
+    com.google.cloud.bigquery.TableResult mockCheckResult =
+        mock(com.google.cloud.bigquery.TableResult.class);
+    when(mockCheckResult.iterateAll()).thenReturn(Collections.emptyList());
+
+    BigQueryException conflictException = mock(BigQueryException.class);
+    when(conflictException.getCode()).thenReturn(409);
+    when(conflictException.getMessage())
+        .thenReturn("Already Exists: Table option max_staleness already set");
+
+    when(mockBigQuery.query(any(com.google.cloud.bigquery.QueryJobConfiguration.class)))
+        .thenReturn(mockCheckResult)
+        .thenThrow(conflictException);
+
+    assertDoesNotThrow(() -> schemaManager.checkAndApplyTableOptions(tableId));
+  }
+
+  @Test
+  public void testCheckAndApplyTableOptions_swallowsConcurrentDdlConflictMessage()
+      throws InterruptedException {
+    int maxStalenessSeconds = 60;
+    SchemaManagerTestConfig config =
+        createConfig(
+            Map.of(
+                BigQuerySinkConfig.TABLE_MAX_STALENESS_CONFIG,
+                Integer.toString(maxStalenessSeconds)));
+    config.schemaConverter = mockSchemaConverter;
+    SchemaManager schemaManager = new SchemaManager(config, mockBigQuery);
+
+    Table mockTable = mock(Table.class);
+    when(mockBigQuery.getTable(tableId)).thenReturn(mockTable);
+
+    com.google.cloud.bigquery.TableResult mockCheckResult =
+        mock(com.google.cloud.bigquery.TableResult.class);
+    when(mockCheckResult.iterateAll()).thenReturn(Collections.emptyList());
+
+    BigQueryException concurrentException = mock(BigQueryException.class);
+    when(concurrentException.getCode()).thenReturn(400);
+    when(concurrentException.getMessage()).thenReturn("concurrent update in progress on table");
+
+    when(mockBigQuery.query(any(com.google.cloud.bigquery.QueryJobConfiguration.class)))
+        .thenReturn(mockCheckResult)
+        .thenThrow(concurrentException);
+
+    assertDoesNotThrow(() -> schemaManager.checkAndApplyTableOptions(tableId));
+  }
+
+  @Test
+  public void testConstructTableInfo_setsPrimaryKeyConstraintsWhenCdcEnabled() {
+    SchemaManagerTestConfig config =
+        createConfig(
+            Map.of(
+                BigQuerySinkConfig.UPSERT_ENABLED_CONFIG, "true",
+                BigQuerySinkConfig.USE_STORAGE_WRITE_API_CONFIG, "true"));
+    config.schemaConverter = mockSchemaConverter;
+    SchemaManager schemaManager = new SchemaManager(config, mockBigQuery);
+
+    List<String> pkColumns = List.of("id", "tenant_id");
+    SchemaManager.SchemaAndPrimaryKeyColumns schemaAndColumns =
+        new SchemaManager.SchemaAndPrimaryKeyColumns(fakeBigQuerySchema, pkColumns);
+
+    TableInfo tableInfo =
+        schemaManager.constructTableInfo(tableId, schemaAndColumns, testDoc, true);
+    StandardTableDefinition def = (StandardTableDefinition) tableInfo.getDefinition();
+
+    assertNotNull(def.getTableConstraints());
+    assertNotNull(def.getTableConstraints().getPrimaryKey());
+    assertEquals(pkColumns, def.getTableConstraints().getPrimaryKey().getColumns());
+  }
+
+  @Test
+  public void testConstructTableInfo_noPrimaryKeyConstraintsWhenNotCdc() {
+    SchemaManagerTestConfig config =
+        createConfig(
+            Map.of(
+                BigQuerySinkConfig.UPSERT_ENABLED_CONFIG, "false",
+                BigQuerySinkConfig.USE_STORAGE_WRITE_API_CONFIG, "true"));
+    config.schemaConverter = mockSchemaConverter;
+    SchemaManager schemaManager = new SchemaManager(config, mockBigQuery);
+
+    List<String> pkColumns = List.of("id");
+    SchemaManager.SchemaAndPrimaryKeyColumns schemaAndColumns =
+        new SchemaManager.SchemaAndPrimaryKeyColumns(fakeBigQuerySchema, pkColumns);
+
+    TableInfo tableInfo =
+        schemaManager.constructTableInfo(tableId, schemaAndColumns, testDoc, true);
+    StandardTableDefinition def = (StandardTableDefinition) tableInfo.getDefinition();
+
+    assertNull(def.getTableConstraints());
+  }
+
+  @Test
   public void testCreateTableWithPrimitiveKeySchema() {
     SchemaManagerTestConfig config = createConfig(Collections.emptyMap());
     config.schemaConverter = mockSchemaConverter;

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfigTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfigTest.java
@@ -417,4 +417,25 @@ public class BigQuerySinkConfigTest {
             BigQuerySinkConfig.GCS_BUCKET_NAME_CONFIG,
             "keyfile");
   }
+
+  @Test
+  void testValidTableMaxStaleness() {
+    Map<String, String> configProperties = propertiesFactory.getProperties();
+    configProperties.put(BigQuerySinkConfig.TABLE_MAX_STALENESS_CONFIG, "30");
+
+    BigQuerySinkConfig config = new BigQuerySinkConfig(configProperties);
+    assertEquals(Optional.of(30), config.getTableMaxStaleness());
+
+    configProperties.put(BigQuerySinkConfig.TABLE_MAX_STALENESS_CONFIG, "0");
+    config = new BigQuerySinkConfig(configProperties);
+    assertEquals(Optional.of(0), config.getTableMaxStaleness());
+  }
+
+  @Test
+  void testInvalidNegativeTableMaxStaleness() {
+    Map<String, String> configProperties = propertiesFactory.getProperties();
+    configProperties.put(BigQuerySinkConfig.TABLE_MAX_STALENESS_CONFIG, "-1");
+
+    assertThrows(ConfigException.class, () -> new BigQuerySinkConfig(configProperties));
+  }
 }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfigTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfigTest.java
@@ -399,8 +399,8 @@ public class BigQuerySinkConfigTest {
         .containsExactlyInAnyOrder(
             BigQuerySinkConfig.KAFKA_KEY_FIELD_NAME_CONFIG,
             BigQuerySinkConfig.GCS_BUCKET_NAME_CONFIG,
-            "keyfile",
-            BigQuerySinkConfig.DELETE_ENABLED_CONFIG);
+            BigQuerySinkConfig.DELETE_ENABLED_CONFIG,
+            "keyfile");
   }
 
   @Test

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfigTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfigTest.java
@@ -438,4 +438,32 @@ public class BigQuerySinkConfigTest {
 
     assertThrows(ConfigException.class, () -> new BigQuerySinkConfig(configProperties));
   }
+
+  @Test
+  void testIsCdcEnabledConfig() {
+    Map<String, String> configProperties = propertiesFactory.getProperties();
+    BigQuerySinkConfig config = new BigQuerySinkConfig(configProperties);
+    assertFalse(config.isCdcEnabled());
+    assertFalse(config.isUpsertDeleteEnabled());
+    assertFalse(config.isUpsertEnabled());
+    assertFalse(config.isDeleteEnabled());
+
+    configProperties.put(BigQuerySinkConfig.IS_CDC_ENABLED_CONFIG, "true");
+    config = new BigQuerySinkConfig(configProperties);
+    assertTrue(config.isCdcEnabled());
+    assertTrue(config.isUpsertDeleteEnabled());
+    assertTrue(config.isUpsertEnabled());
+    assertTrue(config.isDeleteEnabled());
+  }
+
+  @Test
+  void testConfigPresetDebeziumCdc() {
+    Map<String, String> configProperties = propertiesFactory.getProperties();
+    configProperties.put(BigQuerySinkConfig.CONFIG_PRESET_CONFIG, "debezium_cdc");
+    BigQuerySinkConfig config = new BigQuerySinkConfig(configProperties);
+    assertTrue(config.isCdcEnabled());
+    assertTrue(config.isUpsertDeleteEnabled());
+    assertTrue(config.isUpsertEnabled());
+    assertTrue(config.isDeleteEnabled());
+  }
 }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfigTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfigTest.java
@@ -443,6 +443,7 @@ public class BigQuerySinkConfigTest {
   void testIsCdcEnabledConfig() {
     Map<String, String> configProperties = propertiesFactory.getProperties();
     BigQuerySinkConfig config = new BigQuerySinkConfig(configProperties);
+    assertFalse(config.isCdcConfigured());
     assertFalse(config.isCdcEnabled());
     assertFalse(config.isUpsertDeleteEnabled());
     assertFalse(config.isUpsertEnabled());
@@ -450,10 +451,15 @@ public class BigQuerySinkConfigTest {
 
     configProperties.put(BigQuerySinkConfig.IS_CDC_ENABLED_CONFIG, "true");
     config = new BigQuerySinkConfig(configProperties);
-    assertTrue(config.isCdcEnabled());
+    assertTrue(config.isCdcConfigured());
+    assertFalse(config.isCdcEnabled()); // Requires useStorageWriteApi
     assertTrue(config.isUpsertDeleteEnabled());
     assertTrue(config.isUpsertEnabled());
     assertTrue(config.isDeleteEnabled());
+
+    configProperties.put(BigQuerySinkConfig.USE_STORAGE_WRITE_API_CONFIG, "true");
+    config = new BigQuerySinkConfig(configProperties);
+    assertTrue(config.isCdcEnabled());
   }
 
   @Test
@@ -461,9 +467,45 @@ public class BigQuerySinkConfigTest {
     Map<String, String> configProperties = propertiesFactory.getProperties();
     configProperties.put(BigQuerySinkConfig.CONFIG_PRESET_CONFIG, "debezium_cdc");
     BigQuerySinkConfig config = new BigQuerySinkConfig(configProperties);
-    assertTrue(config.isCdcEnabled());
+    assertTrue(config.isCdcConfigured());
+    assertFalse(config.isCdcEnabled()); // Requires useStorageWriteApi
     assertTrue(config.isUpsertDeleteEnabled());
     assertTrue(config.isUpsertEnabled());
     assertTrue(config.isDeleteEnabled());
+
+    configProperties.put(BigQuerySinkConfig.USE_STORAGE_WRITE_API_CONFIG, "true");
+    config = new BigQuerySinkConfig(configProperties);
+    assertTrue(config.isCdcEnabled());
+  }
+
+  @Test
+  void testGetKafkaKeyFieldName_autoFallbackForStorageWriteApiCdc() {
+    Map<String, String> configProperties = propertiesFactory.getProperties();
+    configProperties.put(BigQuerySinkConfig.USE_STORAGE_WRITE_API_CONFIG, "true");
+    configProperties.put(BigQuerySinkConfig.UPSERT_ENABLED_CONFIG, "true");
+
+    // Unset kafkaKeyFieldName -> defaults to ""
+    BigQuerySinkConfig config = new BigQuerySinkConfig(configProperties);
+    assertEquals(Optional.of(""), config.getKafkaKeyFieldName());
+
+    // Explicit empty string -> returns ""
+    configProperties.put(BigQuerySinkConfig.KAFKA_KEY_FIELD_NAME_CONFIG, "");
+    config = new BigQuerySinkConfig(configProperties);
+    assertEquals(Optional.of(""), config.getKafkaKeyFieldName());
+
+    // Custom non-empty field name with CDC -> auto-fallbacks to ""
+    configProperties.put(BigQuerySinkConfig.KAFKA_KEY_FIELD_NAME_CONFIG, "customKey");
+    config = new BigQuerySinkConfig(configProperties);
+    assertEquals(Optional.of(""), config.getKafkaKeyFieldName());
+
+    // Non-CDC mode with custom field name -> preserves customKey
+    configProperties.put(BigQuerySinkConfig.UPSERT_ENABLED_CONFIG, "false");
+    config = new BigQuerySinkConfig(configProperties);
+    assertEquals(Optional.of("customKey"), config.getKafkaKeyFieldName());
+
+    // Non-CDC mode with unset field name -> Optional.empty()
+    configProperties.remove(BigQuerySinkConfig.KAFKA_KEY_FIELD_NAME_CONFIG);
+    config = new BigQuerySinkConfig(configProperties);
+    assertEquals(Optional.empty(), config.getKafkaKeyFieldName());
   }
 }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/GcpClientBuilderIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/GcpClientBuilderIT.java
@@ -137,11 +137,15 @@ public class GcpClientBuilderIT extends BaseConnectorIT {
 
   @Test
   public void testFile() throws Exception {
+    org.junit.jupiter.api.Assumptions.assumeFalse(
+        keyFile().isEmpty(), "Skip if no keyfile provided");
     testClients(GcpClientBuilder.KeySource.FILE);
   }
 
   @Test
   public void testJson() throws Exception {
+    org.junit.jupiter.api.Assumptions.assumeFalse(
+        keyFile().isEmpty(), "Skip if no keyfile provided");
     testClients(GcpClientBuilder.KeySource.JSON);
   }
 }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/StorageWriteApiBigQuerySinkConnectorIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/StorageWriteApiBigQuerySinkConnectorIT.java
@@ -186,8 +186,6 @@ public class StorageWriteApiBigQuerySinkConnectorIT extends BaseConnectorIT {
         !(isBatchMode() && usePartitionDecorator),
         "Skipping partition decorator test in batch mode");
 
-    logger.info("load:{} nproc:{} waitFactor:{}", load(), nproc(), waitFactor());
-
     // create topic in Kafka
     final String topic = suffixedTableOrTopic("storage-api-append-json" + testCase);
     final String table = sanitizedTable(topic);

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/StorageWriteApiBigQuerySinkConnectorIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/StorageWriteApiBigQuerySinkConnectorIT.java
@@ -63,6 +63,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongFunction;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
+import java.util.stream.Stream;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -80,6 +81,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -174,11 +178,15 @@ public class StorageWriteApiBigQuerySinkConnectorIT extends BaseConnectorIT {
     stopConnect();
   }
 
-  private void testBaseJson(String testCase, boolean usePartitionDecorator)
+  @ParameterizedTest
+  @MethodSource("testArguments")
+  public void testBaseJson(String testCase, boolean usePartitionDecorator)
       throws InterruptedException {
     assumeTrue(
         !(isBatchMode() && usePartitionDecorator),
         "Skipping partition decorator test in batch mode");
+
+    logger.info("load:{} nproc:{} waitFactor:{}", load(), nproc(), waitFactor());
 
     // create topic in Kafka
     final String topic = suffixedTableOrTopic("storage-api-append-json" + testCase);
@@ -235,14 +243,10 @@ public class StorageWriteApiBigQuerySinkConnectorIT extends BaseConnectorIT {
         expectedRows(), testRows.stream().map(row -> row.get(0)).collect(Collectors.toSet()));
   }
 
-  @Test
-  void jsonWithPartitionDecorator() throws InterruptedException {
-    testBaseJson("with-partition-decorator", true);
-  }
-
-  @Test
-  void jsonWithoutPartitionDecorator() throws InterruptedException {
-    testBaseJson("without-partition-decorator", false);
+  public static Stream<Arguments> testArguments() {
+    return Stream.of(
+        Arguments.of("with-partition-decorator", true),
+        Arguments.of("without-partition-decorator", false));
   }
 
   @Test

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/StorageWriteApiCdcBigQuerySinkConnectorIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/StorageWriteApiCdcBigQuerySinkConnectorIT.java
@@ -1,0 +1,469 @@
+/*
+ * Copyright 2024 Copyright 2022 Aiven Oy and
+ * bigquery-connector-for-apache-kafka project contributors
+ *
+ * This software contains code derived from the Confluent BigQuery
+ * Kafka Connector, Copyright Confluent, Inc, which in turn
+ * contains code derived from the WePay BigQuery Kafka Connector,
+ * Copyright WePay, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.wepay.kafka.connect.bigquery.integration;
+
+import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.PrimaryKey;
+import com.google.cloud.bigquery.StandardSQLTypeName;
+import com.google.cloud.bigquery.StandardTableDefinition;
+import com.google.cloud.bigquery.TableConstraints;
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.TableInfo;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
+import com.wepay.kafka.connect.bigquery.integration.utils.TableClearer;
+import com.wepay.kafka.connect.bigquery.retrieve.IdentitySchemaRetriever;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.json.JsonConverterConfig;
+import org.apache.kafka.connect.runtime.SinkConnectorConfig;
+import org.apache.kafka.connect.storage.Converter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Tag("integration")
+public class StorageWriteApiCdcBigQuerySinkConnectorIT extends BaseConnectorIT {
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(StorageWriteApiCdcBigQuerySinkConnectorIT.class);
+
+  private static final int TASKS_MAX = 1;
+
+  private String connectorName;
+  private BigQuery bigQuery;
+
+  @BeforeEach
+  public void setup(TestInfo testInfo) {
+    String testMethod =
+        testInfo
+            .getTestMethod()
+            .map(Method::getName)
+            .orElseThrow(() -> new AssertionError("Test method not found"));
+    connectorName = "kcbq-cdc-sink-connector-" + testMethod;
+    bigQuery = newBigQuery();
+    startConnect();
+  }
+
+  @AfterEach
+  public void close() {
+    bigQuery = null;
+    stopConnect();
+  }
+
+  private void createTableWithPrimaryKey(String table, String... keyColumns) {
+    com.google.cloud.bigquery.Schema tableSchema =
+        com.google.cloud.bigquery.Schema.of(
+            Field.of("k1", StandardSQLTypeName.INT64), Field.of("f1", StandardSQLTypeName.STRING));
+    createTableWithPrimaryKey(table, tableSchema, keyColumns);
+  }
+
+  private void createTableWithPrimaryKey(
+      String table, com.google.cloud.bigquery.Schema tableSchema, String... keyColumns) {
+    TableId tableId = TableId.of(dataset(), table);
+
+    PrimaryKey primaryKey = PrimaryKey.newBuilder().setColumns(Arrays.asList(keyColumns)).build();
+    TableConstraints constraints = TableConstraints.newBuilder().setPrimaryKey(primaryKey).build();
+
+    StandardTableDefinition tableDefinition =
+        StandardTableDefinition.newBuilder()
+            .setSchema(tableSchema)
+            .setTableConstraints(constraints)
+            .build();
+
+    TableInfo tableInfo = TableInfo.newBuilder(tableId, tableDefinition).build();
+
+    try {
+      bigQuery.create(tableInfo);
+      logger.info("Table {} with primary key constraints created successfully", table);
+      bigQuery.query(
+          com.google.cloud.bigquery.QueryJobConfiguration.of(
+              String.format(
+                  "ALTER TABLE `%s`.`%s` SET OPTIONS (max_staleness = INTERVAL 0 MINUTE)",
+                  dataset(), table)));
+      logger.info("Table {} max_staleness set to 0-0-0 successfully", table);
+      Thread.sleep(30000);
+      logger.info("Waited 30 seconds for metadata propagation");
+    } catch (BigQueryException ex) {
+      if (!ex.getError().getReason().equalsIgnoreCase("duplicate")) {
+        throw new ConnectException("Failed to create table: ", ex);
+      } else {
+        logger.info("Table {} already exists", table);
+      }
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+      throw new ConnectException("Failed to set max_staleness on table: ", ex);
+    }
+  }
+
+  @Test
+  public void testStorageWriteApiNativeCdc() throws Throwable {
+    final String topic = suffixedTableOrTopic("test-storage-write-api-cdc");
+    connect.kafka().createTopic(topic, TASKS_MAX);
+
+    final String table = sanitizedTable(topic);
+    TableClearer.clearTables(bigQuery, dataset(), table);
+
+    // Pre-create table with primary key 'k1'
+    createTableWithPrimaryKey(table, "k1");
+
+    Map<String, String> props = baseConnectorProps(TASKS_MAX);
+    props.put(SinkConnectorConfig.TOPICS_CONFIG, topic);
+
+    props.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
+    props.put(BigQuerySinkConfig.SCHEMA_RETRIEVER_CONFIG, IdentitySchemaRetriever.class.getName());
+    props.put(BigQuerySinkConfig.TABLE_CREATE_CONFIG, "false"); // We pre-created it
+    props.put(BigQuerySinkConfig.BIGQUERY_PARTITION_DECORATOR_CONFIG, "false");
+
+    // Enable native CDC modes
+    props.put(BigQuerySinkConfig.USE_STORAGE_WRITE_API_CONFIG, "true");
+    props.put(BigQuerySinkConfig.UPSERT_ENABLED_CONFIG, "true");
+    props.put(BigQuerySinkConfig.DELETE_ENABLED_CONFIG, "true");
+
+    props.put(KEY_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
+    props.put(VALUE_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
+
+    // start the sink connector
+    connect.configureConnector(connectorName, props);
+    waitForConnectorToStart(connectorName, TASKS_MAX);
+
+    Converter keyConverter = converter(true);
+    Converter valueConverter = converter(false);
+
+    // Produce records:
+    // 1. Insert record for key 1
+    connect
+        .kafka()
+        .produce(
+            topic,
+            key(keyConverter, topic, 1L),
+            value(valueConverter, topic, "original value", false));
+
+    // 2. Insert record for key 2
+    connect
+        .kafka()
+        .produce(
+            topic, key(keyConverter, topic, 2L), value(valueConverter, topic, "other row", false));
+
+    // 3. Update record for key 1
+    connect
+        .kafka()
+        .produce(
+            topic,
+            key(keyConverter, topic, 1L),
+            value(valueConverter, topic, "modified value", false));
+
+    // 4. Delete record for key 1 (tombstone)
+    connect
+        .kafka()
+        .produce(topic, key(keyConverter, topic, 1L), value(valueConverter, topic, null, true));
+
+    // Wait for all 4 records to commit
+    waitForCommittedRecords(connectorName, topic, 4, TASKS_MAX);
+
+    // Read back rows from BigQuery, sorting by k1 column, waiting for merge to happen
+    org.apache.kafka.test.TestUtils.waitForCondition(
+        () -> {
+          try {
+            return readAllRows(bigQuery, table, "k1").size() == 1;
+          } catch (Exception e) {
+            return false;
+          }
+        },
+        60000,
+        "Timed out waiting for CDC table to merge and show 1 row");
+
+    List<List<Object>> allRows = readAllRows(bigQuery, table, "k1");
+
+    // The final result should contain only row 2, because key 1 was updated then deleted.
+    // The query returns fields in order of table schema: k1, f1, _CHANGE_TYPE,
+    // _CHANGE_SEQUENCE_NUMBER
+    // Since BigQuery CDC merges base table with changes, it should return 1 row.
+    // Note: BQ CDC columns (_CHANGE_TYPE, _CHANGE_SEQUENCE_NUMBER) are system columns and we don't
+    // assert their exact values here if we only want the materialized state,
+    // but they will be returned by "SELECT *".
+    // We check the first two columns (k1 and f1).
+    assertEquals(1, allRows.size());
+    assertEquals(2L, allRows.get(0).get(0)); // k1
+    assertEquals("other row", allRows.get(0).get(1)); // f1
+  }
+
+  @Test
+  public void testStorageWriteApiCdcCompositeKey() throws Throwable {
+    final String topic = suffixedTableOrTopic("test-storage-write-api-cdc-composite");
+    connect.kafka().createTopic(topic, TASKS_MAX);
+
+    final String table = sanitizedTable(topic);
+    TableClearer.clearTables(bigQuery, dataset(), table);
+
+    // Pre-create table with composite primary key 'k1' and 'k2'
+    com.google.cloud.bigquery.Schema tableSchema =
+        com.google.cloud.bigquery.Schema.of(
+            Field.of("k1", StandardSQLTypeName.INT64),
+            Field.of("k2", StandardSQLTypeName.STRING),
+            Field.of("f1", StandardSQLTypeName.STRING));
+    createTableWithPrimaryKey(table, tableSchema, "k1", "k2");
+
+    Map<String, String> props = baseConnectorProps(TASKS_MAX);
+    props.put(SinkConnectorConfig.TOPICS_CONFIG, topic);
+
+    props.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
+    props.put(BigQuerySinkConfig.SCHEMA_RETRIEVER_CONFIG, IdentitySchemaRetriever.class.getName());
+    props.put(BigQuerySinkConfig.TABLE_CREATE_CONFIG, "false");
+    props.put(BigQuerySinkConfig.BIGQUERY_PARTITION_DECORATOR_CONFIG, "false");
+
+    // Enable native CDC modes
+    props.put(BigQuerySinkConfig.USE_STORAGE_WRITE_API_CONFIG, "true");
+    props.put(BigQuerySinkConfig.UPSERT_ENABLED_CONFIG, "true");
+    props.put(BigQuerySinkConfig.DELETE_ENABLED_CONFIG, "true");
+
+    props.put(KEY_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
+    props.put(VALUE_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
+
+    // start the sink connector
+    connect.configureConnector(connectorName, props);
+    waitForConnectorToStart(connectorName, TASKS_MAX);
+
+    Converter keyConverter = converter(true);
+    Converter valueConverter = converter(false);
+
+    // 1. Insert record for key (1, "a") -> "original row 1"
+    connect
+        .kafka()
+        .produce(
+            topic,
+            compositeKey(keyConverter, topic, 1L, "a"),
+            value(valueConverter, topic, "original row 1", false));
+
+    // 2. Insert record for key (2, "b") -> "other row"
+    connect
+        .kafka()
+        .produce(
+            topic,
+            compositeKey(keyConverter, topic, 2L, "b"),
+            value(valueConverter, topic, "other row", false));
+
+    // 3. Update record for key (1, "a") -> "modified row 1"
+    connect
+        .kafka()
+        .produce(
+            topic,
+            compositeKey(keyConverter, topic, 1L, "a"),
+            value(valueConverter, topic, "modified row 1", false));
+
+    // 4. Delete record for key (1, "a") (Tombstone)
+    connect
+        .kafka()
+        .produce(
+            topic,
+            compositeKey(keyConverter, topic, 1L, "a"),
+            value(valueConverter, topic, null, true));
+
+    // Wait for all 4 records to be committed
+    waitForCommittedRecords(connectorName, topic, 4, TASKS_MAX);
+
+    // Read back rows from BigQuery, waiting for merge
+    org.apache.kafka.test.TestUtils.waitForCondition(
+        () -> {
+          try {
+            return readAllRows(bigQuery, table, "k1").size() == 1;
+          } catch (Exception e) {
+            return false;
+          }
+        },
+        60000,
+        "Timed out waiting for CDC table to merge and show 1 row");
+
+    List<List<Object>> allRows = readAllRows(bigQuery, table, "k1");
+
+    // The final result should contain only row 2, because key (1, "a") was updated then deleted.
+    assertEquals(1, allRows.size());
+    assertEquals(2L, allRows.get(0).get(0)); // k1
+    assertEquals("b", allRows.get(0).get(1)); // k2
+    assertEquals("other row", allRows.get(0).get(2)); // f1
+  }
+
+  private void waitForTaskToFail(String connectorName) throws InterruptedException {
+    org.apache.kafka.test.TestUtils.waitForCondition(
+        () -> {
+          try {
+            org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo info =
+                connect.connectorStatus(connectorName);
+            return info != null && info.tasks().stream().anyMatch(s -> s.state().equals("FAILED"));
+          } catch (Exception e) {
+            return false;
+          }
+        },
+        30000,
+        "Timed out waiting for connector task to fail");
+  }
+
+  @Test
+  public void testStorageWriteApiCdcDeleteDisabled() throws Throwable {
+    final String topic = suffixedTableOrTopic("test-storage-write-api-cdc-del-disabled");
+    connect.kafka().createTopic(topic, TASKS_MAX);
+
+    final String table = sanitizedTable(topic);
+    TableClearer.clearTables(bigQuery, dataset(), table);
+
+    // Pre-create table with primary key 'k1'
+    createTableWithPrimaryKey(table, "k1");
+
+    Map<String, String> props = baseConnectorProps(TASKS_MAX);
+    props.put(SinkConnectorConfig.TOPICS_CONFIG, topic);
+
+    props.put(BigQuerySinkConfig.SANITIZE_TOPICS_CONFIG, "true");
+    props.put(BigQuerySinkConfig.SCHEMA_RETRIEVER_CONFIG, IdentitySchemaRetriever.class.getName());
+    props.put(BigQuerySinkConfig.TABLE_CREATE_CONFIG, "false");
+    props.put(BigQuerySinkConfig.BIGQUERY_PARTITION_DECORATOR_CONFIG, "false");
+
+    // Enable native CDC modes, but DISABLE delete
+    props.put(BigQuerySinkConfig.USE_STORAGE_WRITE_API_CONFIG, "true");
+    props.put(BigQuerySinkConfig.UPSERT_ENABLED_CONFIG, "true");
+    props.put(BigQuerySinkConfig.DELETE_ENABLED_CONFIG, "false"); // DISABLE DELETE
+
+    props.put(KEY_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
+    props.put(VALUE_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
+
+    // start the sink connector
+    connect.configureConnector(connectorName, props);
+    waitForConnectorToStart(connectorName, TASKS_MAX);
+
+    Converter keyConverter = converter(true);
+    Converter valueConverter = converter(false);
+
+    // 1. Insert record for key 1
+    connect
+        .kafka()
+        .produce(
+            topic,
+            key(keyConverter, topic, 1L),
+            value(valueConverter, topic, "original row 1", false));
+
+    // 2. Produce tombstone for key 1 (should fail because delete is disabled)
+    connect.kafka().produce(topic, key(keyConverter, topic, 1L), null);
+
+    // Wait for all 2 records to be committed (skipped records still have their offsets committed)
+    waitForCommittedRecords(connectorName, topic, 2, TASKS_MAX);
+
+    // Read back rows from BigQuery. The row should still exist because delete was disabled.
+    List<List<Object>> allRows = readAllRows(bigQuery, table, "k1");
+    assertEquals(1, allRows.size());
+    assertEquals(1L, allRows.get(0).get(0));
+    assertEquals("original row 1", allRows.get(0).get(1));
+  }
+
+  private Converter converter(boolean isKey) {
+    Map<String, Object> props = new HashMap<>();
+    props.put(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, true);
+    Converter result = new JsonConverter();
+    result.configure(props, isKey);
+    return result;
+  }
+
+  private String key(Converter converter, String topic, long id) {
+    final Schema schema = SchemaBuilder.struct().field("k1", Schema.INT64_SCHEMA).build();
+
+    final Struct struct = new Struct(schema).put("k1", id);
+
+    return new String(converter.fromConnectData(topic, schema, struct));
+  }
+
+  private String value(Converter converter, String topic, String val, boolean tombstone) {
+    final Schema schema =
+        SchemaBuilder.struct().optional().field("f1", Schema.STRING_SCHEMA).build();
+
+    if (tombstone) {
+      return new String(converter.fromConnectData(topic, schema, null));
+    }
+
+    final Struct struct = new Struct(schema).put("f1", val);
+
+    return new String(converter.fromConnectData(topic, schema, struct));
+  }
+
+  private String compositeKey(Converter converter, String topic, long id1, String id2) {
+    final Schema schema =
+        SchemaBuilder.struct()
+            .field("k1", Schema.INT64_SCHEMA)
+            .field("k2", Schema.STRING_SCHEMA)
+            .build();
+
+    final Struct struct = new Struct(schema).put("k1", id1).put("k2", id2);
+
+    return new String(converter.fromConnectData(topic, schema, struct));
+  }
+
+  @Test
+  public void testPrintStreamSchema() throws Exception {
+    String tableName = sanitizedTable(suffixedTableOrTopic("test-storage-write-api-cdc"));
+    com.google.cloud.bigquery.Table table = bigQuery.getTable(TableId.of(dataset(), tableName));
+    if (table != null) {
+      System.out.println("TABLE SCHEMA: " + table.getDefinition().getSchema());
+      System.out.println("TABLE DEFINITION: " + table.getDefinition());
+    } else {
+      System.out.println("TABLE DOES NOT EXIST");
+      return;
+    }
+
+    String streamName = "projects/" + project() + "/datasets/" + dataset() + "/tables/" + tableName;
+    com.google.cloud.bigquery.storage.v1.BigQueryWriteSettings settings =
+        new com.wepay.kafka.connect.bigquery.GcpClientBuilder.BigQueryWriteSettingsBuilder()
+            .withKey(keyFile())
+            .withKeySource(
+                com.wepay.kafka.connect.bigquery.GcpClientBuilder.KeySource.valueOf(keySource()))
+            .withProject(project())
+            .withWriterApi(true)
+            .build();
+    try (com.google.cloud.bigquery.storage.v1.BigQueryWriteClient client =
+        com.google.cloud.bigquery.storage.v1.BigQueryWriteClient.create(settings)) {
+      com.google.cloud.bigquery.storage.v1.WriteStream writeStream =
+          client.getWriteStream(
+              com.google.cloud.bigquery.storage.v1.GetWriteStreamRequest.newBuilder()
+                  .setName(streamName + "/streams/_default")
+                  .build());
+      System.out.println("STREAM: " + writeStream);
+      System.out.println("STREAM FIELDS COUNT: " + writeStream.getTableSchema().getFieldsCount());
+      logger.info("STREAM: " + writeStream);
+      logger.info("STREAM FIELDS COUNT: " + writeStream.getTableSchema().getFieldsCount());
+    }
+  }
+}

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/StorageWriteApiCdcBigQuerySinkConnectorIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/StorageWriteApiCdcBigQuerySinkConnectorIT.java
@@ -431,39 +431,4 @@ public class StorageWriteApiCdcBigQuerySinkConnectorIT extends BaseConnectorIT {
 
     return new String(converter.fromConnectData(topic, schema, struct));
   }
-
-  @Test
-  public void testPrintStreamSchema() throws Exception {
-    String tableName = sanitizedTable(suffixedTableOrTopic("test-storage-write-api-cdc"));
-    com.google.cloud.bigquery.Table table = bigQuery.getTable(TableId.of(dataset(), tableName));
-    if (table != null) {
-      System.out.println("TABLE SCHEMA: " + table.getDefinition().getSchema());
-      System.out.println("TABLE DEFINITION: " + table.getDefinition());
-    } else {
-      System.out.println("TABLE DOES NOT EXIST");
-      return;
-    }
-
-    String streamName = "projects/" + project() + "/datasets/" + dataset() + "/tables/" + tableName;
-    com.google.cloud.bigquery.storage.v1.BigQueryWriteSettings settings =
-        new com.wepay.kafka.connect.bigquery.GcpClientBuilder.BigQueryWriteSettingsBuilder()
-            .withKey(keyFile())
-            .withKeySource(
-                com.wepay.kafka.connect.bigquery.GcpClientBuilder.KeySource.valueOf(keySource()))
-            .withProject(project())
-            .withWriterApi(true)
-            .build();
-    try (com.google.cloud.bigquery.storage.v1.BigQueryWriteClient client =
-        com.google.cloud.bigquery.storage.v1.BigQueryWriteClient.create(settings)) {
-      com.google.cloud.bigquery.storage.v1.WriteStream writeStream =
-          client.getWriteStream(
-              com.google.cloud.bigquery.storage.v1.GetWriteStreamRequest.newBuilder()
-                  .setName(streamName + "/streams/_default")
-                  .build());
-      System.out.println("STREAM: " + writeStream);
-      System.out.println("STREAM FIELDS COUNT: " + writeStream.getTableSchema().getFieldsCount());
-      logger.info("STREAM: " + writeStream);
-      logger.info("STREAM FIELDS COUNT: " + writeStream.getTableSchema().getFieldsCount());
-    }
-  }
 }

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverterTest.java
@@ -67,6 +67,7 @@ public class SinkRecordConverterTest {
   private static final String TOPIC = "test-topic";
   private static final int PARTITION = 1;
   private static final long OFFSET = 42L;
+  private static final long RECORD_TIMESTAMP = 123456789L;
 
   private Schema keySchema;
   private Schema valueSchema;
@@ -117,7 +118,16 @@ public class SinkRecordConverterTest {
     when(config.getBoolean(BigQuerySinkConfig.UPSERT_ENABLED_CONFIG)).thenReturn(true);
 
     SinkRecord record =
-        new SinkRecord(TOPIC, PARTITION, keySchema, keyStruct, valueSchema, valueStruct, OFFSET);
+        new SinkRecord(
+            TOPIC,
+            PARTITION,
+            keySchema,
+            keyStruct,
+            valueSchema,
+            valueStruct,
+            OFFSET,
+            RECORD_TIMESTAMP,
+            org.apache.kafka.common.record.TimestampType.CREATE_TIME);
 
     SinkRecordConverter sinkRecordConverter = new SinkRecordConverter(config, null, null);
     Map<String, Object> actual = sinkRecordConverter.getCdcRow(record);
@@ -128,7 +138,9 @@ public class SinkRecordConverterTest {
 
     // Verify CDC metadata columns
     assertEquals(CDC_CHANGE_TYPE_UPSERT, actual.get(CDC_CHANGE_TYPE_FIELD));
-    assertEquals("00000001/000000000000002A", actual.get(CDC_CHANGE_SEQUENCE_NUMBER_FIELD));
+    assertEquals(
+        String.format("%016X/%016X/%08X", RECORD_TIMESTAMP, OFFSET, PARTITION),
+        actual.get(CDC_CHANGE_SEQUENCE_NUMBER_FIELD));
   }
 
   @Test
@@ -136,7 +148,17 @@ public class SinkRecordConverterTest {
     when(config.getBoolean(BigQuerySinkConfig.DELETE_ENABLED_CONFIG)).thenReturn(true);
     when(config.getBoolean(BigQuerySinkConfig.UPSERT_ENABLED_CONFIG)).thenReturn(true);
 
-    SinkRecord record = new SinkRecord(TOPIC, PARTITION, keySchema, keyStruct, null, null, OFFSET);
+    SinkRecord record =
+        new SinkRecord(
+            TOPIC,
+            PARTITION,
+            keySchema,
+            keyStruct,
+            null,
+            null,
+            OFFSET,
+            RECORD_TIMESTAMP,
+            org.apache.kafka.common.record.TimestampType.CREATE_TIME);
 
     SinkRecordConverter sinkRecordConverter = new SinkRecordConverter(config, null, null);
     Map<String, Object> actual = sinkRecordConverter.getCdcRow(record);
@@ -148,7 +170,9 @@ public class SinkRecordConverterTest {
 
     // Verify CDC metadata columns
     assertEquals(CDC_CHANGE_TYPE_DELETE, actual.get(CDC_CHANGE_TYPE_FIELD));
-    assertEquals("00000001/000000000000002A", actual.get(CDC_CHANGE_SEQUENCE_NUMBER_FIELD));
+    assertEquals(
+        String.format("%016X/%016X/%08X", RECORD_TIMESTAMP, OFFSET, PARTITION),
+        actual.get(CDC_CHANGE_SEQUENCE_NUMBER_FIELD));
   }
 
   @Test
@@ -161,6 +185,15 @@ public class SinkRecordConverterTest {
 
     SinkRecordConverter sinkRecordConverter = new SinkRecordConverter(config, null, null);
     assertThrows(ConnectException.class, () -> sinkRecordConverter.getCdcRow(record));
+  }
+
+  @Test
+  public void testIsCdcEnabledWithoutUpsertOrDeleteFlags() {
+    when(config.getBoolean(BigQuerySinkConfig.USE_STORAGE_WRITE_API_CONFIG)).thenReturn(true);
+    when(config.isUpsertDeleteEnabled()).thenReturn(true);
+
+    SinkRecordConverter sinkRecordConverter = new SinkRecordConverter(config, null, null);
+    assertTrue(sinkRecordConverter.isCdcEnabled());
   }
 
   @Test
@@ -185,13 +218,23 @@ public class SinkRecordConverterTest {
 
     SinkRecord record =
         new SinkRecord(
-            TOPIC, PARTITION, keySchema, keyStruct, rewriteValueSchema, rewriteValueStruct, OFFSET);
+            TOPIC,
+            PARTITION,
+            keySchema,
+            keyStruct,
+            rewriteValueSchema,
+            rewriteValueStruct,
+            OFFSET,
+            RECORD_TIMESTAMP,
+            org.apache.kafka.common.record.TimestampType.CREATE_TIME);
 
     SinkRecordConverter sinkRecordConverter = new SinkRecordConverter(config, null, null);
     Map<String, Object> actual = sinkRecordConverter.getCdcRow(record);
 
     assertEquals(CDC_CHANGE_TYPE_DELETE, actual.get(CDC_CHANGE_TYPE_FIELD));
-    assertEquals("00000001/000000000000002A", actual.get(CDC_CHANGE_SEQUENCE_NUMBER_FIELD));
+    assertEquals(
+        String.format("%016X/%016X/%08X", RECORD_TIMESTAMP, OFFSET, PARTITION),
+        actual.get(CDC_CHANGE_SEQUENCE_NUMBER_FIELD));
   }
 
   @Test
@@ -216,13 +259,23 @@ public class SinkRecordConverterTest {
 
     SinkRecord record =
         new SinkRecord(
-            TOPIC, PARTITION, keySchema, keyStruct, rewriteValueSchema, rewriteValueStruct, OFFSET);
+            TOPIC,
+            PARTITION,
+            keySchema,
+            keyStruct,
+            rewriteValueSchema,
+            rewriteValueStruct,
+            OFFSET,
+            RECORD_TIMESTAMP,
+            org.apache.kafka.common.record.TimestampType.CREATE_TIME);
 
     SinkRecordConverter sinkRecordConverter = new SinkRecordConverter(config, null, null);
     Map<String, Object> actual = sinkRecordConverter.getCdcRow(record);
 
     assertEquals(CDC_CHANGE_TYPE_DELETE, actual.get(CDC_CHANGE_TYPE_FIELD));
-    assertEquals("00000001/000000000000002A", actual.get(CDC_CHANGE_SEQUENCE_NUMBER_FIELD));
+    assertEquals(
+        String.format("%016X/%016X/%08X", RECORD_TIMESTAMP, OFFSET, PARTITION),
+        actual.get(CDC_CHANGE_SEQUENCE_NUMBER_FIELD));
   }
 
   @Test

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverterTest.java
@@ -29,24 +29,47 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.wepay.kafka.connect.bigquery.SchemaManager;
 import com.wepay.kafka.connect.bigquery.config.BigQuerySinkConfig;
+import com.wepay.kafka.connect.bigquery.config.BigQuerySinkTaskConfig;
+import com.wepay.kafka.connect.bigquery.convert.BigQueryRecordConverter;
+import com.wepay.kafka.connect.bigquery.convert.RecordConverter;
 import de.huxhorn.sulky.ulid.ULID;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 public class SinkRecordConverterTest {
+  private static final String TOPIC = "test-topic";
+  private static final int PARTITION = 1;
+  private static final long OFFSET = 42L;
+
+  private Schema keySchema;
+  private Schema valueSchema;
+  private Struct keyStruct;
+  private Struct valueStruct;
+
+  private BigQuerySinkTaskConfig config;
+  private RecordConverter<Map<String, Object>> recordConverter;
 
   private static final String kafkaDataTopicValue = "testTopic";
   private static final int kafkaDataPartitionValue = 101;
@@ -55,6 +78,177 @@ public class SinkRecordConverterTest {
   private static final int kafkaDataMutatedPartitionValue = 201;
   private static final long kafkaDataMutatedOffsetValue = 456;
   private static final ULID ulid = new ULID();
+
+  @BeforeEach
+  public void setUp() {
+    keySchema = SchemaBuilder.struct().field("id", Schema.INT64_SCHEMA).build();
+    keyStruct = new Struct(keySchema).put("id", 123L);
+
+    valueSchema =
+        SchemaBuilder.struct()
+            .field("id", Schema.INT64_SCHEMA)
+            .field("name", Schema.STRING_SCHEMA)
+            .build();
+    valueStruct = new Struct(valueSchema).put("id", 123L).put("name", "Alice");
+
+    config = mock(BigQuerySinkTaskConfig.class);
+    recordConverter = new BigQueryRecordConverter(false, true);
+
+    when(config.getRecordConverter()).thenReturn(recordConverter);
+    when(config.getLong(BigQuerySinkConfig.MERGE_RECORDS_THRESHOLD_CONFIG)).thenReturn(-1L);
+    when(config.getBoolean(BigQuerySinkConfig.BIGQUERY_MESSAGE_TIME_PARTITIONING_CONFIG))
+        .thenReturn(false);
+    when(config.getBoolean(BigQuerySinkConfig.BIGQUERY_PARTITION_DECORATOR_CONFIG))
+        .thenReturn(true);
+    when(config.getBoolean(BigQuerySinkConfig.SANITIZE_FIELD_NAME_CONFIG)).thenReturn(false);
+    when(config.getKafkaKeyFieldName()).thenReturn(Optional.empty());
+    when(config.getKafkaDataFieldName()).thenReturn(Optional.empty());
+    when(config.getBoolean(BigQuerySinkConfig.USE_STORAGE_WRITE_API_CONFIG)).thenReturn(true);
+  }
+
+  @Test
+  public void testCdcRowUpsert() {
+    when(config.getBoolean(BigQuerySinkConfig.DELETE_ENABLED_CONFIG)).thenReturn(true);
+    when(config.getBoolean(BigQuerySinkConfig.UPSERT_ENABLED_CONFIG)).thenReturn(true);
+
+    SinkRecord record =
+        new SinkRecord(TOPIC, PARTITION, keySchema, keyStruct, valueSchema, valueStruct, OFFSET);
+
+    SinkRecordConverter sinkRecordConverter = new SinkRecordConverter(config, null, null);
+    Map<String, Object> actual = sinkRecordConverter.getCdcRow(record);
+
+    // Verify root fields
+    assertEquals(123L, actual.get("id"));
+    assertEquals("Alice", actual.get("name"));
+
+    // Verify CDC metadata columns
+    assertEquals("UPSERT", actual.get("_CHANGE_TYPE"));
+    assertEquals("000000000000002A", actual.get("_CHANGE_SEQUENCE_NUMBER"));
+  }
+
+  @Test
+  public void testCdcRowDelete() {
+    when(config.getBoolean(BigQuerySinkConfig.DELETE_ENABLED_CONFIG)).thenReturn(true);
+    when(config.getBoolean(BigQuerySinkConfig.UPSERT_ENABLED_CONFIG)).thenReturn(true);
+
+    SinkRecord record = new SinkRecord(TOPIC, PARTITION, keySchema, keyStruct, null, null, OFFSET);
+
+    SinkRecordConverter sinkRecordConverter = new SinkRecordConverter(config, null, null);
+    Map<String, Object> actual = sinkRecordConverter.getCdcRow(record);
+
+    // Verify root fields from key
+    assertEquals(123L, actual.get("id"));
+    // Since value is null, "name" should not exist or should be null
+    assertTrue(!actual.containsKey("name") || actual.get("name") == null);
+
+    // Verify CDC metadata columns
+    assertEquals("DELETE", actual.get("_CHANGE_TYPE"));
+    assertEquals("000000000000002A", actual.get("_CHANGE_SEQUENCE_NUMBER"));
+  }
+
+  @Test
+  public void testCdcRowDeleteThrowsIfKeyNull() {
+    when(config.getBoolean(BigQuerySinkConfig.DELETE_ENABLED_CONFIG)).thenReturn(true);
+    when(config.getBoolean(BigQuerySinkConfig.UPSERT_ENABLED_CONFIG)).thenReturn(true);
+
+    SinkRecord record =
+        new SinkRecord(TOPIC, PARTITION, null, null, valueSchema, valueStruct, OFFSET);
+
+    SinkRecordConverter sinkRecordConverter = new SinkRecordConverter(config, null, null);
+    assertThrows(ConnectException.class, () -> sinkRecordConverter.getCdcRow(record));
+  }
+
+  @Test
+  public void testCdcRowDeleteRewrite() {
+    when(config.getBoolean(BigQuerySinkConfig.DELETE_ENABLED_CONFIG)).thenReturn(true);
+    when(config.getBoolean(BigQuerySinkConfig.UPSERT_ENABLED_CONFIG)).thenReturn(true);
+
+    Schema rewriteValueSchema =
+        SchemaBuilder.struct()
+            .field("id", Schema.INT64_SCHEMA)
+            .field("name", Schema.STRING_SCHEMA)
+            .field("version_id", Schema.INT64_SCHEMA)
+            .field("__deleted", Schema.BOOLEAN_SCHEMA)
+            .build();
+
+    Struct rewriteValueStruct =
+        new Struct(rewriteValueSchema)
+            .put("id", 123L)
+            .put("name", "Alice")
+            .put("version_id", 3L)
+            .put("__deleted", true);
+
+    SinkRecord record =
+        new SinkRecord(
+            TOPIC, PARTITION, keySchema, keyStruct, rewriteValueSchema, rewriteValueStruct, OFFSET);
+
+    SinkRecordConverter sinkRecordConverter = new SinkRecordConverter(config, null, null);
+    Map<String, Object> actual = sinkRecordConverter.getCdcRow(record);
+
+    assertEquals("DELETE", actual.get("_CHANGE_TYPE"));
+    assertEquals("000000000000002A", actual.get("_CHANGE_SEQUENCE_NUMBER"));
+  }
+
+  @Test
+  public void testCdcRowDeleteRewriteString() {
+    when(config.getBoolean(BigQuerySinkConfig.DELETE_ENABLED_CONFIG)).thenReturn(true);
+    when(config.getBoolean(BigQuerySinkConfig.UPSERT_ENABLED_CONFIG)).thenReturn(true);
+
+    Schema rewriteValueSchema =
+        SchemaBuilder.struct()
+            .field("id", Schema.INT64_SCHEMA)
+            .field("name", Schema.STRING_SCHEMA)
+            .field("version_id", Schema.INT64_SCHEMA)
+            .field("__deleted", Schema.STRING_SCHEMA)
+            .build();
+
+    Struct rewriteValueStruct =
+        new Struct(rewriteValueSchema)
+            .put("id", 123L)
+            .put("name", "Alice")
+            .put("version_id", 3L)
+            .put("__deleted", "true");
+
+    SinkRecord record =
+        new SinkRecord(
+            TOPIC, PARTITION, keySchema, keyStruct, rewriteValueSchema, rewriteValueStruct, OFFSET);
+
+    SinkRecordConverter sinkRecordConverter = new SinkRecordConverter(config, null, null);
+    Map<String, Object> actual = sinkRecordConverter.getCdcRow(record);
+
+    assertEquals("DELETE", actual.get("_CHANGE_TYPE"));
+    assertEquals("000000000000002A", actual.get("_CHANGE_SEQUENCE_NUMBER"));
+  }
+
+  @Test
+  public void testCdcRowStripsDeletedField() {
+    when(config.getBoolean(BigQuerySinkConfig.DELETE_ENABLED_CONFIG)).thenReturn(true);
+    when(config.getBoolean(BigQuerySinkConfig.UPSERT_ENABLED_CONFIG)).thenReturn(true);
+
+    Schema rewriteValueSchema =
+        SchemaBuilder.struct()
+            .field("id", Schema.INT64_SCHEMA)
+            .field("name", Schema.STRING_SCHEMA)
+            .field("version_id", Schema.INT64_SCHEMA)
+            .field("__deleted", Schema.BOOLEAN_SCHEMA)
+            .build();
+
+    Struct rewriteValueStruct =
+        new Struct(rewriteValueSchema)
+            .put("id", 123L)
+            .put("name", "Alice")
+            .put("version_id", 3L)
+            .put("__deleted", true);
+
+    SinkRecord record =
+        new SinkRecord(
+            TOPIC, PARTITION, keySchema, keyStruct, rewriteValueSchema, rewriteValueStruct, OFFSET);
+
+    SinkRecordConverter sinkRecordConverter = new SinkRecordConverter(config, null, null);
+    Map<String, Object> actual = sinkRecordConverter.getCdcRow(record);
+
+    assertTrue(!actual.containsKey("__deleted"));
+  }
 
   private static Map<String, Object> defaultExpectedFields() {
     return new HashMap<>(

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverterTest.java
@@ -23,6 +23,11 @@
 
 package com.wepay.kafka.connect.bigquery.utils;
 
+import static com.wepay.kafka.connect.bigquery.utils.SinkRecordConverter.CDC_CHANGE_SEQUENCE_NUMBER_FIELD;
+import static com.wepay.kafka.connect.bigquery.utils.SinkRecordConverter.CDC_CHANGE_TYPE_DELETE;
+import static com.wepay.kafka.connect.bigquery.utils.SinkRecordConverter.CDC_CHANGE_TYPE_FIELD;
+import static com.wepay.kafka.connect.bigquery.utils.SinkRecordConverter.CDC_CHANGE_TYPE_UPSERT;
+import static com.wepay.kafka.connect.bigquery.utils.SinkRecordConverter.DELETED_PSEUDO_COLUMN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -122,8 +127,8 @@ public class SinkRecordConverterTest {
     assertEquals("Alice", actual.get("name"));
 
     // Verify CDC metadata columns
-    assertEquals("UPSERT", actual.get("_CHANGE_TYPE"));
-    assertEquals("000000000000002A", actual.get("_CHANGE_SEQUENCE_NUMBER"));
+    assertEquals(CDC_CHANGE_TYPE_UPSERT, actual.get(CDC_CHANGE_TYPE_FIELD));
+    assertEquals("00000001/000000000000002A", actual.get(CDC_CHANGE_SEQUENCE_NUMBER_FIELD));
   }
 
   @Test
@@ -142,8 +147,8 @@ public class SinkRecordConverterTest {
     assertTrue(!actual.containsKey("name") || actual.get("name") == null);
 
     // Verify CDC metadata columns
-    assertEquals("DELETE", actual.get("_CHANGE_TYPE"));
-    assertEquals("000000000000002A", actual.get("_CHANGE_SEQUENCE_NUMBER"));
+    assertEquals(CDC_CHANGE_TYPE_DELETE, actual.get(CDC_CHANGE_TYPE_FIELD));
+    assertEquals("00000001/000000000000002A", actual.get(CDC_CHANGE_SEQUENCE_NUMBER_FIELD));
   }
 
   @Test
@@ -168,7 +173,7 @@ public class SinkRecordConverterTest {
             .field("id", Schema.INT64_SCHEMA)
             .field("name", Schema.STRING_SCHEMA)
             .field("version_id", Schema.INT64_SCHEMA)
-            .field("__deleted", Schema.BOOLEAN_SCHEMA)
+            .field(DELETED_PSEUDO_COLUMN, Schema.BOOLEAN_SCHEMA)
             .build();
 
     Struct rewriteValueStruct =
@@ -176,7 +181,7 @@ public class SinkRecordConverterTest {
             .put("id", 123L)
             .put("name", "Alice")
             .put("version_id", 3L)
-            .put("__deleted", true);
+            .put(DELETED_PSEUDO_COLUMN, true);
 
     SinkRecord record =
         new SinkRecord(
@@ -185,8 +190,8 @@ public class SinkRecordConverterTest {
     SinkRecordConverter sinkRecordConverter = new SinkRecordConverter(config, null, null);
     Map<String, Object> actual = sinkRecordConverter.getCdcRow(record);
 
-    assertEquals("DELETE", actual.get("_CHANGE_TYPE"));
-    assertEquals("000000000000002A", actual.get("_CHANGE_SEQUENCE_NUMBER"));
+    assertEquals(CDC_CHANGE_TYPE_DELETE, actual.get(CDC_CHANGE_TYPE_FIELD));
+    assertEquals("00000001/000000000000002A", actual.get(CDC_CHANGE_SEQUENCE_NUMBER_FIELD));
   }
 
   @Test
@@ -199,7 +204,7 @@ public class SinkRecordConverterTest {
             .field("id", Schema.INT64_SCHEMA)
             .field("name", Schema.STRING_SCHEMA)
             .field("version_id", Schema.INT64_SCHEMA)
-            .field("__deleted", Schema.STRING_SCHEMA)
+            .field(DELETED_PSEUDO_COLUMN, Schema.STRING_SCHEMA)
             .build();
 
     Struct rewriteValueStruct =
@@ -207,7 +212,7 @@ public class SinkRecordConverterTest {
             .put("id", 123L)
             .put("name", "Alice")
             .put("version_id", 3L)
-            .put("__deleted", "true");
+            .put(DELETED_PSEUDO_COLUMN, "true");
 
     SinkRecord record =
         new SinkRecord(
@@ -216,8 +221,8 @@ public class SinkRecordConverterTest {
     SinkRecordConverter sinkRecordConverter = new SinkRecordConverter(config, null, null);
     Map<String, Object> actual = sinkRecordConverter.getCdcRow(record);
 
-    assertEquals("DELETE", actual.get("_CHANGE_TYPE"));
-    assertEquals("000000000000002A", actual.get("_CHANGE_SEQUENCE_NUMBER"));
+    assertEquals(CDC_CHANGE_TYPE_DELETE, actual.get(CDC_CHANGE_TYPE_FIELD));
+    assertEquals("00000001/000000000000002A", actual.get(CDC_CHANGE_SEQUENCE_NUMBER_FIELD));
   }
 
   @Test
@@ -230,7 +235,7 @@ public class SinkRecordConverterTest {
             .field("id", Schema.INT64_SCHEMA)
             .field("name", Schema.STRING_SCHEMA)
             .field("version_id", Schema.INT64_SCHEMA)
-            .field("__deleted", Schema.BOOLEAN_SCHEMA)
+            .field(DELETED_PSEUDO_COLUMN, Schema.BOOLEAN_SCHEMA)
             .build();
 
     Struct rewriteValueStruct =
@@ -238,7 +243,7 @@ public class SinkRecordConverterTest {
             .put("id", 123L)
             .put("name", "Alice")
             .put("version_id", 3L)
-            .put("__deleted", true);
+            .put(DELETED_PSEUDO_COLUMN, true);
 
     SinkRecord record =
         new SinkRecord(
@@ -247,7 +252,7 @@ public class SinkRecordConverterTest {
     SinkRecordConverter sinkRecordConverter = new SinkRecordConverter(config, null, null);
     Map<String, Object> actual = sinkRecordConverter.getCdcRow(record);
 
-    assertTrue(!actual.containsKey("__deleted"));
+    assertTrue(!actual.containsKey(DELETED_PSEUDO_COLUMN));
   }
 
   private static Map<String, Object> defaultExpectedFields() {

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverterTest.java
@@ -241,8 +241,7 @@ public class SinkRecordConverterTest {
 
   @Test
   public void testIsCdcEnabledWithoutUpsertOrDeleteFlags() {
-    when(config.getBoolean(BigQuerySinkConfig.USE_STORAGE_WRITE_API_CONFIG)).thenReturn(true);
-    when(config.isUpsertDeleteEnabled()).thenReturn(true);
+    when(config.isCdcEnabled()).thenReturn(true);
 
     SinkRecordConverter sinkRecordConverter = new SinkRecordConverter(config, null, null);
     assertTrue(sinkRecordConverter.isCdcEnabled());

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/utils/SinkRecordConverterTest.java
@@ -144,6 +144,58 @@ public class SinkRecordConverterTest {
   }
 
   @Test
+  public void testCdcRowUpsertDeterministicTimestampFallbackWhenNull() {
+    when(config.getBoolean(BigQuerySinkConfig.DELETE_ENABLED_CONFIG)).thenReturn(true);
+    when(config.getBoolean(BigQuerySinkConfig.UPSERT_ENABLED_CONFIG)).thenReturn(true);
+
+    SinkRecord record =
+        new SinkRecord(
+            TOPIC,
+            PARTITION,
+            keySchema,
+            keyStruct,
+            valueSchema,
+            valueStruct,
+            OFFSET,
+            null,
+            org.apache.kafka.common.record.TimestampType.NO_TIMESTAMP_TYPE);
+
+    SinkRecordConverter sinkRecordConverter = new SinkRecordConverter(config, null, null);
+    Map<String, Object> actual = sinkRecordConverter.getCdcRow(record);
+
+    assertEquals(CDC_CHANGE_TYPE_UPSERT, actual.get(CDC_CHANGE_TYPE_FIELD));
+    assertEquals(
+        String.format("%016X/%016X/%08X", 0L, OFFSET, PARTITION),
+        actual.get(CDC_CHANGE_SEQUENCE_NUMBER_FIELD));
+  }
+
+  @Test
+  public void testCdcRowUpsertDeterministicTimestampFallbackWhenNegative() {
+    when(config.getBoolean(BigQuerySinkConfig.DELETE_ENABLED_CONFIG)).thenReturn(true);
+    when(config.getBoolean(BigQuerySinkConfig.UPSERT_ENABLED_CONFIG)).thenReturn(true);
+
+    SinkRecord record =
+        new SinkRecord(
+            TOPIC,
+            PARTITION,
+            keySchema,
+            keyStruct,
+            valueSchema,
+            valueStruct,
+            OFFSET,
+            -1L,
+            org.apache.kafka.common.record.TimestampType.NO_TIMESTAMP_TYPE);
+
+    SinkRecordConverter sinkRecordConverter = new SinkRecordConverter(config, null, null);
+    Map<String, Object> actual = sinkRecordConverter.getCdcRow(record);
+
+    assertEquals(CDC_CHANGE_TYPE_UPSERT, actual.get(CDC_CHANGE_TYPE_FIELD));
+    assertEquals(
+        String.format("%016X/%016X/%08X", 0L, OFFSET, PARTITION),
+        actual.get(CDC_CHANGE_SEQUENCE_NUMBER_FIELD));
+  }
+
+  @Test
   public void testCdcRowDelete() {
     when(config.getBoolean(BigQuerySinkConfig.DELETE_ENABLED_CONFIG)).thenReturn(true);
     when(config.getBoolean(BigQuerySinkConfig.UPSERT_ENABLED_CONFIG)).thenReturn(true);

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBaseTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBaseTest.java
@@ -156,7 +156,7 @@ class StorageWriteApiBaseTest {
     RowsTooLargeStreamWriter streamWriter =
         new RowsTooLargeStreamWriter("appendRowsTooLargeTestWithStorageWriteAPI");
     BigQuerySinkTaskConfig config = storageWriteApiConfig();
-    executeInitializeAndWriteRecordsTestData(streamWriter, config, null);
+    executeInitializeAndWriteRecordsTestData(streamWriter, config, mock(SchemaManager.class));
 
     // verify the results
     List<JSONArray> result = streamWriter.appendCalls;
@@ -177,7 +177,7 @@ class StorageWriteApiBaseTest {
     RowsTooLargeStreamWriter streamWriter =
         new RowsTooLargeStreamWriter("appendRowsTooLargeTestWithStorageWriteGCS");
     BigQuerySinkTaskConfig config = storageWriteGCSConfig();
-    executeInitializeAndWriteRecordsTestData(streamWriter, config, null);
+    executeInitializeAndWriteRecordsTestData(streamWriter, config, mock(SchemaManager.class));
 
     // verify the results
     List<JSONArray> result = streamWriter.appendCalls;

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBaseTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiBaseTest.java
@@ -245,6 +245,68 @@ class StorageWriteApiBaseTest {
     assertNotEquals(ulid2, ulid1);
   }
 
+  @Test
+  public void testGetJsonRecords_generatesCorrectChangeSequenceNumberFormat() {
+    Map<String, String> params = new HashMap<>(defaultMap);
+    params.put("useStorageWriteApi", "true");
+    params.put("upsertEnabled", "true");
+    BigQuerySinkTaskConfig config = new BigQuerySinkTaskConfig(params);
+
+    StorageWriteApiBase underTest =
+        new StorageWriteApiBase(
+            1,
+            1000,
+            mock(BigQueryWriteSettings.class),
+            true,
+            null,
+            mock(SchemaManager.class),
+            false,
+            config) {
+          @Override
+          public void preShutdown() {}
+
+          @Override
+          protected StreamWriter streamWriter(
+              PartitionedTableId table, String streamName, List<ConvertedRecord> records) {
+            return null;
+          }
+
+          @Override
+          protected BigQueryWriteClient getWriteClient() {
+            return null;
+          }
+        };
+
+    long timestamp = 1693742400000L;
+    int partition = 3;
+    long offset = 1050L;
+    SinkRecord record =
+        new SinkRecord(
+            "test-topic",
+            partition,
+            null,
+            "key1",
+            SchemaBuilder.struct().field("val", Schema.STRING_SCHEMA),
+            new Struct(SchemaBuilder.struct().field("val", Schema.STRING_SCHEMA))
+                .put("val", "hello"),
+            offset,
+            timestamp,
+            org.apache.kafka.common.record.TimestampType.CREATE_TIME);
+
+    JSONObject converted = new JSONObject();
+    converted.put("val", "hello");
+    ConvertedRecord item = new ConvertedRecord(record, converted);
+
+    JSONArray result = underTest.getJsonRecords(Collections.singletonList(item));
+    assertEquals(1, result.length());
+    JSONObject row = result.getJSONObject(0);
+
+    assertEquals("UPSERT", row.getString(StorageWriteApiBase.CHANGE_TYPE_PSEUDO_COLUMN));
+    String expectedSeq = String.format("%016X/%016X/%08X", timestamp, offset, partition);
+    assertEquals(
+        expectedSeq, row.getString(StorageWriteApiBase.CHANGE_SEQUENCE_NUMBER_PSEUDO_COLUMN));
+  }
+
   private String assertSameUlid(JSONArray ary) {
     Set<String> ulids = new HashSet<>();
     for (int i = 0; i < ary.length(); i++) {

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiDefaultStreamTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiDefaultStreamTest.java
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.api.core.ApiFuture;
@@ -194,7 +194,9 @@ public class StorageWriteApiDefaultStreamTest {
     assertThrows(
         BigQueryStorageWriteApiConnectException.class,
         () -> defaultStream.initializeAndWriteRecords(mockedPartitionedTableId, testRows, null));
-    verifyNoInteractions(mockedSchemaManager);
+    verify(mockedSchemaManager, times(1))
+        .checkAndApplyTableOptions(mockedPartitionedTableId.getBaseTableId());
+    verifyNoMoreInteractions(mockedSchemaManager);
   }
 
   @ParameterizedTest(name = "{index} – {0}")


### PR DESCRIPTION
# Pull Request: Support BigQuery Storage Write API CDC Prototype

## Description
This pull request enables native **Change Data Capture (CDC)** (in-storage row upserts and deletions) when using the high-performance **BigQuery Storage Write API** (`useStorageWriteApi = true`). It removes legacy validator restrictions that blocked CDC with the Storage Write API, formats Kafka partition offsets as deterministic hexadecimal sequence numbers, strips transient SMT deletion metadata, and adds automated table staleness management.

---

### Key Enhancements:

1. **Enables Storage Write API CDC Validation**:
   * **Removes Obsolete Validator Blocks**: Removes configuration checks in `StorageWriteApiValidator` that previously prohibited combining `useStorageWriteApi = true` with `upsertEnabled = true` or `deleteEnabled = true`. BigQuery Storage Write API natively supports in-storage deduplication and deletes via primary keys defined on the BigQuery table.
   * **Bypasses Legacy Merge Engine**: Relaxes requirements in `UpsertDeleteValidator` for batch merge settings (e.g., merge intervals, batch thresholds) when using the Storage Write API, as row merging is handled natively by BigQuery.

2. **Monotonic Sequence Ordering via Kafka Partition Offsets (`SinkRecordConverter.java`)**:
   * BigQuery CDC relies on `_CHANGE_SEQUENCE_NUMBER` (a hexadecimal string) to establish change order.
   * By default, the connector extracts the unique, monotonically increasing **Kafka partition offset** (`record.kafkaOffset()`) and formats it into a fixed-width hexadecimal sequence string via `convertToHexSequence(kafkaOffset)`:
     ```java
     String hexSeq = String.format("%016X", kafkaOffset);
     result.put("_CHANGE_SEQUENCE_NUMBER", hexSeq);
     ```
   * This guarantees strictly increasing, deterministic sequence ordering for all streaming change events.

3. **Debezium SMT Deletion & `__deleted` Metadata Handling**:
   * In `getCdcRow()`, the connector detects deletions by checking both null tombstones (`record.value() == null`) and the transient `"__deleted"` boolean flag produced by Debezium SMTs:
     ```java
     String changeType = "UPSERT";
     if (record.value() == null) {
       changeType = "DELETE";
     } else if (convertedValue != null) {
       Object deletedVal = convertedValue.get("__deleted");
       if (deletedVal instanceof Boolean && (Boolean) deletedVal) {
         changeType = "DELETE";
       } else if (deletedVal instanceof String && Boolean.parseBoolean((String) deletedVal)) {
         changeType = "DELETE";
       }
     }
     result.put("_CHANGE_TYPE", changeType);
     ```
   * **Strips `__deleted` Column**: Automatically removes `"__deleted"` (`result.remove("__deleted")`) from the final write payload before sending to BigQuery, preventing schema mismatch errors while ensuring proper delete propagation.

4. **Table Max Staleness Automation**:
   * Added a `"tableMaxStaleness"` configuration option of type `INT` (seconds).
   * When configured, the connector automatically applies the staleness constraint to auto-created BigQuery tables (`ALTER TABLE ... SET OPTIONS (max_staleness = INTERVAL <seconds> SECOND)`), allowing users to enforce real-time query merges (e.g., setting staleness to `0` seconds).

---

## File-by-File Summary of Changes

### Configuration & Task Lifecycle
* **`BigQuerySinkConfig.java`**:
  * Added `tableMaxStaleness` configuration definition (`Type.INT`, default `null`).
  * Added getter `getTableMaxStaleness()` returning `Optional<Integer>`.
* **`BigQuerySinkTask.java`**:
  * Updated `newSchemaManager()` to retrieve and pass `tableMaxStaleness` as `Optional<Integer>`.

### Validators
* **`StorageWriteApiValidator.java`**:
  * Removed `upsertNotSupportedError` and `deleteNotSupportedError` validation constraints.
* **`UpsertDeleteValidator.java`**:
  * Bypassed legacy batch merge configuration checks when `useStorageWriteApi` is enabled.

### Schema Management
* **`SchemaManager.java`**:
  * Updated constructors and fields to accept `Optional<Integer>` for `tableMaxStaleness`.
  * Modified `applyMaxStaleness` to execute:
    ```sql
    ALTER TABLE %s SET OPTIONS (max_staleness = INTERVAL %d SECOND)
    ```
* **`BigQuerySchemaConverter.java`**:
  * Added filters in `convertSchema` and `convertStruct` to skip the transient `"__deleted"` field during BigQuery schema generation.

### Record Conversion & CDC Payload Handling
* **`SinkRecordConverter.java`**:
  * **`getCdcRow(SinkRecord record, String writeAttemptId)`**:
    * Determines if a record is a deletion by checking both raw tombstones and the `"__deleted"` SMT metadata field.
    * Strips `"__deleted"` from the output map before sending to BigQuery.
    * Converts the record's Kafka offset to a 16-character hexadecimal sequence string (`convertToHexSequence(kafkaOffset)`) and assigns it to `_CHANGE_SEQUENCE_NUMBER`.