### PR TITLE
Handle HTTP 413 as a batch-size error on the insertAll path

### DIFF
--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/BigQueryErrorResponses.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/exception/BigQueryErrorResponses.java
@@ -41,6 +41,7 @@ public class BigQueryErrorResponses {
   private static final int AUTHENTICATION_ERROR_CODE = 401;
   private static final int FORBIDDEN_CODE = 403;
   private static final int NOT_FOUND_CODE = 404;
+  private static final int CONTENT_TOO_LARGE_CODE = 413;
   private static final int INTERNAL_SERVICE_ERROR_CODE = 500;
   private static final int BAD_GATEWAY_CODE = 502;
   private static final int SERVICE_UNAVAILABLE_CODE = 503;
@@ -144,6 +145,23 @@ public class BigQueryErrorResponses {
     return BAD_REQUEST_CODE == exception.getCode()
         && BAD_REQUEST_REASON.equals(exception.getReason())
         && message(exception.getError()).startsWith("Request payload size exceeds the limit: ");
+  }
+
+  /**
+   * Google's HTTP frontend can reject a very large request before it reaches the BigQuery API,
+   * answering with an HTTP 413 and an HTML body instead of the documented JSON error that {@link
+   * #isRequestTooLargeError(BigQueryException)} matches. Which of the two responses comes back is
+   * not deterministic: an identical oversized request can be answered with the 400 JSON error on
+   * one attempt and the 413 on the next, so both have to be treated as meaning the payload was too
+   * large.
+   *
+   * <p>A 413 does not always mean the request was too large: per <a
+   * href="https://docs.cloud.google.com/docs/quotas/troubleshoot">Google's quota troubleshooting
+   * guide</a>, the legacy streaming API also returns one when throughput exceeds 300MB/s. This is a
+   * separate edge case that this project does not yet handle.
+   */
+  public static boolean isContentTooLargeError(BigQueryException exception) {
+    return CONTENT_TOO_LARGE_CODE == exception.getCode();
   }
 
   public static boolean isTooManyRowsError(BigQueryException exception) {

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/batch/TableWriter.java
@@ -119,9 +119,13 @@ public class TableWriter implements Runnable {
      * documented but is referenced slightly under "Error codes" here:
      * https://cloud.google.com/bigquery/quota-policy
      * (by decreasing the batch size we can eventually expect to end up with a request under 10MB)
+     *
+     * A 413 is the same condition reported by Google's HTTP frontend rather than by BigQuery
+     * itself, which happens intermittently for payloads well above the limit.
      */
     return BigQueryErrorResponses.isUnspecifiedBadRequestError(exception)
         || BigQueryErrorResponses.isRequestTooLargeError(exception)
+        || BigQueryErrorResponses.isContentTooLargeError(exception)
         || BigQueryErrorResponses.isTooManyRowsError(exception);
   }
 

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/exception/BigQueryErrorResponsesTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/exception/BigQueryErrorResponsesTest.java
@@ -98,6 +98,21 @@ public class BigQueryErrorResponsesTest {
   }
 
   @Test
+  public void testIsContentTooLargeError() {
+    // Google's HTTP frontend answers with an HTML body, so the client populates neither a reason
+    // nor a structured error - only the status code
+    assertTrue(
+        BigQueryErrorResponses.isContentTooLargeError(
+            new BigQueryException(413, "413 Request Entity Too Large")));
+
+    // the 400 form of the same condition is matched by isRequestTooLargeError instead
+    String message = "Request payload size exceeds the limit: 10485760 bytes.";
+    assertFalse(
+        BigQueryErrorResponses.isContentTooLargeError(
+            new BigQueryException(400, message, new BigQueryError("badRequest", null, message))));
+  }
+
+  @Test
   public void testIsAuthenticationError() {
     BigQueryException error = new BigQueryException(0, "......401.....Unauthorized error.....");
     assertTrue(BigQueryErrorResponses.isAuthenticationError(error));

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BigQueryErrorResponsesIT.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/integration/BigQueryErrorResponsesIT.java
@@ -48,12 +48,15 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import org.apache.kafka.test.TestUtils;
@@ -273,6 +276,60 @@ public class BigQueryErrorResponsesIT extends BaseConnectorIT {
 
     logger.debug("Large request payload write error", e);
     assertTrue(BigQueryErrorResponses.isRequestTooLargeError(e));
+  }
+
+  @Test
+  public void testContentTooLarge() throws Exception {
+    TableId table = TableId.of(dataset(), suffixedAndSanitizedTable("content too large"));
+    Schema schema =
+        Schema.of(
+            Field.newBuilder("f1", StandardSQLTypeName.STRING)
+                .setMode(Field.Mode.REQUIRED)
+                .build());
+    createOrAssertSchemaMatches(table, schema);
+
+    // The payload must be incompressible: the client gzips request bodies and the frontend judges
+    // the compressed size, so repetitive filler would shrink enough to draw the 400 instead.
+    byte[] randomBytes = new byte[50 * 1024 * 1024];
+    new Random().nextBytes(randomBytes);
+    String columnValue = Base64.getEncoder().encodeToString(randomBytes);
+    InsertAllRequest request =
+        InsertAllRequest.of(table, RowToInsert.of(Collections.singletonMap("f1", columnValue)));
+
+    final ExceptionTracker exceptionTracker = new ExceptionTracker();
+    final AtomicInteger attempts = new AtomicInteger();
+
+    // An oversized request is answered either with the documented 400 JSON error or, once the
+    // frontend rejects it before reading the body, with a 413. Which one comes back is not
+    // deterministic, so re-issue the same request until the 413 appears. Every rejected attempt
+    // uploads the whole payload first, so allow for several slow round trips.
+    TestUtils.waitForCondition(
+        () -> {
+          try {
+            bigQuery.insertAll(request);
+            return false;
+          } catch (BigQueryException e) {
+            exceptionTracker.recordException(e);
+            int attempt = attempts.incrementAndGet();
+            if (BigQueryErrorResponses.isContentTooLargeError(e)) {
+              logger.info("Attempt {} was rejected with an HTTP 413, as expected", attempt);
+              return true;
+            }
+            // the 400 form is the other acceptable answer; anything else is a real failure
+            assertTrue(
+                BigQueryErrorResponses.isRequestTooLargeError(e),
+                "Oversized request failed with an unexpected error: " + e.getMessage());
+            logger.info("Attempt {} was rejected with the 400 form; retrying", attempt);
+            return false;
+          }
+        },
+        5 * ONE_MINUTE,
+        ONE_SECOND,
+        () ->
+            exceptionTracker.report(
+                "BigQuery never answered an oversized request with an HTTP 413 after "
+                    + attempts.get()
+                    + " attempts."));
   }
 
   @Test


### PR DESCRIPTION
TableWriter halves the batch and retries when BigQuery rejects a streaming insert for being too large, but it only recognized HTTP 400 responses with a JSON body. For very large payloads Google's HTTP frontend rejects the request before it reaches BigQuery, answering with an HTTP 413 and an HTML body. That arrives as a `BigQueryException` with code 413 and a null reason and error, so it matched no predicate, the batch was never split, and the task failed.

Which response comes back is not deterministic: a slow first call draws the 400, while an immediate repeat of the same 50MB payload is answered quickly with the 413.

It is very easy to reproduce this using curl.  First, create a `payload.bin` of 50 megabytes.  It must be incompressible (e.g. copy from `/dev/random`).  Next, try posting it.

    % curl -s -i \
      -X POST \
      -H "Content-Type: application/octet-stream" \
      --data-binary @/tmp/payload.bin \
      'https://bigquery.googleapis.com/bigquery/v2/projects/myproj/datasets/testds/tables/testtable/insertAll?prettyPrint=false'
    HTTP/2 413
    content-type: text/html; charset=UTF-8
    content-length: 2393

    <!DOCTYPE html>
    <html lang=en>
      <title>Error 413 (Request Entity Too Large)!!1</title>
      <p><b>413.</b> <ins>That's an error.</ins>
      <p>Your client issued a request that was too large.
      <ins>That's all we know.</ins>

In this PR, the new error classification function `isContentTooLargeError` matches on the status code alone, since the HTML body leaves nothing else to go on, and is ORed into the existing `isBatchSizeError` implementation.

Without this change, the above scenario will cause the task to fail with:

```
org.apache.kafka.connect.errors.ConnectException: Exiting WorkerSinkTask due to unrecoverable exception.
	at org.apache.kafka.connect.runtime.WorkerSinkTask.deliverMessages(WorkerSinkTask.java:659)
	at org.apache.kafka.connect.runtime.WorkerSinkTask.poll(WorkerSinkTask.java:360)
	at org.apache.kafka.connect.runtime.WorkerSinkTask.iteration(WorkerSinkTask.java:262)
	at org.apache.kafka.connect.runtime.WorkerSinkTask.execute(WorkerSinkTask.java:226)
	at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:243)
	at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:298)
	at org.apache.kafka.connect.runtime.isolation.Plugins.lambda$withClassLoader$1(Plugins.java:254)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
Caused by: com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException: A write thread has failed with an unrecoverable error Caused by: Failed to write to table
	at com.wepay.kafka.connect.bigquery.write.batch.KcbqThreadPoolExecutor.lambda$maybeThrowEncounteredError$0(KcbqThreadPoolExecutor.java:111)
	at java.base/java.util.Optional.ifPresent(Unknown Source)
	at com.wepay.kafka.connect.bigquery.write.batch.KcbqThreadPoolExecutor.maybeThrowEncounteredError(KcbqThreadPoolExecutor.java:110)
	at com.wepay.kafka.connect.bigquery.BigQuerySinkTask.maybeThrowErrors(BigQuerySinkTask.java:557)
	at com.wepay.kafka.connect.bigquery.BigQuerySinkTask.writeSinkRecords(BigQuerySinkTask.java:215)
	at com.wepay.kafka.connect.bigquery.BigQuerySinkTask.put(BigQuerySinkTask.java:285)
	at org.apache.kafka.connect.runtime.WorkerSinkTask.deliverMessages(WorkerSinkTask.java:629)
	... 11 more
Caused by: com.wepay.kafka.connect.bigquery.exception.BigQueryConnectException: Failed to write to table Caused by: 413 Request Entity Too Large
POST https://bigquery.googleapis.com/bigquery/v2/projects/tt-dp-staging/datasets/cdc_pg_customerinfo/tables/multimodal_queries_v1_tmp_0_75540e19_bca6_41b8_8034_665e34643f75_1787095725666/insertAll?prettyPrint=false <!DOCTYPE html>
<html lang=en>
  <meta charset=utf-8>
  <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
  <title>Error 413 (Request Entity Too Large)!!1</title>
  <snip>

	at com.wepay.kafka.connect.bigquery.write.batch.TableWriter.run(TableWriter.java:149)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at com.wepay.kafka.connect.bigquery.BigQuerySinkTask$MdcContextThreadFactory.lambda$newThread$0(BigQuerySinkTask.java:671)
	... 1 more
Caused by: com.google.cloud.bigquery.BigQueryException: 413 Request Entity Too Large POST https://bigquery.googleapis.com/bigquery/v2/projects/tt-dp-staging/datasets/cdc_pg_customerinfo/tables/multimodal_queries_v1_tmp_0_75540e19_bca6_41b8_8034_665e34643f75_1787095725666/insertAll?prettyPrint=false <!DOCTYPE html>
<html lang=en>
  <meta charset=utf-8>
  <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
  <title>Error 413 (Request Entity Too Large)!!1</title>
  <snip>

	at com.google.cloud.bigquery.spi.v2.HttpBigQueryRpc.translate(HttpBigQueryRpc.java:115)
	at com.google.cloud.bigquery.spi.v2.HttpBigQueryRpc.insertAll(HttpBigQueryRpc.java:548)
	at com.google.cloud.bigquery.BigQueryImpl$28.call(BigQueryImpl.java:1119)
	at com.google.cloud.bigquery.BigQueryImpl$28.call(BigQueryImpl.java:1116)
	at com.google.api.gax.retrying.DirectRetryingExecutor.submit(DirectRetryingExecutor.java:103)
	at com.google.cloud.RetryHelper.run(RetryHelper.java:76)
	at com.google.cloud.RetryHelper.runWithRetries(RetryHelper.java:50)
	at com.google.cloud.bigquery.BigQueryImpl.insertAll(BigQueryImpl.java:1115)
	at com.wepay.kafka.connect.bigquery.write.row.AdaptiveBigQueryWriter.performWriteRequest(AdaptiveBigQueryWriter.java:131)
	at com.wepay.kafka.connect.bigquery.write.row.BigQueryWriter.writeRows(BigQueryWriter.java:150)
	at com.wepay.kafka.connect.bigquery.write.batch.TableWriter.run(TableWriter.java:136)
	... 4 more
Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 413 Request Entity Too Large POST https://bigquery.googleapis.com/bigquery/v2/projects/tt-dp-staging/datasets/cdc_pg_customerinfo/tables/multimodal_queries_v1_tmp_0_75540e19_bca6_41b8_8034_665e34643f75_1787095725666/insertAll?prettyPrint=false <!DOCTYPE html>
<html lang=en>
  <meta charset=utf-8>
  <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
  <title>Error 413 (Request Entity Too Large)!!1</title>
  <snip>

	at com.google.api.client.googleapis.json.GoogleJsonResponseException.from(GoogleJsonResponseException.java:146)
	at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:118)
	at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:37)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest$3.interceptResponse(AbstractGoogleClientRequest.java:466)
	at com.google.api.client.http.HttpRequest.execute(HttpRequest.java:1111)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:552)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:493)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.execute(AbstractGoogleClientRequest.java:603)
	at com.google.cloud.bigquery.spi.v2.HttpBigQueryRpc.insertAll(HttpBigQueryRpc.java:546)
	... 13 more
```

After making this change, the task halves the batch sizes as expected, and then runs to completion.  With this change, the task logs warnings as one might expect.  We tested this in our staging environment where version 2.12.0 was consistently crashing with this error.  Now, the staging environment logs a new message at warning level.  The connector does not fail and the backfilling eventually finishes successfully since batch sizes are being halved.  From our logs:

```
Message: Could not write batch of size 500 to BigQuery.
    Error code: 413, underlying error (if present): null

Stack trace:

com.google.cloud.bigquery.BigQueryException: 413 Request Entity Too Large POST https://bigquery.googleapis.com/bigquery/v2/projects/tt-dp-staging/datasets/cdc_pg_customerinfo/tables/multimodal_queries_v1_tmp_0_01M0X9WZ654SJEHRA4PS71PFZD_1787689860314/insertAll?prettyPrint=false <!DOCTYPE html>
<html lang=en>
  <meta charset=utf-8>
  <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
  <title>Error 413 (Request Entity Too Large)!!1</title>
  <snip>
	at com.google.cloud.bigquery.spi.v2.HttpBigQueryRpc.translate(HttpBigQueryRpc.java:115)
	at com.google.cloud.bigquery.spi.v2.HttpBigQueryRpc.insertAll(HttpBigQueryRpc.java:548)
	at com.google.cloud.bigquery.BigQueryImpl$28.call(BigQueryImpl.java:1119)
	at com.google.cloud.bigquery.BigQueryImpl$28.call(BigQueryImpl.java:1116)
	at com.google.api.gax.retrying.DirectRetryingExecutor.submit(DirectRetryingExecutor.java:103)
	at com.google.cloud.RetryHelper.run(RetryHelper.java:76)
	at com.google.cloud.RetryHelper.runWithRetries(RetryHelper.java:50)
	at com.google.cloud.bigquery.BigQueryImpl.insertAll(BigQueryImpl.java:1115)
	at com.wepay.kafka.connect.bigquery.write.row.AdaptiveBigQueryWriter.performWriteRequest(AdaptiveBigQueryWriter.java:134)
	at com.wepay.kafka.connect.bigquery.write.row.BigQueryWriter.writeRows(BigQueryWriter.java:185)
	at com.wepay.kafka.connect.bigquery.write.batch.TableWriter.run(TableWriter.java:149)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at com.wepay.kafka.connect.bigquery.BigQuerySinkTask$MdcContextThreadFactory.lambda$newThread$0(BigQuerySinkTask.java:699)
	at java.base/java.lang.Thread.run(Unknown Source)
Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 413 Request Entity Too Large POST https://bigquery.googleapis.com/bigquery/v2/projects/tt-dp-staging/datasets/cdc_pg_customerinfo/tables/multimodal_queries_v1_tmp_0_01M0X9WZ654SJEHRA4PS71PFZD_1787689860314/insertAll?prettyPrint=false <!DOCTYPE html>
<html lang=en>
  <meta charset=utf-8>
  <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
  <title>Error 413 (Request Entity Too Large)!!1</title>
  <snip>

	at com.google.api.client.googleapis.json.GoogleJsonResponseException.from(GoogleJsonResponseException.java:146)
	at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:118)
	at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:37)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest$3.interceptResponse(AbstractGoogleClientRequest.java:466)
	at com.google.api.client.http.HttpRequest.execute(HttpRequest.java:1111)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:552)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:493)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.execute(AbstractGoogleClientRequest.java:603)
	at com.google.cloud.bigquery.spi.v2.HttpBigQueryRpc.insertAll(HttpBigQueryRpc.java:546)
	... 13 more
```

This manual testing in our deployment environment proved to our satisfaction that this PR helps with HTTP 413 errors that were not previously addressed.

Developer Certificate of Origin:

The contribution was created in whole or in part by me and I have the right to submit it under the open source license
indicated in the file