### PR TITLE
Add defaultStreamWritersPerTable for parallel Storage Write API writers

### DIFF
--- a/docs/sink-connector-config-options.rst
+++ b/docs/sink-connector-config-options.rst
@@ -212,6 +212,14 @@ BigQuery Sink Connector Configuration Options
   * Default: false
   * Importance: low
 
+``defaultStreamWritersPerTable``
+  The number of concurrent Storage Write API writers per destination table in default-stream mode (useStorageWriteApi=true, enableBatchMode=false). Each writer serializes its appends, so with the default of 1 all write threads targeting a table take turns; raising it lets up to that many threads write to the table in parallel. Set it to threadPoolSize for full parallelism; values above that have no effect. Not used in batch mode.
+
+  * Type: int
+  * Default: 1
+  * Valid Values: [1,...]
+  * Importance: low
+
 ``deleteEnabled``
   Enable delete functionality on the connector through the use of record keys, intermediate tables, and periodic merge flushes. A delete will be performed when a record with a null value (i.e., a tombstone record) is read.
 

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/config/BigQuerySinkConfig.java
@@ -166,6 +166,9 @@ public class BigQuerySinkConfig extends AbstractConfig {
   public static final long MERGE_RECORDS_THRESHOLD_DEFAULT = -1;
   public static final String THREAD_POOL_SIZE_CONFIG = "threadPoolSize";
   public static final Integer THREAD_POOL_SIZE_DEFAULT = 10;
+  public static final String DEFAULT_STREAM_WRITERS_PER_TABLE_CONFIG =
+      "defaultStreamWritersPerTable";
+  public static final int DEFAULT_STREAM_WRITERS_PER_TABLE_DEFAULT = 1;
   public static final String QUEUE_SIZE_CONFIG = "queueSize";
   // should this even have a default?
   public static final Long QUEUE_SIZE_DEFAULT = -1L;
@@ -579,6 +582,18 @@ public class BigQuerySinkConfig extends AbstractConfig {
   private static final String THREAD_POOL_SIZE_DOC =
       "The size of the BigQuery write thread pool. This establishes the maximum number of "
           + "concurrent writes to BigQuery.";
+  private static final ConfigDef.Type DEFAULT_STREAM_WRITERS_PER_TABLE_TYPE = ConfigDef.Type.INT;
+  private static final ConfigDef.Validator DEFAULT_STREAM_WRITERS_PER_TABLE_VALIDATOR =
+      ConfigDef.Range.atLeast(1);
+  private static final ConfigDef.Importance DEFAULT_STREAM_WRITERS_PER_TABLE_IMPORTANCE =
+      ConfigDef.Importance.LOW;
+  private static final String DEFAULT_STREAM_WRITERS_PER_TABLE_DOC =
+      "The number of concurrent Storage Write API writers per destination table in default-stream "
+          + "mode (useStorageWriteApi=true, enableBatchMode=false). Each writer serializes its "
+          + "appends, so with the default of 1 all write threads targeting a table take turns; "
+          + "raising it lets up to that many threads write to the table in parallel. Set it to "
+          + "threadPoolSize for full parallelism; values above that have no effect. Not used in "
+          + "batch mode.";
   private static final ConfigDef.Type QUEUE_SIZE_TYPE = ConfigDef.Type.LONG;
   private static final ConfigDef.Validator QUEUE_SIZE_VALIDATOR = ConfigDef.Range.atLeast(-1);
   private static final ConfigDef.Importance QUEUE_SIZE_IMPORTANCE = ConfigDef.Importance.HIGH;
@@ -1066,6 +1081,13 @@ public class BigQuerySinkConfig extends AbstractConfig {
             THREAD_POOL_SIZE_VALIDATOR,
             THREAD_POOL_SIZE_IMPORTANCE,
             THREAD_POOL_SIZE_DOC)
+        .define(
+            DEFAULT_STREAM_WRITERS_PER_TABLE_CONFIG,
+            DEFAULT_STREAM_WRITERS_PER_TABLE_TYPE,
+            DEFAULT_STREAM_WRITERS_PER_TABLE_DEFAULT,
+            DEFAULT_STREAM_WRITERS_PER_TABLE_VALIDATOR,
+            DEFAULT_STREAM_WRITERS_PER_TABLE_IMPORTANCE,
+            DEFAULT_STREAM_WRITERS_PER_TABLE_DOC)
         .define(
             QUEUE_SIZE_CONFIG,
             QUEUE_SIZE_TYPE,

--- a/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiDefaultStream.java
+++ b/kcbq-connector/src/main/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiDefaultStream.java
@@ -40,17 +40,33 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 import org.json.JSONArray;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * An extension of {@link StorageWriteApiBase} which uses default streams to write data following at
- * least once semantic
+ * least once semantic.
+ *
+ * <p>{@link JsonStreamWriter#append} is synchronized per instance and converts JSON to protobuf
+ * inside the lock, so a single writer per table serializes every write thread targeting that table.
+ * {@code defaultStreamWritersPerTable} opens up to N writers per table, each worker thread being
+ * assigned one slot round-robin on its first write to any table and keeping it. Threads are spread
+ * evenly over the slots when N equals {@code threadPoolSize}; smaller N is approximately balanced.
+ * The default of 1 keeps the previous behavior.
  */
 public class StorageWriteApiDefaultStream extends StorageWriteApiBase {
   private static final Logger logger = LoggerFactory.getLogger(StorageWriteApiDefaultStream.class);
-  ConcurrentMap<String, JsonStreamWriter> tableToStream = new ConcurrentHashMap<>();
+  // Slots are created lazily; the atomic array publishes each writer to the lock-free fast path
+  // in getDefaultStream.
+  ConcurrentMap<String, AtomicReferenceArray<JsonStreamWriter>> tableToStreams =
+      new ConcurrentHashMap<>();
+
+  @VisibleForTesting int writersPerTable;
+  @VisibleForTesting ThreadLocal<Integer> threadWriterSlot;
 
   public StorageWriteApiDefaultStream(
       int retry,
@@ -70,6 +86,9 @@ public class StorageWriteApiDefaultStream extends StorageWriteApiBase {
         schemaManager,
         attemptSchemaUpdate,
         config);
+    this.writersPerTable =
+        config.getInt(BigQuerySinkConfig.DEFAULT_STREAM_WRITERS_PER_TABLE_CONFIG);
+    this.threadWriterSlot = slotAssigner(writersPerTable);
   }
 
   /**
@@ -96,38 +115,73 @@ public class StorageWriteApiDefaultStream extends StorageWriteApiBase {
         errantRecordHandler,
         schemaManager,
         attemptSchemaUpdate);
+    this.writersPerTable = BigQuerySinkConfig.DEFAULT_STREAM_WRITERS_PER_TABLE_DEFAULT;
+    this.threadWriterSlot = slotAssigner(writersPerTable);
+  }
+
+  /** Assigns each thread the next slot on first use, round-robin, and keeps it for that thread. */
+  @VisibleForTesting
+  static ThreadLocal<Integer> slotAssigner(int writersPerTable) {
+    AtomicInteger next = new AtomicInteger(0);
+    return ThreadLocal.withInitial(() -> Math.floorMod(next.getAndIncrement(), writersPerTable));
   }
 
   @Override
   public void preShutdown() {
-    logger.info("Closing all writer for default stream on all tables");
-    tableToStream.keySet().forEach(this::closeAndDelete);
-    logger.info("Closed all writer for default stream on all tables");
+    logger.info("Closing all writers for default stream on all tables");
+    tableToStreams.keySet().forEach(this::closeAndDelete);
+    logger.info("Closed all writers for default stream on all tables");
   }
 
   /**
    * Either gets called when shutting down the task or when we receive exception that the stream is
-   * actually closed on Google side. This will close and remove the stream from our cache.
+   * actually closed on Google side. This will close and remove every writer for the table.
    *
-   * @param tableName The table name for which stream has to be removed.
+   * @param tableName The table name for which writers have to be removed.
    */
   private void closeAndDelete(String tableName) {
-    tableToStream.computeIfPresent(
+    tableToStreams.computeIfPresent(
         tableName,
-        (t, writer) -> {
-          logger.debug("Closing stream on table {}", t);
-          try {
-            writer.close();
-            logger.debug("Closed stream on table {}", t);
-          } catch (Throwable e) {
-            logger.warn("Error closing stream for table {}", t, e);
+        (t, writers) -> {
+          logger.debug("Closing {} writer(s) on table {}", writers.length(), t);
+          for (int i = 0; i < writers.length(); i++) {
+            JsonStreamWriter writer = writers.get(i);
+            if (writer == null) {
+              continue;
+            }
+            try {
+              writer.close();
+              logger.debug("Closed writer {} on table {}", i, t);
+            } catch (Throwable e) {
+              logger.warn("Error closing writer {} for table {}", i, t, e);
+            }
           }
           return null;
         });
   }
 
   /**
-   * Open a default stream on table if not already present
+   * Close and remove one writer of a table, only if it is still the writer that failed. A writer
+   * that another thread already replaced is left alone.
+   */
+  private void closeSlot(String tableName, int slot, JsonStreamWriter failed) {
+    tableToStreams.computeIfPresent(
+        tableName,
+        (t, writers) -> {
+          if (writers.compareAndSet(slot, failed, null)) {
+            logger.debug("Closing writer {} on table {}", slot, t);
+            try {
+              failed.close();
+            } catch (Throwable e) {
+              logger.warn("Error closing writer {} for table {}", slot, t, e);
+            }
+          }
+          return writers;
+        });
+  }
+
+  /**
+   * Open a default stream on table if not already present in the calling thread's slot.
    *
    * @param table The table on which stream has to be opened
    * @param rows The input rows (would be sent while table creation to identify schema)
@@ -136,32 +190,68 @@ public class StorageWriteApiDefaultStream extends StorageWriteApiBase {
   @VisibleForTesting
   JsonStreamWriter getDefaultStream(PartitionedTableId table, List<ConvertedRecord> rows) {
     String tableName = TableNameUtils.tableName(table.getFullTableId()).toString();
-    return tableToStream.computeIfAbsent(
+    int slot = writerSlot();
+    AtomicReferenceArray<JsonStreamWriter> writers =
+        tableToStreams.computeIfAbsent(tableName, t -> new AtomicReferenceArray<>(writersPerTable));
+    JsonStreamWriter existing = writers.get(slot);
+    if (existing != null) {
+      return existing;
+    }
+    // The fast path above may return a writer that a concurrent close just retired; the append
+    // then fails with a closed-stream error and the caller refreshes, as before this change.
+    // Creation runs inside compute() so it serializes with close paths on the table key and a
+    // concurrent close cannot drop the entry while a stream is still being opened.
+    // Capture the writer inside compute(): a re-read of the slot after compute() returns could
+    // observe a concurrent closeSlot() and yield null.
+    AtomicReference<JsonStreamWriter> created = new AtomicReference<>();
+    tableToStreams.compute(
         tableName,
-        t -> {
-          StorageWriteApiRetryHandler retryHandler =
-              new StorageWriteApiRetryHandler(
-                  table.getBaseTableId(), getSinkRecords(rows), retry, retryWait, time);
-          do {
-            try {
-              return jsonWriterFactory.create(tableName);
-            } catch (Exception e) {
-              String baseErrorMessage =
-                  String.format(
-                      "Failed to create Default stream writer on table %s due to %s",
-                      tableName, e.getMessage());
-              retryHandler.setMostRecentException(
-                  new BigQueryStorageWriteApiConnectException(baseErrorMessage, e));
-              if (shouldHandleTableCreation(e.getMessage())) {
-                retryHandler.attemptTableOperation(schemaManager::createTable);
-              } else if (isNonRetriable(e)) {
-                throw retryHandler.getMostRecentException();
-              }
-              logger.warn(baseErrorMessage + " Retry attempt {}", retryHandler.getAttempt());
-            }
-            retryHandler.maybeRetry("create default stream on table " + tableName);
-          } while (true);
+        (t, arr) -> {
+          if (arr == null) {
+            arr = new AtomicReferenceArray<>(writersPerTable);
+          }
+          JsonStreamWriter writer = arr.get(slot);
+          if (writer == null) {
+            writer = createDefaultStream(table, tableName, rows);
+            arr.set(slot, writer);
+          }
+          created.set(writer);
+          return arr;
         });
+    return created.get();
+  }
+
+  @VisibleForTesting
+  JsonStreamWriter createDefaultStream(
+      PartitionedTableId table, String tableName, List<ConvertedRecord> rows) {
+    StorageWriteApiRetryHandler retryHandler =
+        new StorageWriteApiRetryHandler(
+            table.getBaseTableId(), getSinkRecords(rows), retry, retryWait, time);
+    do {
+      try {
+        return jsonWriterFactory.create(tableName);
+      } catch (Exception e) {
+        String baseErrorMessage =
+            String.format(
+                "Failed to create Default stream writer on table %s due to %s",
+                tableName, e.getMessage());
+        retryHandler.setMostRecentException(
+            new BigQueryStorageWriteApiConnectException(baseErrorMessage, e));
+        if (shouldHandleTableCreation(e.getMessage())) {
+          retryHandler.attemptTableOperation(schemaManager::createTable);
+        } else if (isNonRetriable(e)) {
+          throw retryHandler.getMostRecentException();
+        }
+        logger.warn(baseErrorMessage + " Retry attempt {}", retryHandler.getAttempt());
+      }
+      retryHandler.maybeRetry("create default stream on table " + tableName);
+    } while (true);
+  }
+
+  /** Slot for the calling thread, assigned round-robin on first use and kept for its lifetime. */
+  @VisibleForTesting
+  int writerSlot() {
+    return threadWriterSlot.get();
   }
 
   @Override
@@ -210,7 +300,12 @@ public class StorageWriteApiDefaultStream extends StorageWriteApiBase {
 
     @Override
     public void refresh() {
-      closeAndDelete(TableNameUtils.tableName(table.getFullTableId()).toString());
+      if (jsonStreamWriter != null) {
+        closeSlot(
+            TableNameUtils.tableName(table.getFullTableId()).toString(),
+            writerSlot(),
+            jsonStreamWriter);
+      }
       jsonStreamWriter = null;
     }
 

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiDefaultStreamTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiDefaultStreamTest.java
@@ -26,9 +26,12 @@ package com.wepay.kafka.connect.bigquery.write.storage;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -48,13 +51,16 @@ import com.wepay.kafka.connect.bigquery.utils.MockTime;
 import com.wepay.kafka.connect.bigquery.utils.PartitionedTableId;
 import com.wepay.kafka.connect.bigquery.utils.TableNameUtils;
 import io.grpc.StatusRuntimeException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.stream.Stream;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.sink.ErrantRecordReporter;
@@ -123,8 +129,11 @@ public class StorageWriteApiDefaultStreamTest {
   @BeforeEach
   public void setUp() throws Exception {
     errorMapping.put(0, "f0 field is unknown");
-    defaultStream.tableToStream = new ConcurrentHashMap<>();
-    defaultStream.tableToStream.put("testTable", mockedStreamWriter);
+    defaultStream.tableToStreams = new ConcurrentHashMap<>();
+    defaultStream.tableToStreams.put(
+        "testTable", new AtomicReferenceArray<>(new JsonStreamWriter[] {mockedStreamWriter}));
+    defaultStream.writersPerTable = 1;
+    defaultStream.threadWriterSlot = ThreadLocal.withInitial(() -> 0);
     defaultStream.schemaManager = mockedSchemaManager;
     defaultStream.time = time;
     defaultStream.errantRecordHandler = mockedErrantRecordHandler;
@@ -260,10 +269,125 @@ public class StorageWriteApiDefaultStreamTest {
 
   @Test
   public void testShutdown() {
-    defaultStream.tableToStream = new ConcurrentHashMap<>();
-    defaultStream.tableToStream.put("testTable", mockedStreamWriter);
+    defaultStream.tableToStreams = new ConcurrentHashMap<>();
+    defaultStream.tableToStreams.put(
+        "testTable", new AtomicReferenceArray<>(new JsonStreamWriter[] {mockedStreamWriter}));
     defaultStream.preShutdown();
     verify(mockedStreamWriter, times(1)).close();
+  }
+
+  @Test
+  public void testGetDefaultStreamCreatesOneWriterPerSlotLazily() {
+    JsonStreamWriter w0 = mock(JsonStreamWriter.class);
+    JsonStreamWriter w1 = mock(JsonStreamWriter.class);
+    defaultStream.tableToStreams = new ConcurrentHashMap<>();
+    defaultStream.writersPerTable = 2;
+    defaultStream.threadWriterSlot = ThreadLocal.withInitial(() -> 0);
+    doCallRealMethod().when(defaultStream).getDefaultStream(any(), any());
+    doReturn(w0, w1).when(defaultStream).createDefaultStream(any(), any(), any());
+
+    assertSame(w0, defaultStream.getDefaultStream(mockedPartitionedTableId, testRows));
+    assertSame(w0, defaultStream.getDefaultStream(mockedPartitionedTableId, testRows));
+    assertNull(defaultStream.tableToStreams.get(mockedTableName).get(1));
+
+    defaultStream.threadWriterSlot.set(1);
+    assertSame(w1, defaultStream.getDefaultStream(mockedPartitionedTableId, testRows));
+    verify(defaultStream, times(2)).createDefaultStream(any(), any(), any());
+  }
+
+  @Test
+  public void testSlotAssignerIsRoundRobinAcrossThreadsAndStickyPerThread() throws Exception {
+    ThreadLocal<Integer> slots = StorageWriteApiDefaultStream.slotAssigner(2);
+    List<Integer> firstCalls = new CopyOnWriteArrayList<>();
+    List<Boolean> sticky = new CopyOnWriteArrayList<>();
+    List<Thread> threads = new ArrayList<>();
+    for (int i = 0; i < 4; i++) {
+      Thread t =
+          new Thread(
+              () -> {
+                int slot = slots.get();
+                firstCalls.add(slot);
+                sticky.add(slot == slots.get());
+              });
+      threads.add(t);
+      t.start();
+    }
+    for (Thread t : threads) {
+      t.join();
+    }
+    assertEquals(2, Collections.frequency(firstCalls, 0));
+    assertEquals(2, Collections.frequency(firstCalls, 1));
+    assertTrue(sticky.stream().allMatch(Boolean::booleanValue));
+  }
+
+  @Test
+  public void testRefreshClosesOnlyTheFailedWriterSlot() throws Exception {
+    JsonStreamWriter other = mock(JsonStreamWriter.class);
+    defaultStream.tableToStreams = new ConcurrentHashMap<>();
+    defaultStream.tableToStreams.put(
+        mockedTableName,
+        new AtomicReferenceArray<>(new JsonStreamWriter[] {mockedStreamWriter, other}));
+    defaultStream.threadWriterSlot = ThreadLocal.withInitial(() -> 0);
+    StorageWriteApiDefaultStream.DefaultStreamWriter writer =
+        defaultStream.new DefaultStreamWriter(mockedPartitionedTableId, testRows);
+    writer.appendRows(new JSONArray());
+
+    writer.refresh();
+
+    verify(mockedStreamWriter, times(1)).close();
+    verify(other, times(0)).close();
+    AtomicReferenceArray<JsonStreamWriter> writers =
+        defaultStream.tableToStreams.get(mockedTableName);
+    assertNull(writers.get(0));
+    assertSame(other, writers.get(1));
+  }
+
+  @Test
+  public void testRefreshLeavesAlreadyReplacedWriterAlone() throws Exception {
+    JsonStreamWriter replacement = mock(JsonStreamWriter.class);
+    AtomicReferenceArray<JsonStreamWriter> writers =
+        new AtomicReferenceArray<>(new JsonStreamWriter[] {mockedStreamWriter});
+    defaultStream.tableToStreams = new ConcurrentHashMap<>();
+    defaultStream.tableToStreams.put(mockedTableName, writers);
+    defaultStream.threadWriterSlot = ThreadLocal.withInitial(() -> 0);
+    StorageWriteApiDefaultStream.DefaultStreamWriter writer =
+        defaultStream.new DefaultStreamWriter(mockedPartitionedTableId, testRows);
+    writer.appendRows(new JSONArray());
+    writers.set(0, replacement);
+
+    writer.refresh();
+
+    verify(mockedStreamWriter, never()).close();
+    verify(replacement, never()).close();
+    assertSame(replacement, writers.get(0));
+  }
+
+  @Test
+  public void testShutdownClosesAllWritersPerTable() {
+    JsonStreamWriter writerA = mock(JsonStreamWriter.class);
+    JsonStreamWriter writerB = mock(JsonStreamWriter.class);
+    defaultStream.tableToStreams = new ConcurrentHashMap<>();
+    // slot 1 never opened a stream
+    defaultStream.tableToStreams.put(
+        "testTable", new AtomicReferenceArray<>(new JsonStreamWriter[] {writerA, null, writerB}));
+    defaultStream.preShutdown();
+    verify(writerA, times(1)).close();
+    verify(writerB, times(1)).close();
+    assertFalse(defaultStream.tableToStreams.containsKey("testTable"));
+  }
+
+  @Test
+  public void testShutdownToleratesWriterCloseFailure() {
+    JsonStreamWriter failing = mock(JsonStreamWriter.class);
+    JsonStreamWriter ok = mock(JsonStreamWriter.class);
+    doThrow(new RuntimeException("close failed")).when(failing).close();
+    defaultStream.tableToStreams = new ConcurrentHashMap<>();
+    defaultStream.tableToStreams.put(
+        "testTable", new AtomicReferenceArray<>(new JsonStreamWriter[] {failing, ok}));
+    defaultStream.preShutdown();
+    verify(failing, times(1)).close();
+    verify(ok, times(1)).close();
+    assertFalse(defaultStream.tableToStreams.containsKey("testTable"));
   }
 
   private void verifyTerminalException(String expectedException) {

--- a/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiWriterTest.java
+++ b/kcbq-connector/src/test/java/com/wepay/kafka/connect/bigquery/write/storage/StorageWriteApiWriterTest.java
@@ -207,7 +207,7 @@ public class StorageWriteApiWriterTest {
     StorageWriteApiDefaultStream stream =
         mock(StorageWriteApiDefaultStream.class, CALLS_REAL_METHODS);
     JsonStreamWriter jsonWriter = mock(JsonStreamWriter.class);
-    stream.tableToStream = new ConcurrentHashMap<>();
+    stream.tableToStreams = new ConcurrentHashMap<>();
     stream.schemaManager = mock(SchemaManager.class);
     stream.errantRecordHandler = mock(ErrantRecordHandler.class);
     stream.time = new MockTime();
@@ -262,7 +262,7 @@ public class StorageWriteApiWriterTest {
     StorageWriteApiDefaultStream stream =
         mock(StorageWriteApiDefaultStream.class, CALLS_REAL_METHODS);
     JsonStreamWriter jsonWriter = mock(JsonStreamWriter.class);
-    stream.tableToStream = new ConcurrentHashMap<>();
+    stream.tableToStreams = new ConcurrentHashMap<>();
     stream.schemaManager = mock(SchemaManager.class);
     stream.errantRecordHandler = mock(ErrantRecordHandler.class);
     stream.time = new MockTime();
@@ -310,7 +310,7 @@ public class StorageWriteApiWriterTest {
     StorageWriteApiDefaultStream stream =
         mock(StorageWriteApiDefaultStream.class, CALLS_REAL_METHODS);
     JsonStreamWriter jsonWriter = mock(JsonStreamWriter.class);
-    stream.tableToStream = new ConcurrentHashMap<>();
+    stream.tableToStreams = new ConcurrentHashMap<>();
     stream.schemaManager = mock(SchemaManager.class);
     stream.errantRecordHandler = mock(ErrantRecordHandler.class);
     stream.time = new MockTime();


### PR DESCRIPTION
Relates to #238.

In default-stream mode one `JsonStreamWriter` is kept per destination table. Its `append()` is synchronized and converts JSON to protobuf inside the lock, so every write thread targeting a table serializes through one monitor and the effective parallelism per table is 1 regardless of `threadPoolSize`.

This adds a `defaultStreamWritersPerTable` sink config (default 1 = current behaviour). With N > 1 the connector keeps up to N writers per table. Each worker thread is assigned a slot round-robin on first use and keeps it, so a fixed pool never churns writers and opens at most min(threadPoolSize, N) streams per table; set it equal to `threadPoolSize` for full parallelism. Slots are created lazily inside the table's `compute()` so creation serializes with the close paths, and the slot array is an `AtomicReferenceArray` so writers are safely published to the lock-free fast path. The `_default` stream supports concurrent writers and the builder already enables the connection pool, so extra writers cost descriptor state, not connections. Batch mode is unaffected.

A closed-stream error on one writer now closes and replaces only that writer's slot (compare-and-set guarded, so a writer another thread already replaced is left alone) instead of closing every writer for the table.

On the shipped google-cloud-bom this alone is not sufficient at high volume; the next serialization point is the threeten-bp timestamp parsing described in #238. Combined with the BOM raise proposed there, the same setting kept up at full production volume. The two are kept separate because the dependency upgrade is a policy decision for the maintainers.

Tests (`StorageWriteApiDefaultStreamTest`): lazy per-slot creation and caching; round-robin assignment across threads with per-thread stickiness; scoped refresh closes only the failed slot and leaves an already-replaced writer alone; shutdown closes every slot, skips lazy null slots, and a failing close does not stop the others. Full suite green with `mvn -P ci`. Running in production for several weeks with the value set to `threadPoolSize`.